### PR TITLE
Change g.Renderer specification

### DIFF
--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -97,7 +97,7 @@ namespace g {
 		/**
 		 * 本Rendererの描画内容を表すImageDataを取得する。
 		 * 引数は CanvasRenderingContext2D#getImageData() と同様である。
-		 * 本メソッドは `Renderer#end()` から `Renderer#begin()` の間に呼び出さなければならない。
+		 * 本メソッドの呼び出しは `Renderer#end()` から `Renderer#begin()` の間でなければならない。
 		 * NOTE: 実行環境によっては戻り値が `null` または `undefined` となりえることに注意。
 		 */
 		abstract _getImageData(sx: number, sy: number, sw: number, sh: number): ImageData;
@@ -105,7 +105,7 @@ namespace g {
 		/**
 		 * 本Rendererの描画内容を上書きする。
 		 * 引数は CanvasRenderingContext2D#putImageData() と同様である。
-		 * 本メソッドは `Renderer#end()` から `Renderer#begin()` の間に呼び出さなければならない。
+		 * 本メソッドの呼び出しは `Renderer#end()` から `Renderer#begin()` の間でなければならない。
 		 */
 		abstract _putImageData(imageData: ImageData, dx: number, dy: number, dirtyX?: number, dirtyY?: number,
 		                       dirtyWidth?: number, dirtyHeight?: number): void;

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -97,6 +97,7 @@ namespace g {
 		/**
 		 * 本Rendererの描画内容を表すImageDataを取得する。
 		 * 引数は CanvasRenderingContext2D#getImageData() と同様である。
+		 * 本メソッドは `Renderer#end()` から `Renderer#begin()` の間に呼び出さなければならない。
 		 * NOTE: 実行環境によっては戻り値が `null` または `undefined` となりえることに注意。
 		 */
 		abstract _getImageData(sx: number, sy: number, sw: number, sh: number): ImageData;
@@ -104,6 +105,7 @@ namespace g {
 		/**
 		 * 本Rendererの描画内容を上書きする。
 		 * 引数は CanvasRenderingContext2D#putImageData() と同様である。
+		 * 本メソッドは `Renderer#end()` から `Renderer#begin()` の間に呼び出さなければならない。
 		 */
 		abstract _putImageData(imageData: ImageData, dx: number, dy: number, dirtyX?: number, dirtyY?: number,
 		                       dirtyWidth?: number, dirtyHeight?: number): void;


### PR DESCRIPTION
## このpull requestが解決する内容
`Renderer#_getImageData()` , `Renderer#_putImageData()` の呼び出しタイミングを `Renderer#end()` から `Renderer#begin()` までであることを仕様化します。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

