### PR TITLE
Support moduleMainScripts in game.json

### DIFF
--- a/spec/ModuleSpec.js
+++ b/spec/ModuleSpec.js
@@ -162,7 +162,22 @@ describe("test Module", function() {
 				"path": "/node_modules/randomnumber/index.js",
 				"virtualPath": "node_modules/randomnumber/index.js",
 				"global": true
+			},
+			"node_modules/noPackageJsonModule/hoge.js": {
+				"type": "script",
+				"path": "/node_modules/noPackageJsonModule/hoge.js",
+				"virtualPath": "node_modules/noPackageJsonModule/hoge.js",
+				"global": true
+			},
+			"node_modules/noPackageJsonModule/fuga.js": {
+				"type": "script",
+				"path": "/node_modules/noPackageJsonModule/fuga.js",
+				"virtualPath": "node_modules/noPackageJsonModule/fuga.js",
+				"global": true
 			}
+		},
+		moduleMainScripts: {
+			"noPackageJsonModule": "node_modules/noPackageJsonModule/hoge.js"
 		}
 	}
 
@@ -178,6 +193,8 @@ describe("test Module", function() {
 		"/node_modules/wrongPackageJsonMain/package.json": '{ "main": "__not_exists__.js" }',
 		"/node_modules/wrongPackageJsonMain/index.js": "module.exports = { me: 'wrongPackageJsonMain-index', thisModule: module };",
 		"/node_modules/wrongPackageJsonMain/aJsonFile.json": '{ "aJsonFile": "aValue" }',
+		"/node_modules/noPackageJsonModule/hoge.js": "module.exports = { me: 'noPackageJsonModule', thisModule: module }",
+		"/node_modules/noPackageJsonModule/fuga.js": "module.exports = { me: 'dummy'}",
 
 		// directory structure
 		"/script/useA.js": [
@@ -316,6 +333,14 @@ describe("test Module", function() {
 			expect(mod.me).toBe("script-foo");
 			expect(mod.thisModule instanceof g.Module).toBe(true);
 			expect(mod.thisModule.filename).toBe("/script/foo.js");
+			expect(mod.thisModule.parent).toBe(module);
+			expect(mod.thisModule.children).toEqual([]);
+			expect(mod.thisModule.loaded).toBe(true);
+
+			var mod = module.require("noPackageJsonModule");
+			expect(mod.me).toBe("noPackageJsonModule");
+			expect(mod.thisModule instanceof g.Module).toBe(true);
+			expect(mod.thisModule.filename).toBe("/node_modules/noPackageJsonModule/hoge.js");
 			expect(mod.thisModule.parent).toBe(module);
 			expect(mod.thisModule.children).toEqual([]);
 			expect(mod.thisModule.loaded).toBe(true);

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -79,6 +79,12 @@ namespace g {
 		_liveAbsolutePathTable: {[path: string]: string};
 
 		/**
+		 * requireの第一引数から対応する仮想パスを引くためのテーブル。
+		 * @private
+		 */
+		_moduleMainScripts: ModuleMainScriptsMap;
+
+		/**
 		 * 各アセットに対する参照の数。
 		 * 参照は requestAssets() で増え、unrefAssets() で減る。
 		 * なおロード中であっても参照に数える。つまり (this._refCounts[id] > 1) であるなら !!(this._assets[id] || this._loadings[id])
@@ -97,12 +103,14 @@ namespace g {
 		 * @param game このインスタンスが属するゲーム
 		 * @param conf このアセットマネージャに与えるアセット定義。game.json の `"assets"` に相当。
 		 */
-		constructor(game: Game, conf?: AssetConfigurationMap, audioSystemConfMap?: AudioSystemConfigurationMap) {
+		constructor(game: Game, conf?: AssetConfigurationMap, audioSystemConfMap?: AudioSystemConfigurationMap,
+		            moduleMainScripts?: ModuleMainScriptsMap) {
 			this.game = game;
 			this.configuration = this._normalize(conf || {}, normalizeAudioSystemConfMap(audioSystemConfMap));
 			this._assets = {};
 			this._liveAssetVirtualPathTable = {};
 			this._liveAbsolutePathTable = {};
+			this._moduleMainScripts = moduleMainScripts ? moduleMainScripts : {};
 			this._refCounts = {};
 			this._loadings = {};
 		}

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -476,7 +476,7 @@ namespace g {
 			this._main = gameConfiguration.main;
 			this._mainParameter = undefined;
 			this._configuration = gameConfiguration;
-			this._assetManager = new AssetManager(this, gameConfiguration.assets, gameConfiguration.audio);
+			this._assetManager = new AssetManager(this, gameConfiguration.assets, gameConfiguration.audio, gameConfiguration.moduleMainScripts);
 
 			var operationPluginsField = <InternalOperationPluginInfo[]>(gameConfiguration.operationPlugins || []);
 			this._operationPluginManager = new OperationPluginManager(this, operationPluginViewInfo, operationPluginsField);

--- a/src/GameConfiguration.ts
+++ b/src/GameConfiguration.ts
@@ -93,6 +93,11 @@ namespace g {
 	export type AssetConfigurationMap = {[key: string]: AssetConfiguration};
 
 	/**
+	 * require()解決用のエントリポイント
+	 */
+	export type ModuleMainScriptsMap = {[path: string]: string};
+
+	/**
 	 * AudioSystemの設定を表すインターフェース。
 	 */
 	export interface AudioSystemConfiguration {
@@ -167,6 +172,13 @@ namespace g {
 		// akashic-engine はこのフィールドを認識しないので、エンジンユーザはあらかじめ
 		// `globalScripts` を相当する `assets` 定義に変換する必要がある。
 		globalScripts?: string[];
+
+		/**
+		 * require()解決用ののエントリポイントを格納したテーブル。
+		 *
+		 * require()の第一引数をキーとした値が本テーブルに存在した場合、require()時にその値をパスとしたスクリプトアセットを評価する。
+		 */
+		moduleMainScripts?: ModuleMainScriptsMap;
 
 		/**
 		 * デフォルトローディングシーンについての指定。

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -21,6 +21,7 @@ namespace g {
 		var resolvedPath: string;
 		var resolvedVirtualPath: string;
 		var liveAssetVirtualPathTable = game._assetManager._liveAssetVirtualPathTable;
+		var moduleMainScripts = game._assetManager._moduleMainScripts;
 
 		// 0. アセットIDらしい場合はまず当該アセットを探す
 		if (path.indexOf("/") === -1) {
@@ -29,7 +30,7 @@ namespace g {
 		}
 
 		// 1. If X is a core module,
-		// (何もしない。コアモジュールには対応していない。ゲーム開発者は自でコアモジュールへの依存を解決する必要がある)
+		// (何もしない。コアモジュールには対応していない。ゲーム開発者は自分でコアモジュールへの依存を解決する必要がある)
 
 		if (/^\.\/|^\.\.\/|^\//.test(path)) {
 			// 2. If X begins with './' or '/' or '../'
@@ -66,6 +67,12 @@ namespace g {
 		} else {
 			// 3. LOAD_NODE_MODULES(X, dirname(Y))
 			// `path` は node module の名前であると仮定して探す
+
+			// akashic-engine独自拡張: 対象の `path` が `moduleMainScripts` に指定されていたらそちらを参照する
+			if (moduleMainScripts[path]) {
+				targetScriptAsset = game._assetManager._assets[moduleMainScripts[path]];
+			}
+
 			if (! targetScriptAsset) {
 				var dirs = currentModule ? currentModule.paths : [];
 				dirs.push("node_modules");

--- a/unreleased-changes/support-module-main-scripts.md
+++ b/unreleased-changes/support-module-main-scripts.md
@@ -1,0 +1,4 @@
+
+機能追加
+ * game.json に moduleMainScripts フィールドが存在した場合、そのキーと対応するパスのスクリプトアセットが require() 時に評価されるようになります。
+ * moduleMainScripts フィールドが存在しない場合は既存の動作を行います。


### PR DESCRIPTION
## このpull requestが解決する内容
game.jsonに `moduleMainScripts` フィールドを追加します。
require()の第一引数の値が `moduleMainScripts` のキーとして存在した場合、そのキーと対応する値をパスとしたスクリプトアセットとして評価します。

### 例
game.json
```
...
   "moduleMainScripts": {
    "hoge": "node_modules/hoge/lib/main.js"
  }
```

node_modules/hoge/lib/main.js
```
module.exports = "hoge";
```

content
```
console.log(require("hoge")); // "hoge"
```

**v1ブランチへのマージは本PRのレビュー後に対応いたします**

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

