### PR TITLE
Change g.game.random to a g.RandomGenerator from an array

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "prepublish": "npm run minify && npm run doc",
-    "postinstall": "npm run prepublish",
+    "prepare": "npm run prepublish",
     "build": "npm run clean && tsc -p ./ && npm run compile:cp && npm run concat:define && npm run concat:node",
     "clean": "rimraf tmp && rimraf lib",
     "compile:cp": "cpx tmp/tmp.d.ts lib && cpx tmp/tmp.js lib && renamer --find tmp --replace main ./lib/*",

--- a/spec/GameSpec.js
+++ b/spec/GameSpec.js
@@ -15,7 +15,7 @@ describe("test Game", function() {
 		expect(game.db).toEqual({});
 		expect(game.renderers.length).toBe(0);
 		expect(game.scenes.length).toBe(0);
-		expect(game.random.length).toBe(0);
+		expect(game.random).toBe(null);
 		expect(game.events.length).toBe(0);
 		expect(game.modified).toBe(true);
 		expect(game.external).toEqual({});
@@ -716,7 +716,7 @@ describe("test Game", function() {
 		});
 		game.resourceFactory.scriptContents["/script/mainScene.js"] = "module.exports = function () {return new g.Scene({game: g.game})}";
 		expect(game.age).toBe(0);
-		expect(game.random[0]).toBe(undefined);
+		expect(game.random).toBe(null);
 
 		game._loaded.handle(function () {
 			expect(game.isLoaded).toBe(true);
@@ -735,7 +735,7 @@ describe("test Game", function() {
 
 			expect(game.scene()).toBe(game._initialScene);
 			expect(game.age).toBe(3);
-			expect(game.random[0]).toBe(randGen);
+			expect(game.random).toBe(randGen);
 			done();
 		});
 		game._loadAndStart();
@@ -756,7 +756,7 @@ describe("test Game", function() {
 		});
 		game.resourceFactory.scriptContents["/script/mainScene.js"] = "module.exports = function () {return new g.Scene({game: g.game})};";
 		expect(game.age).toBe(0);
-		expect(game.random[0]).toBe(undefined);
+		expect(game.random).toBe(null);
 
 		var testDone = false;
 		game._loaded.handle(function () {

--- a/spec/ModuleSpec.js
+++ b/spec/ModuleSpec.js
@@ -222,7 +222,7 @@ describe("test Module", function() {
 		// cache
 		"/script/cache1.js": "module.exports = { v1: require('randomnumber'), v2: require('randomnumber'), cache2: require('./cache2.js') };",
 		"/script/cache2.js": "module.exports = { v1: require('randomnumber'), v2: require('randomnumber') };",
-		"/node_modules/randomnumber/index.js": "module.exports = g.game.random[0].get(0, 1000000);",
+		"/node_modules/randomnumber/index.js": "module.exports = g.game.random.get(0, 1000000);",
 	};
 
 	beforeEach(function() {
@@ -578,7 +578,7 @@ describe("test Module", function() {
 	it("require - cache", function (done) {
 		var game = new mock.Game(gameConfiguration, "/");
 		game.resourceFactory.scriptContents = scriptContents;
-		game.random.push(new g.XorshiftRandomGenerator(1));
+		game.random = new g.XorshiftRandomGenerator(1);
 		game._loaded.handle(function () {
 			var module = new g.Module(game, "dummymod", "/script/dummypath.js");
 			var cache1 = module.require("./cache1");

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -67,7 +67,7 @@ namespace g {
 		age?: number;
 
 		/**
-		 * `Game#random[0]` に設定する値。
+		 * `Game#random` に設定する値。
 		 * 省略された場合、元の値が維持される。
 		 */
 		randGen?: RandomGenerator;
@@ -108,7 +108,7 @@ namespace g {
 		/**
 		 * このGameで利用可能な乱数生成機群。
 		 */
-		random: RandomGenerator[];
+		random: RandomGenerator;
 		/**
 		 * 処理待ちのイベント。
 		 */
@@ -408,7 +408,7 @@ namespace g {
 			this.height = gameConfiguration.height;
 			this.renderers = [];
 			this.scenes = [];
-			this.random = [];
+			this.random = null;
 			this.age = 0;
 			this.assetBase = assetBase || "";
 			this.resourceFactory = resourceFactory;
@@ -825,7 +825,7 @@ namespace g {
 				if (param.age !== undefined)
 					this.age = param.age;
 				if (param.randGen !== undefined)
-					this.random[0] = param.randGen;
+					this.random = param.randGen;
 			}
 
 			this._loaded.removeAllByHandler(this._start);

--- a/src/RandomGenerator.ts
+++ b/src/RandomGenerator.ts
@@ -9,8 +9,16 @@ namespace g {
 		 */
 		seed: number;
 
+		/**
+		 * このインスタンス (`this`) と同じ値。
+		 * この値は過去に `g.Game#random` が配列だった当時との互換性のために提供されている。
+		 * @deprecated 非推奨である。ゲーム開発者はこの値ではなく単にこのインスタンス自身を利用すべきである。
+		 */
+		0?: RandomGenerator;
+
 		constructor(seed: number) {
 			this.seed = seed;
+			this[0] = this;
 		}
 
 		abstract get(min: number, max: number): number;

--- a/unreleased-changes/nonarray-random.md
+++ b/unreleased-changes/nonarray-random.md
@@ -1,0 +1,16 @@
+
+その他変更
+ * `g.Game#random` を配列でないように変更
+
+### ゲーム開発者への影響
+
+ * `g.Game#random` を配列でないように変更
+   * 型を `g.RandomGenerator[]` から `g.RandomGenerator` に変更しました。
+   * 従来 `g.game.random[0]` で参照できた乱数生成器は、 `g.game.random` に置かれるようになりました。
+     (`random` は歴史的経緯から配列として定義されていましたが、第0要素以外は利用されていませんでした。)
+
+### 非推奨機能の変更
+
+ * `g.game.random[0]` を非推奨に
+    * 利用している場合、 `g.game.random` を使うよう変更してください。
+


### PR DESCRIPTION
## このpull requestが解決する内容

`g.game.random` を配列でなく単なる乱数生成器に変更します。
これにより `g.game.random[0].get(0, 10)` などの `[0]` が不要になります。

この値は導入当初から配列でした。その後の検討によって第 0 要素以外が使われることはありませんでしたが、互換性のため長らく配列の形を維持してきたものです。

## 破壊的な変更を含んでいるか?

- なし。ただし deprecated に `g.game.random[0]` を追加。
