### PR TITLE
Reorder arguments of Scene#setTimeout(), setInterval()

### DIFF
--- a/spec/SceneSpec.js
+++ b/spec/SceneSpec.js
@@ -947,7 +947,7 @@ describe("test Scene", function() {
 		expect(scene2._timer._timers.length).toBe(0);
 	});
 
-	it("setTimeout", function() {
+	it("setTimeout - deprecated", function() {
 		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 32 });
 		var game = runtime.game;
 		var scene1 = game.scene();
@@ -975,6 +975,32 @@ describe("test Scene", function() {
 		game.tick(1);
 		game.tick(1);
 		expect(scene1._timer._timers.length).toBe(0);
+	});
+
+	it("setTimeout", function() {
+		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 32 });
+		var game = runtime.game;
+		var scene = game.scene();
+		var owner = {};
+		var callCount = 0;
+		var timerId = scene.setTimeout(function () {
+			expect(this).toBe(owner);
+			callCount++;
+		}, 100, owner);
+
+		game.tick(1);
+		game.tick(1);
+		game.tick(1);
+		expect(callCount).toBe(0);
+		game.tick(1);
+		expect(callCount).toBe(1);
+		game.tick(1);
+		game.tick(1);
+		game.tick(1);
+		game.tick(1);
+		game.tick(1);
+		game.tick(1);
+		expect(callCount).toBe(1);
 	});
 
 	it("clearTimeout", function() {
@@ -1037,6 +1063,35 @@ describe("test Scene", function() {
 		game.replaceScene(scene3);
 		game._flushSceneChangeRequests();
 		expect(scene1._timer._timers).toBeUndefined();
+	});
+
+	it("setInterval", function() {
+		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 32 });
+		var game = runtime.game;
+		var scene = game.scene();
+		var owner = {};
+		var callCount = 0;
+		var timerId = scene.setInterval(function () {
+			expect(this).toBe(owner);
+			callCount++;
+		}, 100, owner);
+
+		game.tick(1);
+		game.tick(1);
+		game.tick(1);  // 3/32*1000 = 93.75ms
+		expect(callCount).toBe(0);
+		game.tick(1);  // 4/32*1000 = 125ms
+		expect(callCount).toBe(1);
+		game.tick(1);
+		game.tick(1);
+		expect(callCount).toBe(1);
+		game.tick(1);  // 7/32*1000 = 218.75ms
+		expect(callCount).toBe(2);
+		game.tick(1);
+		game.tick(1);
+		expect(callCount).toBe(2);
+		game.tick(1);  // 10/32*1000 = 312.5ms
+		expect(callCount).toBe(3);
 	});
 
 	it("isCurrentScene/gotoScene/end", function(done){

--- a/spec/TimerManagerSpec.js
+++ b/spec/TimerManagerSpec.js
@@ -127,10 +127,10 @@ describe("test TimerManager", function () {
 		var parent = new Object();
 		var passedOwner = null;
 		var count = 0;
-		var timeout = m.setTimeout(1000, parent, function() {
+		var timeout = m.setTimeout(function() {
 			count++;
 			passedOwner = this;
-		});
+		}, 1000, parent);
 		expect(m._identifiers.length).toEqual(1);
 		loopFire(29); // 966.666ms
 		expect(count).toBe(0);
@@ -147,9 +147,9 @@ describe("test TimerManager", function () {
 
 		var parent = new Object();
 		var count = 0;
-		var timeout = m.setInterval(2000, parent, function() {
+		var timeout = m.setInterval(function() {
 			count++;
-		});
+		}, 2000, parent);
 		loopFire(60);
 		expect(count).toBe(1);
 	});
@@ -160,9 +160,9 @@ describe("test TimerManager", function () {
 
 		var parent = new Object();
 		var count = 0;
-		var timeout = m.setTimeout(1000, parent, function() {
+		var timeout = m.setTimeout(function() {
 			count++;
-		});
+		}, 1000, parent);
 		expect(m._identifiers.length).toEqual(1);
 		m._identifiers.length = 0;
 		expect(function() { loopFire(30); }).toThrowError("AssertionError");
@@ -173,17 +173,17 @@ describe("test TimerManager", function () {
 
 		var count1 = 0;
 		var count2 = 0;
-		var timeout1 = m.setTimeout(1000, function() {
+		var timeout1 = m.setTimeout(function() {
 			count1++;
-		});
+		}, 1000);
 		expect(m._identifiers.length).toEqual(1);
 		loopFire(30); // 1000ms
 		expect(m._identifiers.length).toEqual(0);
 		expect(count1).toBe(1);
 
-		var timeout2 = m.setTimeout(1000, function() {
+		var timeout2 = m.setTimeout(function() {
 			count2++;
-		});
+		}, 1000);
 		expect(m._identifiers.length).toEqual(1);
 		loopFire(29); // 1966.666ms
 		expect(count2).toBe(0);
@@ -200,12 +200,12 @@ describe("test TimerManager", function () {
 
 		var count1 = 0;
 		var count2 = 0;
-		var timeout1 = m.setTimeout(1000, function() {
+		var timeout1 = m.setTimeout(function() {
 			count1++;
-		});
-		var timeout2 = m.setTimeout(1000, function() {
+		}, 1000);
+		var timeout2 = m.setTimeout(function() {
 			count2++;
-		});
+		}, 1000);
 		expect(m._identifiers.length).toEqual(2);
 		loopFire(29); // 966.666ms
 		expect(count1).toBe(0);
@@ -224,15 +224,15 @@ describe("test TimerManager", function () {
 
 		var count1 = 0;
 		var count2 = 0;
-		var timeout1 = m.setTimeout(500, function() {
+		var timeout1 = m.setTimeout(function() {
 			count1++;
-		});
+		}, 500);
 		loopFire(5); // 500ms
 		expect(count1).toBe(1);
 
-		var timeout2 = m.setTimeout(1000, function() {
+		var timeout2 = m.setTimeout(function() {
 			count2++;
-		});
+		}, 1000);
 		loopFire(10); // 1500ms
 		expect(count2).toBe(1);
 		loopFire(15); // 3000ms
@@ -246,12 +246,12 @@ describe("test TimerManager", function () {
 
 		var count1 = 0;
 		var count2 = 0;
-		var timeout1 = m.setTimeout(500, function() {
+		var timeout1 = m.setTimeout(function() {
 			count1++;
-		});
-		var timeout2 = m.setTimeout(1000, function() {
+		}, 500);
+		var timeout2 = m.setTimeout(function() {
 			count2++;
-		});
+		}, 1000);
 		loopFire(5); // 500ms
 		expect(count1).toBe(1);
 		expect(count2).toBe(0);
@@ -265,9 +265,9 @@ describe("test TimerManager", function () {
 		var m = new g.TimerManager(trigger, 10);
 
 		var count = 0;
-		var timeout = m.setTimeout(0, function() {
+		var timeout = m.setTimeout(function() {
 			count++;
-		});
+		}, 0);
 
 		loopFire(1); // 100ms
 		expect(count).toBe(1);
@@ -279,9 +279,9 @@ describe("test TimerManager", function () {
 		var m = new g.TimerManager(trigger, 10);
 
 		var count = 0;
-		var timeout = m.setTimeout(500, function() {
+		var timeout = m.setTimeout(function() {
 			count++;
-		});
+		}, 500);
 		expect(m._identifiers.length).toEqual(1);
 		loopFire(3); // 300ms
 		m.clearTimeout(timeout);
@@ -295,7 +295,7 @@ describe("test TimerManager", function () {
 	it("clearTimeout - error(not found)", function() {
 		var m = new g.TimerManager(trigger, 10);
 
-		var timeout = m.setTimeout(500, function() {});
+		var timeout = m.setTimeout(function() {}, 500);
 		loopFire(3);
 		m.clearTimeout(timeout);
 		expect(function() { m.clearTimeout(timeout); }).toThrowError("AssertionError");
@@ -304,7 +304,7 @@ describe("test TimerManager", function () {
 	it("clearTimeout - error(invalid identifier)", function() {
 		var m = new g.TimerManager(trigger, 10);
 
-		var timeout = m.setTimeout(500, function() {});
+		var timeout = m.setTimeout(function() {}, 500);
 		loopFire(3);
 		timeout.destroy();
 		expect(function() { m.clearTimeout(timeout); }).toThrowError("AssertionError");
@@ -315,12 +315,12 @@ describe("test TimerManager", function () {
 
 		var count1 = 0;
 		var count2 = 0;
-		var timeout1 = m.setTimeout(500, function() {
+		var timeout1 = m.setTimeout(function() {
 			count1++;
-		});
-		var timeout2 = m.setTimeout(500, function() {
+		}, 500);
+		var timeout2 = m.setTimeout(function() {
 			count2++;
-		});
+		}, 500);
 		loopFire(3); // 300ms
 		m.clearTimeout(timeout1);
 		loopFire(2); // 500ms
@@ -332,9 +332,9 @@ describe("test TimerManager", function () {
 		var m = new g.TimerManager(trigger, 10);
 
 		var count = 0;
-		var timeout = m.setTimeout(0, function() {
+		var timeout = m.setTimeout(function() {
 			count++;
-		});
+		}, 0);
 		m.clearTimeout(timeout);
 		loopFire(10); // 1000ms
 		expect(count).toBe(0);
@@ -346,10 +346,10 @@ describe("test TimerManager", function () {
 		var parent = new Object();
 		var passedOwner = null;
 		var count = 0;
-		var interval = m.setInterval(500, parent, function() {
+		var interval = m.setInterval(function() {
 			count++;
 			passedOwner = this;
-		});
+		}, 500, parent);
 		loopFire(4); // 400ms
 		expect(count).toBe(0);
 		trigger.fire(); // 500ms
@@ -369,12 +369,12 @@ describe("test TimerManager", function () {
 
 		var count1 = 0;
 		var count2 = 0;
-		var interval1 = m.setInterval(500, function() {
+		var interval1 = m.setInterval(function() {
 			count1++;
-		});
-		var interval2 = m.setInterval(500, function() {
+		}, 500);
+		var interval2 = m.setInterval(function() {
 			count2++;
-		});
+		}, 500);
 		loopFire(4); // 400ms
 		expect(count1).toBe(0);
 		expect(count2).toBe(0);
@@ -398,12 +398,12 @@ describe("test TimerManager", function () {
 
 		var count1 = 0;
 		var count2 = 0;
-		var timeout1 = m.setInterval(500, function() {
+		var timeout1 = m.setInterval(function() {
 			count1++;
-		});
-		var timeout2 = m.setInterval(1000, function() {
+		}, 500);
+		var timeout2 = m.setInterval(function() {
 			count2++;
-		});
+		}, 1000);
 		loopFire(5); // 500ms
 		expect(count1).toBe(1);
 		expect(count2).toBe(0);
@@ -424,9 +424,9 @@ describe("test TimerManager", function () {
 		var m = new g.TimerManager(trigger, 10);
 
 		var count = 0;
-		var interval = m.setInterval(0, function() {
+		var interval = m.setInterval(function() {
 			count++;
-		});
+		}, 0);
 		loopFire(10); // 1000ms
 		expect(count).toBe(1000);
 	});
@@ -435,9 +435,9 @@ describe("test TimerManager", function () {
 		var m = new g.TimerManager(trigger, 10);
 
 		var count = 0;
-		var interval = m.setInterval(500, function() {
+		var interval = m.setInterval(function() {
 			count++;
-		});
+		}, 500);
 		loopFire(20); // 2000ms
 		expect(count).toBe(4);
 		m.clearInterval(interval);
@@ -449,7 +449,7 @@ describe("test TimerManager", function () {
 	it("clearInterval - error(not found)", function() {
 		var m = new g.TimerManager(trigger, 10);
 
-		var interval = m.setInterval(500, function() {});
+		var interval = m.setInterval(function() {}, 500);
 		loopFire(3);
 		m.clearInterval(interval);
 		expect(function() { m.clearInterval(interval); }).toThrowError("AssertionError");
@@ -458,7 +458,7 @@ describe("test TimerManager", function () {
 	it("clearInterval - error(invalid identifier)", function() {
 		var m = new g.TimerManager(trigger, 10);
 
-		var interval = m.setInterval(500, function() {});
+		var interval = m.setInterval(function() {}, 500);
 		loopFire(3);
 		interval.destroy();
 		expect(function() { m.clearInterval(interval); }).toThrowError("AssertionError");
@@ -469,12 +469,12 @@ describe("test TimerManager", function () {
 
 		var count1 = 0;
 		var count2 = 0;
-		var interval1 = m.setInterval(500, function() {
+		var interval1 = m.setInterval(function() {
 			count1++;
-		});
-		var interval2 = m.setInterval(500, function() {
+		}, 500);
+		var interval2 = m.setInterval(function() {
 			count2++;
-		});
+		}, 500);
 		expect(m._identifiers.length).toEqual(2);
 		loopFire(20); // 2000ms
 		m.clearInterval(interval1);
@@ -491,9 +491,9 @@ describe("test TimerManager", function () {
 	it("destroy", function () {
 		var m = new g.TimerManager(trigger, 10);
 
-		var timeout1 = m.setTimeout(100, function() {});
-		var timeout2 = m.setTimeout(200, function() {});
-		var timeout3 = m.setTimeout(300, function() {});
+		var timeout1 = m.setTimeout(function() {}, 100);
+		var timeout2 = m.setTimeout(function() {}, 200);
+		var timeout3 = m.setTimeout(function() {}, 300);
 		var timer1 = timeout1._timer;
 		var timer2 = timeout1._timer;
 		var timer3 = timeout1._timer;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -784,7 +784,6 @@ namespace g {
 		/**
 		 * @private
 		 */
-
 		_fireSceneReady(scene: Scene): void {
 			this._sceneChangeRequests.push({ type: SceneChangeType.FireReady, scene: scene });
 		}
@@ -792,7 +791,6 @@ namespace g {
 		/**
 		 * @private
 		 */
-
 		_fireSceneLoaded(scene: Scene): void {
 			if (scene._loadingState < SceneLoadState.LoadedFired) {
 				this._sceneChangeRequests.push({ type: SceneChangeType.FireLoaded, scene: scene });
@@ -802,7 +800,6 @@ namespace g {
 		/**
 		 * @private
 		 */
-
 		_callSceneAssetHolderHandler(assetHolder: SceneAssetHolder): void {
 			this._sceneChangeRequests.push({ type: SceneChangeType.CallAssetHolderHandler, assetHolder: assetHolder });
 		}
@@ -810,7 +807,6 @@ namespace g {
 		/**
 		 * @private
 		 */
-
 		_normalizeConfiguration(gameConfiguration: GameConfiguration): GameConfiguration {
 			if (!gameConfiguration)
 				throw ExceptionFactory.createAssertionError("Game#_normalizeConfiguration: invalid arguments");
@@ -832,7 +828,6 @@ namespace g {
 		/**
 		 * @private
 		 */
-
 		_setAudioPlaybackRate(playbackRate: number): void {
 			this._audioSystemManager._setPlaybackRate(playbackRate);
 		}
@@ -840,7 +835,6 @@ namespace g {
 		/**
 		 * @private
 		 */
-
 		_setMuted(muted: boolean): void {
 			this._audioSystemManager._setMuted(muted);
 		}
@@ -947,7 +941,6 @@ namespace g {
 		/**
 		 * @private
 		 */
-
 		_updateEventTriggers(scene: Scene): void {
 			this.modified = true;
 			if (! scene) {
@@ -970,7 +963,6 @@ namespace g {
 		/**
 		 * @private
 		 */
-
 		_onInitialSceneLoaded(): void {
 			this._initialScene.loaded.remove(this, this._onInitialSceneLoaded);
 			this.assets = this._initialScene.assets;

--- a/src/Matrix.ts
+++ b/src/Matrix.ts
@@ -103,7 +103,6 @@ namespace g {
 	 * 各フィールド、メソッドの詳細は `Matrix` インターフェースの説明を参照。
 	 */
 	export class PlainMatrix {
-
 		/**
 		 * @private
 		 */

--- a/src/Pane.ts
+++ b/src/Pane.ts
@@ -69,7 +69,6 @@ namespace g {
 		 */
 		_normalizedPadding: CommonRect;
 
-
 		/**
 		 * @private
 		 */

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -664,7 +664,7 @@ namespace g {
 		 * @param interval 実行間隔(ミリ秒)
 		 * @param owner handlerの所有者。省略された場合、null
 		 * @param handler 処理
-		 * @deprecated この引数順は非推奨である。関数を先に指定するDOM互換のものを利用すべきである。
+		 * @deprecated この引数順は現在非推奨である。関数を先に指定するものを利用すべきである。
 		 */
 		setInterval(interval: number, owner: any, handler: () => void): TimerIdentifier;
 		/**
@@ -672,7 +672,7 @@ namespace g {
 		 * `interval` ミリ秒おきに `owner` を `this` として `handler` を呼び出す。
 		 * @param interval 実行間隔(ミリ秒)
 		 * @param handler 処理
-		 * @deprecated この引数順は非推奨である。関数を先に指定するDOM互換のものを利用すべきである。
+		 * @deprecated この引数順は現在非推奨である。関数を先に指定するものを利用すべきである。
 		 */
 		setInterval(interval: number, handler: () => void): TimerIdentifier;
 
@@ -698,7 +698,6 @@ namespace g {
 		 * 一定時間後に一度だけ実行される処理を作成する。
 		 *
 		 * `milliseconds` ミリ秒後(以降)に、一度だけ `owner` を `this` として `handler` を呼び出す。
-		 * 引数 `owner` は省略できるが、 `handler` は省略できない。
 		 * 戻り値は `Scene#clearTimeout` の引数に指定して処理を削除するために使える値である。
 		 *
 		 * このタイマーはフレーム経過処理(`Scene#update`)で実現される疑似的なタイマーである。実時間の影響は受けない。
@@ -718,7 +717,7 @@ namespace g {
 		 * @param handler 処理
 		 * @param milliseconds 時間(ミリ秒)
 		 * @param owner handlerの所有者。省略された場合、null
-		 * @deprecated この引数順は非推奨である。関数を先に指定するDOM互換のものを利用すべきである。
+		 * @deprecated この引数順は現在非推奨である。関数を先に指定するものを利用すべきである。
 		 */
 		setTimeout(milliseconds: number, owner: any, handler: () => void): TimerIdentifier;
 		/**
@@ -727,7 +726,7 @@ namespace g {
 		 * `milliseconds` ミリ秒後(以降)に、一度だけ `handler` を呼び出す。
 		 * @param handler 処理
 		 * @param milliseconds 時間(ミリ秒)
-		 * @deprecated この引数順は非推奨である。関数を先に指定するDOM互換のものを利用すべきである。
+		 * @deprecated この引数順は現在非推奨である。関数を先に指定するものを利用すべきである。
 		 */
 		setTimeout(milliseconds: number, handler: () => void): TimerIdentifier;
 

--- a/src/TimerManager.ts
+++ b/src/TimerManager.ts
@@ -159,13 +159,8 @@ namespace g {
 			}
 		}
 
-		setTimeout(milliseconds: number, owner: any, handler?: () => void): TimerIdentifier {
-			if (handler === undefined) {
-				handler = owner;
-				owner = null;
-			}
+		setTimeout(handler: () => void, milliseconds: number, owner?: any): TimerIdentifier {
 			var timer = this.createTimer(milliseconds);
-
 			var identifier = new TimerIdentifier(timer, handler, owner, this._onTimeoutFired, this);
 			this._identifiers.push(identifier);
 			return identifier;
@@ -175,11 +170,7 @@ namespace g {
 			this._clear(identifier);
 		}
 
-		setInterval(interval: number, owner: any, handler?: () => void): TimerIdentifier {
-			if (handler === undefined) {
-				handler = owner;
-				owner = null;
-			}
+		setInterval(handler: () => void, interval: number, owner?: any): TimerIdentifier {
 			var timer = this.createTimer(interval);
 			var identifier = new TimerIdentifier(timer, handler, owner);
 			this._identifiers.push(identifier);

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -228,7 +228,6 @@ namespace g {
 		}
 
 		export type AnimatingHandler = {
-
 			/**
 			 * @private
 			 */

--- a/unreleased-changes/reorder-settimeout-args.md
+++ b/unreleased-changes/reorder-settimeout-args.md
@@ -1,0 +1,19 @@
+
+その他変更
+ * `g.Scene#setTimeout()`, `setInterval()` の引数順を変更。旧仕様を非推奨に。
+
+### ゲーム開発者への影響
+
+ * `g.Scene#setTimeout()`, `g.Scene#setInterval()` の引数順を変更。
+    * DOM Level 0(Webブラウザの `window.setTimeout()` など)により近くなるよう、
+      引数を `(handler: () => void, milliseconds: number, owner?: any)` の順で与えるよう変更しました。
+    * なおDOMとの完全な互換性は意図していません。次の点で異なります。
+       * 第三引数以降に引数を与えることはできません(代わりに `this` が指定可能)
+       * 関数の代わりに文字列を与えることはできません
+    * 従来は `(milliseconds, handler)` または `(millicseconds, owner, handler)` の順でした。
+
+### 非推奨機能の変更
+
+ * `g.Scene#setTimeout()`, `g.Scene#setInterval()` のうち、第一引数が `milliseconds: number` であるものを非推奨に。
+    * 利用中のユーザは第一引数に関数を指定するものに移行してください。
+


### PR DESCRIPTION
## このpull requestが解決する内容

`Scene#setTimeout()`, 同 `setInterval()` の引数順を変更し、DOMにより近くなるようにします。

歴史的経緯に基づく旧仕様の意図は明らかではありませんが、利用者の混乱を招きがちであり、引数順かメソッド名のどちらかを変更すべきと判断します。

ついでに不要な空行を削除しています。

## 破壊的な変更を含んでいるか?

- なし
- ただし `g.Scene#setTimeout()`, 同 `setInterval()` の旧仕様を非推奨とします。

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

