### PR TITLE
Support bold font at DynamicFont

### DIFF
--- a/spec/BitmapFontSpec.js
+++ b/spec/BitmapFontSpec.js
@@ -38,6 +38,7 @@ describe("test BitmapFont", function() {
 	});
 
 	it("初期化 - BitmapFont", function() {
+		// deprecatedなコンストラクタの動作確認を行う
 		var surface = new g.Surface(480, 480);
 		var map = {"37564": {"x": 0, "y": 1}};
 		var missingGlyph = {"x": 2, "y": 3};
@@ -50,11 +51,50 @@ describe("test BitmapFont", function() {
 	});
 
 	it("初期化 - BitmapFont given Asset", function() {
+		// deprecatedなコンストラクタの動作確認を行う
 		var runtime = skeletonRuntime();
 		var asset = runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", 480, 480);
 		var map = {"37564": {"x": 0, "y": 1}};
 		var missingGlyph = {"x": 2, "y": 3};
 		var bmpFont = new g.BitmapFont(asset, map, 20, 30, missingGlyph);
+		var assetToSurface = g.Util.asSurface(asset);
+		expect(bmpFont.surface).toEqual(assetToSurface);
+		expect(bmpFont.map).toEqual(map);
+		expect(bmpFont.missingGlyph).toEqual(missingGlyph);
+		expect(bmpFont.defaultGlyphWidth).toEqual(20);
+		expect(bmpFont.defaultGlyphHeight).toEqual(30);
+	});
+
+	it("初期化 - ParamterObject", function() {
+		var surface = new g.Surface(480, 480);
+		var map = {"37564": {"x": 0, "y": 1}};
+		var missingGlyph = {"x": 2, "y": 3};
+		var bmpFont = new g.BitmapFont({
+			src: surface,
+			map: map,
+			defaultGlyphWidth: 20,
+			defaultGlyphHeight: 30,
+			missingGlyph: missingGlyph
+		});
+		expect(bmpFont.surface).toEqual(surface);
+		expect(bmpFont.map).toEqual(map);
+		expect(bmpFont.missingGlyph).toEqual(missingGlyph);
+		expect(bmpFont.defaultGlyphWidth).toEqual(20);
+		expect(bmpFont.defaultGlyphHeight).toEqual(30);
+	});
+
+	it("初期化 - ParamterObject given Asset", function() {
+		var runtime = skeletonRuntime();
+		var asset = runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", 480, 480);
+		var map = {"37564": {"x": 0, "y": 1}};
+		var missingGlyph = {"x": 2, "y": 3};
+		var bmpFont = new g.BitmapFont({
+			src: asset,
+			map: map,
+			defaultGlyphWidth: 20,
+			defaultGlyphHeight: 30,
+			missingGlyph: missingGlyph
+		});
 		var assetToSurface = g.Util.asSurface(asset);
 		expect(bmpFont.surface).toEqual(assetToSurface);
 		expect(bmpFont.map).toEqual(map);

--- a/spec/DynamicFontSpec.js
+++ b/spec/DynamicFontSpec.js
@@ -1,0 +1,54 @@
+describe("test DynamicFont", function() {
+	var g = require('../lib/main.node.js');
+	var mock = require("./helpers/mock");
+	var skeletonRuntime = require("./helpers/skeleton");
+	beforeEach(function() {
+	});
+	afterEach(function() {
+	});
+	it("初期化", function() {
+		// deprecatedなコンストラクタの動作確認を行う
+		var runtime = skeletonRuntime();
+		runtime.game.suppressedLogLevel = g.LogLevel.Debug;
+
+		var font = new g.DynamicFont(
+			g.FontFamily.SansSerif,
+			20,
+			runtime.game,
+			{},
+			"white",
+			1,
+			"red",
+			true
+		);
+		expect(font.fontFamily).toBe(g.FontFamily.SansSerif);
+		expect(font.size).toBe(20);
+		expect(font.fontColor).toBe("white");
+		expect(font.strokeWidth).toBe(1);
+		expect(font.strokeColor).toBe("red");
+		expect(font.strokeOnly).toBe(true);
+		runtime.game.suppressedLogLevel = undefined;
+	});
+	it("初期化 - ParameterObject", function() {
+		var runtime = skeletonRuntime();
+
+		var font = new g.DynamicFont({
+			game: runtime.game,
+			fontFamily: g.FontFamily.SansSerif,
+			size: 20,
+			hint: {},
+			fontColor: "white",
+			fontWeight: g.FontWeight.Bold,
+			strokeWidth: 1,
+			strokeColor: "red",
+			strokeOnly: true
+		});
+		expect(font.fontFamily).toBe(g.FontFamily.SansSerif);
+		expect(font.size).toBe(20);
+		expect(font.fontColor).toBe("white");
+		expect(font.fontWeight).toBe(g.FontWeight.Bold);
+		expect(font.strokeWidth).toBe(1);
+		expect(font.strokeColor).toBe("red");
+		expect(font.strokeOnly).toBe(true);
+	});
+});

--- a/spec/LabelSpec.js
+++ b/spec/LabelSpec.js
@@ -10,13 +10,20 @@ describe("test Label", function() {
 		// deprecatedなコンストラクタの動作確認を行う
 		var runtime = skeletonRuntime();
 		runtime.game.suppressedLogLevel = g.LogLevel.Debug;
+		var imageAsset = runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", width, height);
 		var width = 32;
 		var height = 64;
 		var map = {"37564": {"x": 0, "y": 1}};
 		var missingGlyph = {"x": 2, "y": 3};
 
-		var bmpfont = new g.BitmapFont(null, map, width, height, missingGlyph);
-		expect(bmpfont.surface).toEqual(null);
+		var bmpfont = new g.BitmapFont({
+			src: imageAsset,
+			map: map,
+			defaultGlyphWidth: width,
+			defaultGlyphHeight: height,
+			missingGlyph: missingGlyph
+		});
+		expect(bmpfont.surface).not.toBeNull();
 		expect(bmpfont.defaultGlyphWidth).toEqual(width);
 		expect(bmpfont.defaultGlyphHeight).toEqual(height);
 		expect(bmpfont.map).toEqual(map);
@@ -32,11 +39,18 @@ describe("test Label", function() {
 	});
 	it("初期化 - ParameterObject", function() {
 		var runtime = skeletonRuntime();
+		var imageAsset = runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", width, height);
 		var width = 32;
 		var height = 64;
 		var map = {"37564": {"x": 0, "y": 1}};
 		var missingGlyph = {"x": 2, "y": 3};
-		var bmpfont = new g.BitmapFont(null, map, width, height, missingGlyph);
+		var bmpfont = new g.BitmapFont({
+			src: imageAsset,
+			map: map,
+			defaultGlyphWidth: width,
+			defaultGlyphHeight: height,
+			missingGlyph: missingGlyph
+		});
 
 		var label = new g.Label({
 			scene: runtime.scene,
@@ -63,13 +77,20 @@ describe("test Label", function() {
 	});
 	it("初期化 - missMissingGlyph", function() {
 		var runtime = skeletonRuntime();
+		var imageAsset = runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", width, height);
 		var width = 32;
 		var height = 64;
 		var map = {"37564": {"x": 0, "y": 1}};
 		var missingGlyph = null;
 
-		var bmpfont = new g.BitmapFont(null, map, width, height, missingGlyph);
-		expect(bmpfont.surface).toEqual(null);
+		var bmpfont = new g.BitmapFont({
+			src: imageAsset,
+			map: map,
+			defaultGlyphWidth: width,
+			defaultGlyphHeight: height,
+			missingGlyph: missingGlyph
+		});
+		expect(bmpfont.surface).not.toBeNull();
 		expect(bmpfont.defaultGlyphWidth).toEqual(width);
 		expect(bmpfont.defaultGlyphHeight).toEqual(height);
 		expect(bmpfont.map).toEqual(map);
@@ -77,12 +98,19 @@ describe("test Label", function() {
 	});
 	it("初期化 - fontSize = 0", function() {
 		var runtime = skeletonRuntime();
+		var imageAsset = runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", width, height);
 		var width = 32;
 		var height = 64;
 		var map = {"37564": {"x": 0, "y": 1}};
 		var missingGlyph = {"x": 2, "y": 3};
-		var bmpfont = new g.BitmapFont(null, map, width, height, missingGlyph);
 
+		var bmpfont = new g.BitmapFont({
+			src: imageAsset,
+			map: map,
+			defaultGlyphWidth: width,
+			defaultGlyphHeight: height,
+			missingGlyph: missingGlyph
+		});
 		var label = new g.Label({
 			scene: runtime.scene,
 			text: "a",
@@ -98,23 +126,37 @@ describe("test Label", function() {
 	});
 	it("glyphForCharacter", function() {
 		var runtime = skeletonRuntime();
+		var imageAsset = runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", width, height);
 		var width = 32;
 		var height = 64;
 		var map = {"37564": {"x": 0, "y": 1}};
 		var missingGlyph = null;
 
-		var bmpfont = new g.BitmapFont(null, map, width, height, missingGlyph);
+		var bmpfont = new g.BitmapFont({
+			src: imageAsset,
+			map: map,
+			defaultGlyphWidth: width,
+			defaultGlyphHeight: height,
+			missingGlyph: missingGlyph
+		});
 		expect(bmpfont.glyphForCharacter(37564).code).toBe(37564);
 		expect(bmpfont.glyphForCharacter(-1)).toBeNull();
 	});
 	it("aligning", function() {
 		var runtime = skeletonRuntime();
+		var imageAsset = runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", width, height);
 		var width = 32;
 		var height = 64;
 		var map = {97: {"x": 0, "y": 1}}; // "a".charCodeAt(0) === 97
 		var missingGlyph = null;
-		var bmpfont = new g.BitmapFont(null, map, width, height, missingGlyph);
 
+		var bmpfont = new g.BitmapFont({
+			src: imageAsset,
+			map: map,
+			defaultGlyphWidth: width,
+			defaultGlyphHeight: height,
+			missingGlyph: missingGlyph
+		});
 		var label = new g.Label({
 			scene: runtime.scene,
 			text: "a",
@@ -138,7 +180,13 @@ describe("test Label", function() {
 		var height = 350;
 		var map = {"37564": {"x": 0, "y": 1}};
 		var missingGlyph = {"x": 2, "y": 3};
-		var bmpfont = new g.BitmapFont(runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", width, height), map, 35, 50, missingGlyph);
+		var bmpfont = new g.BitmapFont({
+			src: runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", width, height),
+			map: map,
+			defaultGlyphWidth: 35,
+			defaultGlyphHeight: 50,
+			missingGlyph: missingGlyph
+		});
 		var label = new g.Label({
 			scene: runtime.scene,
 			text: "a",
@@ -152,7 +200,13 @@ describe("test Label", function() {
 		label.invalidate();
 		label.render(r);
 		var count = label._renderer.methodCallHistory.filter(function(elem) {return elem === "drawImage";}).length;
-		var bmpfont2 = new g.BitmapFont(runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", width, height), map, 0, 0, missingGlyph);
+		var bmpfont2 = new g.BitmapFont({
+			src: runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", width, height),
+			map: map,
+			defaultGlyphWidth: 0,
+			defaultGlyphHeight: 0,
+			missingGlyph: missingGlyph
+		});
 		var label2 = new g.Label({
 			scene: runtime.scene,
 			text: "b",
@@ -186,7 +240,13 @@ describe("test Label", function() {
 		var height = 350;
 		var map = {"37564": {"x": 0, "y": 1}};
 		var missingGlyph = {"x": 2, "y": 3};
-		var bmpfont = new g.BitmapFont(runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", width, height), map, 35, 50, missingGlyph);
+		var bmpfont = new g.BitmapFont({
+			src: runtime.game.resourceFactory.createImageAsset("testId", "testAssetPath", width, height),
+			map: map,
+			defaultGlyphWidth: width,
+			defaultGlyphHeight: height,
+			missingGlyph: missingGlyph
+		});
 		var label = new g.Label({scene: runtime.scene, text: "a", bitmapFont: bmpfont, fontSize: 10, textColor: "blue"});
 		label.render(r);
 

--- a/spec/helpers/mock.ts
+++ b/spec/helpers/mock.ts
@@ -380,6 +380,13 @@ export class AudioPlayer extends g.AudioPlayer {
 	}
 }
 
+export class GlyphFactory extends g.GlyphFactory {
+	constructor(fontFamily: g.FontFamily, fontSize: number, baselineHeight?: number,
+	            fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean, fontWeight?: g.FontWeight) {
+		super(fontFamily, fontSize, baselineHeight, fontColor, strokeWidth, strokeColor, strokeOnly, fontWeight);
+	}
+}
+
 export class ResourceFactory extends g.ResourceFactory {
 	game: g.Game;
 	scriptContents: {[key: string]: string};
@@ -451,6 +458,12 @@ export class ResourceFactory extends g.ResourceFactory {
 
 	createAudioPlayer(system: g.AudioSystem, loop?: boolean): g.AudioPlayer {
 		return new AudioPlayer(system, loop);
+	}
+
+	createGlyphFactory(fontFamily: g.FontFamily, fontSize: number, baselineHeight?: number,
+	                   fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean,
+	                   fontWeight?: g.FontWeight): g.GlyphFactory {
+		return new GlyphFactory(fontFamily, fontSize, baselineHeight, fontColor, strokeWidth, strokeColor, strokeOnly, fontWeight);
 	}
 }
 

--- a/src/BitmapFont.ts
+++ b/src/BitmapFont.ts
@@ -121,6 +121,38 @@ namespace g {
 	}
 
 	/**
+	 * `BitmapFont` のコンストラクタに渡すことができるパラメータ。
+	 * 各メンバの詳細は `BitmapFont` の同名メンバの説明を参照すること。
+	 */
+	export interface BitmapFontParameterObject {
+		/**
+		 * 文字データとして利用する画像を表す `Surface` または `Asset`。文字を敷き詰めたもの。
+		 */
+		src: Surface|Asset;
+
+		/**
+		 * 各文字から画像上の位置・サイズなどを特定する情報。コードポイントから `GlyphArea` への写像。
+		 */
+		map: {[key: string]: GlyphArea};
+
+		/**
+		 * `map` で指定を省略した文字に使われる、デフォルトの文字の幅。
+		 */
+		defaultGlyphWidth: number;
+
+		/**
+		 * `map` で指定を省略した文字に使われる、デフォルトの文字の高さ
+		 */
+		defaultGlyphHeight: number;
+
+		/**
+		 * `map` に存在しないコードポイントの代わりに表示するべき文字の `GlyphArea` 。
+		 * @default undefined
+		 */
+		missingGlyph?: GlyphArea;
+	}
+
+	/**
 	 * ラスタ画像によるフォント。
 	 */
 	export class BitmapFont implements Font {
@@ -133,6 +165,7 @@ namespace g {
 
 		/**
 		 * `BitmapFont` のインスタンスを生成する。
+		 * @deprecated このコンストラクタは非推奨機能である。代わりに `BitmapFontParameterObject` を使うコンストラクタを用いるべきである。
 		 * @param src 文字データとして利用する画像を表す `Surface` または `Asset`。文字を敷き詰めたもの
 		 * @param map 各文字から画像上の位置・サイズなどを特定する情報。コードポイントから `GlyphArea` への写像
 		 * @param defaultGlyphWidth `map` で指定を省略した文字に使われる、デフォルトの文字の幅
@@ -142,13 +175,31 @@ namespace g {
 		// mapは{ codepoint: { x: x, y: y, width: w, height: h, ... }のフォーマットでwidthとheightを省略可能。
 		// 省略した場合はdefaulyGlyph{Width, Height}で指定した値が使用される。
 		constructor(src: Surface|Asset, map: {[key: string]: GlyphArea}, defaultGlyphWidth: number,
-					defaultGlyphHeight: number, missingGlyph?: GlyphArea) {
-			this.surface = Util.asSurface(src);
-			this.map = map;
-			this.defaultGlyphWidth = defaultGlyphWidth;
-			this.defaultGlyphHeight = defaultGlyphHeight;
-			this.missingGlyph = missingGlyph;
-			this.size = defaultGlyphHeight;
+		            defaultGlyphHeight: number, missingGlyph?: GlyphArea);
+		/**
+		 * 各種パラメータを指定して `BitmapFont` のインスタンスを生成する。
+		 * @param param `BitmapFont` に設定するパラメータ
+		 */
+		constructor(param: BitmapFontParameterObject);
+
+		constructor(srcOrParam: Surface|Asset|BitmapFontParameterObject, map?: {[key: string]: GlyphArea}, defaultGlyphWidth?: number,
+		            defaultGlyphHeight?: number, missingGlyph?: GlyphArea) {
+			if (srcOrParam instanceof Surface || srcOrParam instanceof Asset) {
+				this.surface = Util.asSurface(srcOrParam);
+				this.map = map;
+				this.defaultGlyphWidth = defaultGlyphWidth;
+				this.defaultGlyphHeight = defaultGlyphHeight;
+				this.missingGlyph = missingGlyph;
+				this.size = defaultGlyphHeight;
+			} else {
+				var param = <BitmapFontParameterObject>srcOrParam;
+				this.surface = Util.asSurface(param.src);
+				this.map = param.map;
+				this.defaultGlyphWidth = param.defaultGlyphWidth;
+				this.defaultGlyphHeight = param.defaultGlyphHeight;
+				this.missingGlyph = param.missingGlyph;
+				this.size = param.defaultGlyphHeight;
+			}
 		}
 
 		/**

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -386,8 +386,8 @@ namespace g {
 				this._currentAtlasIndex = 0;
 				this._destroyed = false;
 				game.logger.debug(
-					"[deprecated] DynamicFont or Subclass of DynamicFont: This constructor is deprecated. "
-						+ "Refer to the API documentation and use each constructor(param: ParameterObject) instead."
+					"[deprecated] DynamicFont: This constructor is deprecated. "
+						+ "Refer to the API documentation and use constructor(param: DynamicFontParameterObject) instead."
 				);
 			} else {
 				var param = fontFamilyOrParam;

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -1,5 +1,19 @@
 namespace g {
 	/**
+	 * 文字列描画のフォントウェイト。
+	 */
+	export enum FontWeight {
+		/**
+		 * 通常のフォントウェイト。
+		 */
+		Normal,
+		/**
+		 * 太字のフォントウェイト。
+		 */
+		Bold
+	}
+
+	/**
 	 * SurfaceAtlasの空き領域管理クラス。
 	 *
 	 * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
@@ -170,6 +184,64 @@ namespace g {
 	}
 
 	/**
+	 * `DynamicFont` のコンストラクタに渡すことができるパラメータ。
+	 * 各メンバの詳細は `DynamicFont` の同名メンバの説明を参照すること。
+	 */
+	export interface DynamicFontParameterObject {
+		/**
+		 * ゲームインスタンス。
+		 */
+		game: Game;
+
+		/**
+		 * フォントファミリ。
+		 */
+		fontFamily: FontFamily;
+
+		/**
+		 * フォントサイズ。
+		 */
+		size: number;
+
+		/**
+		 * ヒント。
+		 * 
+		 * 詳細は `DynamicFontHint` を参照。
+		 */
+		hint?: DynamicFontHint;
+
+		/**
+		 * フォント色。CSS Colorで指定する。
+		 * @default "black"
+		 */
+		fontColor?: string;
+
+		/**
+		 * フォントウェイト。
+		 * @default FontWeight.Normal
+		 */
+		fontWeight?: FontWeight;
+
+		/**
+		 * 輪郭幅。
+		 * @default 0
+		 */
+		strokeWidth?: number;
+
+		/**
+		 * 輪郭色。
+		 * @default 0
+		 */
+		strokeColor?: string;
+
+		/**
+		 * 文字の輪郭のみを描画するか否か。
+		 * @default false
+		 */
+		strokeOnly?: boolean;
+	}
+
+	/**
 	 * DynamicFontが効率よく動作するためのヒント。
 	 *
 	 * ゲーム開発者はDynamicFontが効率よく動作するための各種初期値・最大値などを
@@ -240,6 +312,12 @@ namespace g {
 		fontColor: string;
 
 		/**
+		 * フォントウェイト。
+		 * @default FontWeight.Normal
+		 */
+		fontWeight: FontWeight;
+
+		/**
 		 * 輪郭幅。
 		 * 0 以上の数値でなければならない。 0 を指定した場合、輪郭は描画されない。
 		 * @default 0
@@ -270,29 +348,66 @@ namespace g {
 		_atlasSize: CommonSize;
 
 		/**
-		 * コンストラクタ。
-		 *
+		 * `DynamicFont` のインスタンスを生成する。
+		 * @deprecated このコンストラクタは非推奨機能である。代わりに `DynamicFontParameterObject` を使うコンストラクタを用いるべきである。
 		 * @param fontFamily フォントファミリ
 		 * @param size フォントサイズ
 		 * @param game ゲームインスタンス
 		 * @param hint ヒント
+		 * @param fontColor フォント色
+		 * @param strokeWidth 輪郭幅
+		 * @param strokeColor 輪郭色
+		 * @param strokeOnly 文字の輪郭のみを描画するか否か
 		 */
-		constructor(fontFamily: FontFamily, size: number, game: Game, hint: DynamicFontHint = {},
+		constructor(fontFamily: FontFamily, size: number, game: Game, hint?: DynamicFontHint,
+		            fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean);
+		/**
+		 * 各種パラメータを指定して `DynamicFont` のインスタンスを生成する。
+		 * @param param `DynamicFont` に設定するパラメータ
+		 */
+		constructor(param: DynamicFontParameterObject);
+
+		constructor(fontFamilyOrParam: FontFamily|DynamicFontParameterObject, size?: number, game?: Game, hint: DynamicFontHint = {},
 		            fontColor: string = "black", strokeWidth: number = 0, strokeColor: string = "black", strokeOnly: boolean = false) {
-			this.fontFamily = fontFamily;
-			this.size = size;
-			this.hint = hint;
-			this.fontColor = fontColor;
-			this.strokeWidth = strokeWidth;
-			this.strokeColor = strokeColor;
-			this.strokeOnly = strokeOnly;
-			this._resourceFactory = game.resourceFactory;
-			this._glyphs = {};
-			this._glyphFactory =
-				this._resourceFactory.createGlyphFactory(fontFamily, size, hint.baselineHeight, fontColor, strokeWidth, strokeColor, strokeOnly);
-			this._atlases = [];
-			this._currentAtlasIndex = 0;
-			this._destroyed = false;
+			if (typeof fontFamilyOrParam === "number") {
+				this.fontFamily = fontFamilyOrParam;
+				this.size = size;
+				this.hint = hint;
+				this.fontColor = fontColor;
+				this.strokeWidth = strokeWidth;
+				this.strokeColor = strokeColor;
+				this.strokeOnly = strokeOnly;
+				this._resourceFactory = game.resourceFactory;
+				this._glyphs = {};
+				this._glyphFactory =
+					this._resourceFactory.createGlyphFactory(fontFamilyOrParam, size, hint.baselineHeight, fontColor,
+						strokeWidth, strokeColor, strokeOnly);
+				this._atlases = [];
+				this._currentAtlasIndex = 0;
+				this._destroyed = false;
+				game.logger.debug(
+					"[deprecated] DynamicFont or Subclass of DynamicFont: This constructor is deprecated. "
+						+ "Refer to the API documentation and use each constructor(param: ParameterObject) instead."
+				);
+			} else {
+				var param = fontFamilyOrParam;
+				this.fontFamily = param.fontFamily;
+				this.size = param.size;
+				this.hint = ("hint" in param) ? param.hint : {};
+				this.fontColor = ("fontColor" in param) ? param.fontColor : "black";
+				this.fontWeight = ("fontWeight" in param) ? param.fontWeight : FontWeight.Normal;
+				this.strokeWidth = ("strokeWidth" in param) ? param.strokeWidth : 0;
+				this.strokeColor = ("strokeColor" in param) ? param.strokeColor : "black";
+				this.strokeOnly = ("strokeOnly" in param) ? param.strokeOnly : false;
+				this._resourceFactory = param.game.resourceFactory;
+				this._glyphs = {};
+				this._glyphFactory =
+					this._resourceFactory.createGlyphFactory(this.fontFamily, this.size, this.hint.baselineHeight,
+						this.fontColor, this.strokeWidth, this.strokeColor, this.strokeOnly, this.fontWeight);
+				this._atlases = [];
+				this._currentAtlasIndex = 0;
+				this._destroyed = false;
+			}
 
 			// 指定がないとき、やや古いモバイルデバイスでも確保できると言われる
 			// 縦横2048pxのテクスチャ一枚のアトラスにまとめる形にする

--- a/src/Font.ts
+++ b/src/Font.ts
@@ -92,6 +92,7 @@ namespace g {
 		 * @param strokeWidth 輪郭幅
 		 * @param strokeColor 輪郭色
 		 * @param strokeOnly 輪郭を描画するか否か
+		 * @param fontWeight フォントウェイト
 		 */
 		constructor(fontFamily: FontFamily, fontSize: number, baselineHeight: number = fontSize,
 		            fontColor: string = "black", strokeWidth: number = 0, strokeColor: string = "black", strokeOnly: boolean = false,

--- a/src/Font.ts
+++ b/src/Font.ts
@@ -56,6 +56,13 @@ namespace g {
 		fontColor: string;
 
 		/**
+		 * フォントウェイト。
+		 *
+		 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
+		 */
+		fontWeight: g.FontWeight;
+
+		/**
 		 * 輪郭幅。
 		 *
 		 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
@@ -70,7 +77,7 @@ namespace g {
 		strokeColor: string;
 
 		/**
-		 * 文字の描画スタイル。
+		 * 輪郭を描画しているか否か。
 		 *
 		 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
 		 */
@@ -84,12 +91,14 @@ namespace g {
 		 * @param baselineHeight ベースラインの高さ
 		 * @param strokeWidth 輪郭幅
 		 * @param strokeColor 輪郭色
-		 * @param strokeOnly 輪郭の描画スタイル
+		 * @param strokeOnly 輪郭を描画するか否か
 		 */
 		constructor(fontFamily: FontFamily, fontSize: number, baselineHeight: number = fontSize,
-		            fontColor: string = "black", strokeWidth: number = 0, strokeColor: string = "black", strokeOnly: boolean = false) {
+		            fontColor: string = "black", strokeWidth: number = 0, strokeColor: string = "black", strokeOnly: boolean = false,
+		            fontWeight: FontWeight = FontWeight.Normal) {
 			this.fontFamily = fontFamily;
 			this.fontSize = fontSize;
+			this.fontWeight = fontWeight;
 			this.baselineHeight = baselineHeight;
 			this.fontColor = fontColor;
 			this.strokeWidth = strokeWidth;

--- a/src/ResourceFactory.ts
+++ b/src/ResourceFactory.ts
@@ -54,9 +54,11 @@ namespace g {
 		 * @param strokeWidth ストローク(縁取り線)の幅。省略された場合、 `0` として扱われる
 		 * @param strokeColor ストロークの色。省略された場合、 `"black"` として扱われる
 		 * @param strokeOnly ストロークのみを描画するか否か。省略された場合、偽として扱われる
+		 * @param fontWeight フォントウェイト。省略された場合、 `FontWeight.Normal` として扱われる
 		 */
 		createGlyphFactory(fontFamily: FontFamily, fontSize: number, baselineHeight?: number,
-		                   fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean): GlyphFactory {
+		                   fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean,
+		                   fontWeight?: FontWeight): GlyphFactory {
 			throw ExceptionFactory.createPureVirtualError("ResourceFactory#createGlphFactory");
 		}
 

--- a/unreleased-changes/support-bold.md
+++ b/unreleased-changes/support-bold.md
@@ -2,16 +2,20 @@
 機能追加
  * `g.DynamicFont` でフォントウェイトが指定可能に
  * `g.DynamicFontParameterObject` を追加
+ * `g.BitmapFontParameterObject` を追加
  * `g.ResourceFactory#createGlyphFactory()` に引数を追加
 
 ### ゲーム開発者への影響
  * `g.DynamicFont` のコンストラクタ引数に `DynamicFontParameterObject` が渡せるように
  * `g.DynamicFont` でフォントウェイトが指定可能に
     * ゲーム開発者は `g.DynamicFontParameterObject#fontWeight` を指定することでフォントウェイトを変更することができます。
+ * `g.BitmapFont` のコンストラクタ引数に `BitmapFontParameterObject` が渡せるように
 
 ### 非推奨機能の変更
  * `g.DynamicFont` の既存のコンストラクタを非推奨に。
     * 利用中のユーザは `DynamicFontParameterObject` を渡すようにしてください。
+ * `g.BitmapFont` の既存のコンストラクタを非推奨に。
+    * 利用中のユーザは `BitmapFontParameterObject` を渡すようにしてください。
 
 ### 内部実装の変更
  * `g.ResourceFactory#createGlyphFactory()` の引数が追加

--- a/unreleased-changes/support-bold.md
+++ b/unreleased-changes/support-bold.md
@@ -1,0 +1,19 @@
+
+機能追加
+ * `g.DynamicFont` でフォントウェイトが指定可能に
+ * `g.DynamicFontParameterObject` を追加
+ * `g.ResourceFactory#createGlyphFactory()` に引数を追加
+
+### ゲーム開発者への影響
+ * `g.DynamicFont` のコンストラクタ引数に `DynamicFontParameterObject` が渡せるように
+ * `g.DynamicFont` でフォントウェイトが指定可能に
+    * ゲーム開発者は `g.DynamicFontParameterObject#fontWeight` を指定することでフォントウェイトを変更することができます。
+
+### 非推奨機能の変更
+ * `g.DynamicFont` の既存のコンストラクタを非推奨に。
+    * 利用中のユーザは `DynamicFontParameterObject` を渡すようにしてください。
+
+### 内部実装の変更
+ * `g.ResourceFactory#createGlyphFactory()` の引数が追加
+    * `g.ResourceFactory` の実装者は引数に応じた `g.GlyphFactory` の実装を返す必要があります。追加される引数は順に次のとおりです。
+      * フォントウェイト(`fontWeight: FontWeight`)


### PR DESCRIPTION
## このpull requestが解決する内容
`g.DynamicFont` でフォントウェイトを指定可能にします。それに伴い以下の修正もしています。
 - `g.DynamicFontParameterObject` を追加
   -  `g.DynamicFont` の既存のコンストラクタが非推奨になります。
 - `g.BitmapFontParameterObject` を追加
   -  `g.BitmapFont` の既存のコンストラクタが非推奨になります。
   - 既存のコンストラクタでは `fontWeight` を指定することは出来ません。
 - `g.ResourceFactory#createGlyphFactory()` に引数 `fontWeight: FontWeight` を追加
 - `g.GlyphFactory#fontWeight` を追加
 - `g.DynamicFont` のテスト追加
 - `g.Label` のテスト修正

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

