### PR TITLE
Fix to resolve moduleMainScripts from _liveAssetVirtualPathTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 1.12.8
+不具合修正
+ * `moduleMainScripts` のファイルパスを `AssetManager#_liveAssetVirtualPathTable` から参照するように修正
+
 ## 1.12.7
 
 機能追加

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "devDependencies": {

--- a/spec/ModuleSpec.js
+++ b/spec/ModuleSpec.js
@@ -165,13 +165,13 @@ describe("test Module", function() {
 			},
 			"node_modules/noPackageJsonModule/hoge.js": {
 				"type": "script",
-				"path": "/node_modules/noPackageJsonModule/hoge.js",
+				"path": "/node_modules/noPackageJsonModule/real_hoge.js",
 				"virtualPath": "node_modules/noPackageJsonModule/hoge.js",
 				"global": true
 			},
 			"node_modules/noPackageJsonModule/fuga.js": {
 				"type": "script",
-				"path": "/node_modules/noPackageJsonModule/fuga.js",
+				"path": "/node_modules/noPackageJsonModule/real_fuga.js",
 				"virtualPath": "node_modules/noPackageJsonModule/fuga.js",
 				"global": true
 			}
@@ -193,8 +193,8 @@ describe("test Module", function() {
 		"/node_modules/wrongPackageJsonMain/package.json": '{ "main": "__not_exists__.js" }',
 		"/node_modules/wrongPackageJsonMain/index.js": "module.exports = { me: 'wrongPackageJsonMain-index', thisModule: module };",
 		"/node_modules/wrongPackageJsonMain/aJsonFile.json": '{ "aJsonFile": "aValue" }',
-		"/node_modules/noPackageJsonModule/hoge.js": "module.exports = { me: 'noPackageJsonModule', thisModule: module }",
-		"/node_modules/noPackageJsonModule/fuga.js": "module.exports = { me: 'dummy'}",
+		"/node_modules/noPackageJsonModule/real_hoge.js": "module.exports = { me: 'noPackageJsonModule', thisModule: module }",
+		"/node_modules/noPackageJsonModule/real_fuga.js": "module.exports = { me: 'dummy'}",
 
 		// directory structure
 		"/script/useA.js": [
@@ -340,7 +340,7 @@ describe("test Module", function() {
 			var mod = module.require("noPackageJsonModule");
 			expect(mod.me).toBe("noPackageJsonModule");
 			expect(mod.thisModule instanceof g.Module).toBe(true);
-			expect(mod.thisModule.filename).toBe("/node_modules/noPackageJsonModule/hoge.js");
+			expect(mod.thisModule.filename).toBe("/node_modules/noPackageJsonModule/real_hoge.js");
 			expect(mod.thisModule.parent).toBe(module);
 			expect(mod.thisModule.children).toEqual([]);
 			expect(mod.thisModule.loaded).toBe(true);

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -70,7 +70,7 @@ namespace g {
 
 			// akashic-engine独自拡張: 対象の `path` が `moduleMainScripts` に指定されていたらそちらを参照する
 			if (moduleMainScripts[path]) {
-				targetScriptAsset = game._assetManager._assets[moduleMainScripts[path]];
+				targetScriptAsset = game._assetManager._liveAssetVirtualPathTable[moduleMainScripts[path]];
 			}
 
 			if (! targetScriptAsset) {


### PR DESCRIPTION
## このpull requestが解決する内容
`moduleMainScripts` のファイルパスを `_liveAssetVirtualPathTable` から参照するように修正します。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

