### PR TITLE
Check minimum drawable fontsize

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "1.10.2",
+  "version": "1.10.1-beta.0",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "devDependencies": {

--- a/src/BitmapFont.ts
+++ b/src/BitmapFont.ts
@@ -130,6 +130,7 @@ namespace g {
 		map: {[key: string]: GlyphArea};
 		missingGlyph: GlyphArea;
 		size: number;
+		_realSize: number;
 
 		/**
 		 * `BitmapFont` のインスタンスを生成する。
@@ -149,6 +150,7 @@ namespace g {
 			this.defaultGlyphHeight = defaultGlyphHeight;
 			this.missingGlyph = missingGlyph;
 			this.size = defaultGlyphHeight;
+			this._realSize = defaultGlyphHeight;
 		}
 
 		/**

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -280,7 +280,6 @@ namespace g {
 		constructor(fontFamily: FontFamily, size: number, game: Game, hint: DynamicFontHint = {},
 		            fontColor: string = "black", strokeWidth: number = 0, strokeColor: string = "black", strokeOnly: boolean = false) {
 			this.fontFamily = fontFamily;
-			this.size = size;
 			this.hint = hint;
 			this.fontColor = fontColor;
 			this.strokeWidth = strokeWidth;
@@ -290,6 +289,7 @@ namespace g {
 			this._glyphs = {};
 			this._glyphFactory =
 				this._resourceFactory.createGlyphFactory(fontFamily, size, hint.baselineHeight, fontColor, strokeWidth, strokeColor, strokeOnly);
+			this.size = this._glyphFactory.fontSize;
 			this._atlases = [];
 			this._currentAtlasIndex = 0;
 			this._destroyed = false;

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -268,6 +268,7 @@ namespace g {
 		_destroyed: boolean;
 		_hint: DynamicFontHint;
 		_atlasSize: CommonSize;
+		_realSize: number;
 
 		/**
 		 * コンストラクタ。
@@ -280,6 +281,7 @@ namespace g {
 		constructor(fontFamily: FontFamily, size: number, game: Game, hint: DynamicFontHint = {},
 		            fontColor: string = "black", strokeWidth: number = 0, strokeColor: string = "black", strokeOnly: boolean = false) {
 			this.fontFamily = fontFamily;
+			this.size = size;
 			this.hint = hint;
 			this.fontColor = fontColor;
 			this.strokeWidth = strokeWidth;
@@ -289,7 +291,7 @@ namespace g {
 			this._glyphs = {};
 			this._glyphFactory =
 				this._resourceFactory.createGlyphFactory(fontFamily, size, hint.baselineHeight, fontColor, strokeWidth, strokeColor, strokeOnly);
-			this.size = this._glyphFactory.fontSize;
+			this._realSize = this._glyphFactory.fontSize;
 			this._atlases = [];
 			this._currentAtlasIndex = 0;
 			this._destroyed = false;
@@ -408,15 +410,15 @@ namespace g {
 				glyphAreaMap[key] = glyphArea;
 			});
 
-			// NOTE: (defaultGlyphWidth, defaultGlyphHeight)= (0, this.size) とする
+			// NOTE: (defaultGlyphWidth, defaultGlyphHeight)= (0, this._realSize) とする
 			//
 			// それぞれの役割は第一に `GlyphArea#width`, `GlyphArea#height` が与えられないときの
 			// デフォルト値である。ここでは必ず与えているのでデフォルト値としては利用されない。
 			// しかし defaultGlyphHeight は BitmapFont#size にも用いられる。
-			// そのために this.size をコンストラクタの第４引数に与えることにする。
+			// そのために this._realSize をコンストラクタの第４引数に与えることにする。
 			let missingGlyph = glyphAreaMap[missingGlyphCharCodePoint];
 			const surface = this._atlases[0].duplicateSurface(this._resourceFactory);
-			const bitmapFont = new BitmapFont(surface, glyphAreaMap, 0, this.size, missingGlyph);
+			const bitmapFont = new BitmapFont(surface, glyphAreaMap, 0, this._realSize, missingGlyph);
 
 			return bitmapFont;
 		}

--- a/src/Font.ts
+++ b/src/Font.ts
@@ -10,6 +10,8 @@ namespace g {
 		 */
 		size: number;
 
+		_realSize: number;
+
 		/**
 		 * グリフの取得。
 		 *
@@ -27,13 +29,6 @@ namespace g {
 	 * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
 	 */
 	export class GlyphFactory {
-		/**
-		 * 動作環境における描画可能なフォントサイズの最小値。
-		 *
-		 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
-		 */
-		static environmentMinimumFontSize: number;
-
 		/**
 		 * フォントファミリ。
 		 *

--- a/src/Font.ts
+++ b/src/Font.ts
@@ -28,6 +28,13 @@ namespace g {
 	 */
 	export class GlyphFactory {
 		/**
+		 * 動作環境における描画可能なフォントサイズの最小値。
+		 *
+		 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
+		 */
+		static environmentMinimumFontSize: number;
+
+		/**
 		 * フォントファミリ。
 		 *
 		 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
@@ -89,12 +96,18 @@ namespace g {
 		constructor(fontFamily: FontFamily, fontSize: number, baselineHeight: number = fontSize,
 		            fontColor: string = "black", strokeWidth: number = 0, strokeColor: string = "black", strokeOnly: boolean = false) {
 			this.fontFamily = fontFamily;
-			this.fontSize = fontSize;
+			this.fontSize = Math.max(fontSize, this.calcMinimumDrawableFontSize());
 			this.baselineHeight = baselineHeight;
 			this.fontColor = fontColor;
 			this.strokeWidth = strokeWidth;
 			this.strokeColor = strokeColor;
 			this.strokeOnly = strokeOnly;
+
+			if (fontSize !== this.fontSize) {
+				const scale = (this.fontSize / fontSize);
+				this.baselineHeight = this.baselineHeight * scale;
+				this.strokeWidth = this.strokeWidth * scale;
+			}
 		}
 
 		/**
@@ -106,6 +119,13 @@ namespace g {
 		 */
 		create(code: number): Glyph {
 			throw ExceptionFactory.createPureVirtualError("GlyphFactory#create");
+		}
+
+		/**
+		 * 動作環境の最小描画フォントサイズを取得する。
+		 */
+		calcMinimumDrawableFontSize(): number {
+			throw ExceptionFactory.createPureVirtualError("GlyphFactory#calcMinimumDrawableFontSize");
 		}
 	}
 }

--- a/src/Font.ts
+++ b/src/Font.ts
@@ -122,7 +122,7 @@ namespace g {
 		}
 
 		/**
-		 * 動作環境の最小描画フォントサイズを取得する。
+		 * 描画可能なフォントサイズの最小値を取得する。
 		 */
 		calcMinimumDrawableFontSize(): number {
 			throw ExceptionFactory.createPureVirtualError("GlyphFactory#calcMinimumDrawableFontSize");

--- a/src/Label.ts
+++ b/src/Label.ts
@@ -224,7 +224,7 @@ namespace g {
 			for (var i = 0; i < this.glyphs.length; ++i) {
 				var glyph = this.glyphs[i];
 
-				var glyphScale = this.fontSize / this.font.size;
+				var glyphScale = this.fontSize / this.font._realSize;
 				var glyphWidth = glyph.advanceWidth * glyphScale;
 
 				if (glyph.surface) { // 非空白文字
@@ -296,7 +296,7 @@ namespace g {
 			}
 
 			var maxHeight = 0;
-			var glyphScale = this.font.size > 0 ? this.fontSize / this.font.size : 0;
+			var glyphScale = this.font._realSize > 0 ? this.fontSize / this.font._realSize : 0;
 			for (var i = 0; i < this.text.length; ++i) {
 				const code = g.Util.charCodeAt(this.text, i);
 				if (! code) {


### PR DESCRIPTION
## このpull requestが解決する内容

AkashicEngineは文字描画に0以上の任意の値を利用できますが、実行環境の中には極端に小さいフォントサイズの描画をサポートしないものがあります。
これによってロジック上のフォントサイズと実際に描画されるフォントサイズがずれ、描画が乱れる場合があります。

これを防ぐため、DynamicFontの初回生成時に、実行環境が描画できる最小のフォントサイズを取得します。
描画可能なフォントサイズ以下の値が指定されている場合、DynamicFont#fontSizeを最小描画可能フォントサイズまで自動的に引き上げます。

## 破壊的な変更を含んでいるか?

あり。

DynamicFont#fontSizeをロジックに利用するコンテンツに影響があります。
