### PR TITLE
【WIP】surfaceを通知された解像度で描画し直す対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 機能追加
  * `g.Surface` でscale変更ができる設定を追加
  * `g.Surface` の省略可能なboolean型引数 `isDynamic` を booleanもしくはnumber型の `statusOption` に変更
+ * `g.Pane`, `g.Label`の内部surfaceに関してscale変更するかどうかの設定を可能にした
+ * `g.DynamicFont`の内部surfaceをscale変更可能にした
 
 ## 2.1.1
 不具合修正

--- a/spec/CacheableESpec.js
+++ b/spec/CacheableESpec.js
@@ -22,7 +22,11 @@ describe("test CacheableE", function () {
 	it("invalidate", function () {
 		var ce = new g.CacheableE({ scene: runtime.scene });
 		var renderer = new mock.Renderer();
-		ce.renderCache = function () {};  // CacheableE は抽象クラスなのでテストできるようにダミーの実装を代入しておく
+		// CacheableE は抽象クラスなのでテストできるようにダミーの実装を代入しておく
+		ce.renderCache = function () {};
+		ce._createCache = function (width, height) {
+			return ce._createSurface(width, height, false);
+		};
 
 		expect(ce.state & mock.EntityStateFlags.Cached).toBe(0);
 		ce.renderSelf(renderer);
@@ -36,7 +40,11 @@ describe("test CacheableE", function () {
 	it("renderSelf", function () {
 		var ce = new g.CacheableE({ scene: runtime.scene });
 		var renderer = new mock.Renderer();
-		ce.renderCache = function () {};  // CacheableE は抽象クラスなのでテストできるようにダミーの実装を代入しておく
+		// CacheableE は抽象クラスなのでテストできるようにダミーの実装を代入しておく
+		ce.renderCache = function () {};
+		ce._createCache = function (width, height) {
+			return ce._createSurface(width, height, false);
+		};
 
 		// 戻り値
 		expect(ce.renderSelf(renderer)).toBe(true);
@@ -55,6 +63,9 @@ describe("test CacheableE", function () {
 		var called = false;
 		ce.renderCache = function(r, c) {
 			called = true;
+		};
+		ce._createCache = function (width, height) {
+			return ce._createSurface(width, height, false);
 		};
 
 		// 呼ばれる (初期状態ではキャッシュされていない)
@@ -86,6 +97,9 @@ describe("test CacheableE", function () {
 		ce.width = 100;
 		ce.height = 200;
 		ce.renderCache = function(r, c) {
+		};
+		ce._createCache = function (width, height) {
+			return ce._createSurface(width, height, false);
 		};
 
 		// 最初の呼び出し時にキャッシュを生成する
@@ -123,6 +137,9 @@ describe("test CacheableE", function () {
 		ce.width = 100;
 		ce.height = 200;
 		ce.renderCache = function(r, c) {
+		};
+		ce._createCache = function (width, height) {
+			return ce._createSurface(width, height, false);
 		};
 		ce.invalidate();
 		ce.renderSelf(r);

--- a/spec/helpers/mock.ts
+++ b/spec/helpers/mock.ts
@@ -399,8 +399,9 @@ export class AudioPlayer extends g.AudioPlayer {
 
 export class GlyphFactory extends g.GlyphFactory {
 	constructor(fontFamily: g.FontFamily|string|string[], fontSize: number, baselineHeight?: number,
-	            fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean, fontWeight?: g.FontWeight) {
-		super(fontFamily, fontSize, baselineHeight, fontColor, strokeWidth, strokeColor, strokeOnly, fontWeight);
+	            fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean, fontWeight?: g.FontWeight,
+	            hasVariableResolution?: boolean) {
+		super(fontFamily, fontSize, baselineHeight, fontColor, strokeWidth, strokeColor, strokeOnly, fontWeight, hasVariableResolution);
 	}
 	create(code: number): g.Glyph { return <g.Glyph>undefined; }
 }
@@ -484,8 +485,18 @@ export class ResourceFactory extends g.ResourceFactory {
 
 	createGlyphFactory(fontFamily: g.FontFamily, fontSize: number, baselineHeight?: number,
 	                   fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean,
-	                   fontWeight?: g.FontWeight): g.GlyphFactory {
-		return new GlyphFactory(fontFamily, fontSize, baselineHeight, fontColor, strokeWidth, strokeColor, strokeOnly, fontWeight);
+	                   fontWeight?: g.FontWeight, hasVariableResolution?: boolean): g.GlyphFactory {
+		return new GlyphFactory(
+			fontFamily,
+			fontSize,
+			baselineHeight,
+			fontColor,
+			strokeWidth,
+			strokeColor,
+			strokeOnly,
+			fontWeight,
+			hasVariableResolution
+		);
 	}
 	createVideoAsset(id: string, assetPath: string, width: number, height: number, system: g.VideoSystem,
 	                 loop: boolean, useRealSize: boolean): g.VideoAsset {

--- a/spec/helpers/mock.ts
+++ b/spec/helpers/mock.ts
@@ -399,9 +399,8 @@ export class AudioPlayer extends g.AudioPlayer {
 
 export class GlyphFactory extends g.GlyphFactory {
 	constructor(fontFamily: g.FontFamily|string|string[], fontSize: number, baselineHeight?: number,
-	            fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean, fontWeight?: g.FontWeight,
-	            hasVariableResolution?: boolean) {
-		super(fontFamily, fontSize, baselineHeight, fontColor, strokeWidth, strokeColor, strokeOnly, fontWeight, hasVariableResolution);
+	            fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean, fontWeight?: g.FontWeight) {
+		super(fontFamily, fontSize, baselineHeight, fontColor, strokeWidth, strokeColor, strokeOnly, fontWeight);
 	}
 	create(code: number): g.Glyph { return <g.Glyph>undefined; }
 }
@@ -475,8 +474,8 @@ export class ResourceFactory extends g.ResourceFactory {
 		return new ScriptAsset(this._game, this._necessaryRetryCount, id, assetPath);
 	}
 
-	createSurface(width: number, height: number): g.Surface {
-		return new Surface(width, height);
+	createSurface(width: number, height: number, state?: number): g.Surface {
+		return new Surface(width, height, {}, state);
 	}
 
 	createAudioPlayer(system: g.AudioSystem): g.AudioPlayer {
@@ -485,7 +484,7 @@ export class ResourceFactory extends g.ResourceFactory {
 
 	createGlyphFactory(fontFamily: g.FontFamily, fontSize: number, baselineHeight?: number,
 	                   fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean,
-	                   fontWeight?: g.FontWeight, hasVariableResolution?: boolean): g.GlyphFactory {
+	                   fontWeight?: g.FontWeight): g.GlyphFactory {
 		return new GlyphFactory(
 			fontFamily,
 			fontSize,
@@ -494,8 +493,7 @@ export class ResourceFactory extends g.ResourceFactory {
 			strokeWidth,
 			strokeColor,
 			strokeOnly,
-			fontWeight,
-			hasVariableResolution
+			fontWeight
 		);
 	}
 	createVideoAsset(id: string, assetPath: string, width: number, height: number, system: g.VideoSystem,

--- a/src/CacheableE.ts
+++ b/src/CacheableE.ts
@@ -109,14 +109,14 @@ namespace g {
 			super.destroy();
 		}
 
-		_createCache(width: number, height: number, isResizable: boolean = false): Surface {
-			const optionalFlag = isResizable ? g.SurfaceStatusOption.hasVariableResolution : g.SurfaceStatusOption.None;
-			const surface = this.scene.game.resourceFactory.createSurface(Math.ceil(width), Math.ceil(height), optionalFlag);
-			surface.scaleChanged.add((scales: number[]) => {
-				this.width *= scales[0];
-				this.height *= scales[1];
-				this.invalidate();
-			});
+		abstract _createCache(width: number, height: number): Surface;
+
+		_createSurface(width: number, height: number, hasVariableResolution: boolean): Surface {
+			const surfaceStateFlag = hasVariableResolution ? g.SurfaceStateFlags.hasVariableResolution : g.SurfaceStateFlags.None;
+			const surface = this.scene.game.resourceFactory.createSurface(Math.ceil(width), Math.ceil(height), surfaceStateFlag);
+			if (surface.hasVariableResolution) {
+				surface.contentReset.add(this.invalidate, this);
+			}
 			return surface;
 		}
 	}

--- a/src/CacheableE.ts
+++ b/src/CacheableE.ts
@@ -71,7 +71,7 @@ namespace g {
 					if (this._cache && !this._cache.destroyed()) {
 						this._cache.destroy();
 					}
-					this._cache = this.scene.game.resourceFactory.createSurface(Math.ceil(this.width), Math.ceil(this.height));
+					this._cache = this._createCache(this.width, this.height);
 					this._renderer = this._cache.renderer();
 				}
 				this._renderer.begin();
@@ -107,6 +107,17 @@ namespace g {
 			this._cache = undefined;
 
 			super.destroy();
+		}
+
+		_createCache(width: number, height: number, isResizable: boolean = false): Surface {
+			const optionalFlag = isResizable ? g.SurfaceStatusOption.hasVariableResolution : g.SurfaceStatusOption.None;
+			const surface = this.scene.game.resourceFactory.createSurface(Math.ceil(width), Math.ceil(height), optionalFlag);
+			surface.scaleChanged.add((scales: number[]) => {
+				this.width *= scales[0];
+				this.height *= scales[1];
+				this.invalidate();
+			});
+			return surface;
 		}
 	}
 }

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -83,9 +83,21 @@ namespace g {
 
 		constructor(surface: Surface) {
 			this._surface = surface;
+			this._surface.contentReset.add(this._onContentReset, this);
 			this._emptySurfaceAtlasSlotHead = new SurfaceAtlasSlot(0, 0, this._surface.width, this._surface.height);
 			this._accessScore = 0;
 			this._usedRectangleAreaSize = { width: 0, height: 0 };
+		}
+
+		/**
+		 * @private
+		 */
+		_onContentReset(): void {
+			const renderer = this._surface.renderer();
+			renderer.begin();
+			renderer.clear();
+			renderer.drawImage(this._surface, 0, 0, this._usedRectangleAreaSize.width, this._usedRectangleAreaSize.height, 0, 0);
+			renderer.end();
 		}
 
 		/**
@@ -196,7 +208,7 @@ namespace g {
 			const dst = resourceFactory.createSurface(
 				this._usedRectangleAreaSize.width,
 				this._usedRectangleAreaSize.height,
-				g.SurfaceStatusOption.hasVariableResolution
+				g.SurfaceStateFlags.hasVariableResolution
 			);
 
 			const renderer = dst.renderer();
@@ -416,7 +428,7 @@ namespace g {
 			this._resourceFactory = param.game.resourceFactory;
 			this._glyphFactory =
 				this._resourceFactory.createGlyphFactory(this.fontFamily, this.size, this.hint.baselineHeight,
-					this.fontColor, this.strokeWidth, this.strokeColor, this.strokeOnly, this.fontWeight, true);
+					this.fontColor, this.strokeWidth, this.strokeColor, this.strokeOnly, this.fontWeight);
 			this._glyphs = {};
 			this._atlases = [];
 			this._currentAtlasIndex = 0;

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -193,7 +193,11 @@ namespace g {
 		 */
 		duplicateSurface(resourceFactory: ResourceFactory): Surface {
 			const src = this._surface;
-			const dst = resourceFactory.createSurface(this._usedRectangleAreaSize.width, this._usedRectangleAreaSize.height);
+			const dst = resourceFactory.createSurface(
+				this._usedRectangleAreaSize.width,
+				this._usedRectangleAreaSize.height,
+				g.SurfaceStatusOption.hasVariableResolution
+			);
 
 			const renderer = dst.renderer();
 			renderer.begin();
@@ -412,7 +416,7 @@ namespace g {
 			this._resourceFactory = param.game.resourceFactory;
 			this._glyphFactory =
 				this._resourceFactory.createGlyphFactory(this.fontFamily, this.size, this.hint.baselineHeight,
-					this.fontColor, this.strokeWidth, this.strokeColor, this.strokeOnly, this.fontWeight);
+					this.fontColor, this.strokeWidth, this.strokeColor, this.strokeOnly, this.fontWeight, true);
 			this._glyphs = {};
 			this._atlases = [];
 			this._currentAtlasIndex = 0;

--- a/src/GlyphFactory.ts
+++ b/src/GlyphFactory.ts
@@ -64,13 +64,6 @@ namespace g {
 		strokeOnly: boolean;
 
 		/**
-		 * surfaceのscaleは変更可能かどうか
-		 *
-		 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
-		 */
-		hasVariableResolution: boolean;
-
-		/**
 		 * `GlyphFactory` を生成する。
 		 *
 		 * @param fontFamily フォントファミリ。g.FontFamilyの定義する定数、フォント名、またはそれらの配列
@@ -80,11 +73,10 @@ namespace g {
 		 * @param strokeColor 輪郭色
 		 * @param strokeOnly 輪郭を描画するか否か
 		 * @param fontWeight フォントウェイト
-		 * @param hasVariableResolution surfaceのscaleが変更可能かどうか
 		 */
 		constructor(fontFamily: FontFamily|string|(g.FontFamily|string)[], fontSize: number, baselineHeight: number = fontSize,
 		            fontColor: string = "black", strokeWidth: number = 0, strokeColor: string = "black", strokeOnly: boolean = false,
-		            fontWeight: FontWeight = FontWeight.Normal, hasVariableResolution: boolean = false) {
+		            fontWeight: FontWeight = FontWeight.Normal) {
 			this.fontFamily = fontFamily;
 			this.fontSize = fontSize;
 			this.fontWeight = fontWeight;
@@ -93,7 +85,6 @@ namespace g {
 			this.strokeWidth = strokeWidth;
 			this.strokeColor = strokeColor;
 			this.strokeOnly = strokeOnly;
-			this.hasVariableResolution = hasVariableResolution;
 		}
 
 		/**

--- a/src/GlyphFactory.ts
+++ b/src/GlyphFactory.ts
@@ -64,6 +64,13 @@ namespace g {
 		strokeOnly: boolean;
 
 		/**
+		 * surfaceのscaleは変更可能かどうか
+		 *
+		 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
+		 */
+		hasVariableResolution: boolean;
+
+		/**
 		 * `GlyphFactory` を生成する。
 		 *
 		 * @param fontFamily フォントファミリ。g.FontFamilyの定義する定数、フォント名、またはそれらの配列
@@ -73,10 +80,11 @@ namespace g {
 		 * @param strokeColor 輪郭色
 		 * @param strokeOnly 輪郭を描画するか否か
 		 * @param fontWeight フォントウェイト
+		 * @param hasVariableResolution surfaceのscaleが変更可能かどうか
 		 */
 		constructor(fontFamily: FontFamily|string|(g.FontFamily|string)[], fontSize: number, baselineHeight: number = fontSize,
 		            fontColor: string = "black", strokeWidth: number = 0, strokeColor: string = "black", strokeOnly: boolean = false,
-		            fontWeight: FontWeight = FontWeight.Normal) {
+		            fontWeight: FontWeight = FontWeight.Normal, hasVariableResolution: boolean = false) {
 			this.fontFamily = fontFamily;
 			this.fontSize = fontSize;
 			this.fontWeight = fontWeight;
@@ -85,6 +93,7 @@ namespace g {
 			this.strokeWidth = strokeWidth;
 			this.strokeColor = strokeColor;
 			this.strokeOnly = strokeOnly;
+			this.hasVariableResolution = hasVariableResolution;
 		}
 
 		/**

--- a/src/Label.ts
+++ b/src/Label.ts
@@ -176,7 +176,7 @@ namespace g {
 			var textSurface =  this.scene.game.resourceFactory.createSurface(
 				Math.ceil(this._textWidth),
 				Math.ceil(this.height),
-				g.SurfaceStatusOption.hasVariableResolution
+				g.SurfaceStateFlags.hasVariableResolution
 			);
 			var textRenderer = textSurface.renderer();
 
@@ -243,8 +243,8 @@ namespace g {
 			super.destroy();
 		}
 
-		_createCache(width: number, height: number, isResizable: boolean = false): Surface {
-			return super._createCache(width, height, true);
+		_createCache(width: number, height: number): Surface {
+			return this._createSurface(width, height, true);
 		}
 
 		private _invalidateSelf(): void {

--- a/src/Label.ts
+++ b/src/Label.ts
@@ -173,7 +173,11 @@ namespace g {
 			if (!this.fontSize || this.height <= 0 || this._textWidth <= 0) {
 				return;
 			}
-			var textSurface =  this.scene.game.resourceFactory.createSurface(Math.ceil(this._textWidth), Math.ceil(this.height));
+			var textSurface =  this.scene.game.resourceFactory.createSurface(
+				Math.ceil(this._textWidth),
+				Math.ceil(this.height),
+				g.SurfaceStatusOption.hasVariableResolution
+			);
 			var textRenderer = textSurface.renderer();
 
 			textRenderer.begin();
@@ -237,6 +241,10 @@ namespace g {
 		 */
 		destroy(): void {
 			super.destroy();
+		}
+
+		_createCache(width: number, height: number, isResizable: boolean = false): Surface {
+			return super._createCache(width, height, true);
 		}
 
 		private _invalidateSelf(): void {

--- a/src/Pane.ts
+++ b/src/Pane.ts
@@ -33,6 +33,13 @@ namespace g {
 		 * @default undefined
 		 */
 		backgroundEffector?: SurfaceEffector;
+
+		/**
+		 * この`Pane`をスケール変更に対応させるか指定する
+		 * falseもしくはundefinedの場合、スケール変更に対応させない
+		 * @default undefined
+		 */
+		hasVariableResolution?: boolean;
 	}
 	/**
 	 * 枠を表すエンティティ。
@@ -107,6 +114,11 @@ namespace g {
 		_childrenRenderer: Renderer;
 
 		/**
+		 * @private
+		 */
+		_hasVariableResolution: boolean;
+
+		/**
 		 * 各種パラメータを指定して `Pane` のインスタンスを生成する。
 		 * @param param このエンティティに指定するパラメータ
 		 */
@@ -118,6 +130,7 @@ namespace g {
 			this.backgroundEffector = param.backgroundEffector;
 			this._shouldRenderChildren = false;
 			this._padding = param.padding;
+			this._hasVariableResolution = param.hasVariableResolution !== undefined ? param.hasVariableResolution : false;
 			this._initialize();
 			this._paddingChanged = false;
 			this._bgSurface = undefined;
@@ -263,10 +276,11 @@ namespace g {
 			if (this._childrenSurface && !this._childrenSurface.destroyed()) {
 				this._childrenSurface.destroy();
 			}
+			const surfaceStateFlag = this._hasVariableResolution ? g.SurfaceStateFlags.hasVariableResolution : g.SurfaceStateFlags.None;
 			this._childrenSurface = resourceFactory.createSurface(
 				Math.ceil(this._childrenArea.width),
 				Math.ceil(this._childrenArea.height),
-				g.SurfaceStatusOption.hasVariableResolution
+				surfaceStateFlag
 			);
 			this._childrenRenderer = this._childrenSurface.renderer();
 			this._normalizedPadding = r;
@@ -312,8 +326,8 @@ namespace g {
 			return result;
 		}
 
-		_createCache(width: number, height: number, isResizable: boolean = false): Surface {
-			return super._createCache(width, height, true);
+		_createCache(width: number, height: number): Surface {
+			return this._createSurface(width, height, this._hasVariableResolution);
 		}
 	}
 }

--- a/src/Pane.ts
+++ b/src/Pane.ts
@@ -263,7 +263,11 @@ namespace g {
 			if (this._childrenSurface && !this._childrenSurface.destroyed()) {
 				this._childrenSurface.destroy();
 			}
-			this._childrenSurface = resourceFactory.createSurface(Math.ceil(this._childrenArea.width), Math.ceil(this._childrenArea.height));
+			this._childrenSurface = resourceFactory.createSurface(
+				Math.ceil(this._childrenArea.width),
+				Math.ceil(this._childrenArea.height),
+				g.SurfaceStatusOption.hasVariableResolution
+			);
 			this._childrenRenderer = this._childrenSurface.renderer();
 			this._normalizedPadding = r;
 		}
@@ -306,6 +310,10 @@ namespace g {
 					result.bottom = convertedPoint.y;
 			}
 			return result;
+		}
+
+		_createCache(width: number, height: number, isResizable: boolean = false): Surface {
+			return super._createCache(width, height, true);
 		}
 	}
 }

--- a/src/ResourceFactory.ts
+++ b/src/ResourceFactory.ts
@@ -43,14 +43,13 @@ namespace g {
 		 * @param strokeColor ストロークの色。省略された場合、 `"black"` として扱われる
 		 * @param strokeOnly ストロークのみを描画するか否か。省略された場合、偽として扱われる
 		 * @param fontWeight フォントウェイト。省略された場合、 `FontWeight.Normal` として扱われる
-		 * @param hasVariableResolution surfaceのscaleが変更可能か否か。省略された場合、偽として扱われる
 		 */
 		abstract createGlyphFactory(fontFamily: FontFamily|string|(g.FontFamily|string)[], fontSize: number, baselineHeight?: number,
 		                            fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean,
-		                            fontWeight?: FontWeight, hasVariableResolution?: boolean): GlyphFactory;
+		                            fontWeight?: FontWeight): GlyphFactory;
 
 		createSurfaceAtlas(width: number, height: number): SurfaceAtlas {
-			return new SurfaceAtlas(this.createSurface(width, height, g.SurfaceStatusOption.hasVariableResolution));
+			return new SurfaceAtlas(this.createSurface(width, height, SurfaceStateFlags.hasVariableResolution));
 		}
 	}
 }

--- a/src/ResourceFactory.ts
+++ b/src/ResourceFactory.ts
@@ -43,13 +43,14 @@ namespace g {
 		 * @param strokeColor ストロークの色。省略された場合、 `"black"` として扱われる
 		 * @param strokeOnly ストロークのみを描画するか否か。省略された場合、偽として扱われる
 		 * @param fontWeight フォントウェイト。省略された場合、 `FontWeight.Normal` として扱われる
+		 * @param hasVariableResolution surfaceのscaleが変更可能か否か。省略された場合、偽として扱われる
 		 */
 		abstract createGlyphFactory(fontFamily: FontFamily|string|(g.FontFamily|string)[], fontSize: number, baselineHeight?: number,
 		                            fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean,
-		                            fontWeight?: FontWeight): GlyphFactory;
+		                            fontWeight?: FontWeight, hasVariableResolution?: boolean): GlyphFactory;
 
 		createSurfaceAtlas(width: number, height: number): SurfaceAtlas {
-			return new SurfaceAtlas(this.createSurface(width, height));
+			return new SurfaceAtlas(this.createSurface(width, height, g.SurfaceStatusOption.hasVariableResolution));
 		}
 	}
 }


### PR DESCRIPTION
## このpull requestが解決する内容
* surfaceの解像度を動的に変更できるようになる
  * 解像度をいくらに変更するかの通知対応は https://github.com/akashic-games/akashic-engine/pull/57 で行っている
## 破壊的な変更を含んでいるか?
* なし

## やったこと
* `g.Pane`, `g.Label`, `g.DynamicFont`の内部surfaceをscale変更可能にした
* スケール変更時に対象のentityのwidth, heightも変更させる対応

## 見ていただきたいところ
* スケール変更時に、`g.Label`等の対象のentityのwidthとheightも変更させる必要があると思うが、こちらどうするべきか？(今の実装だとその変更ができていない)
* 他に不足している対応はないか？

## WIPを外す条件
* akashic-sandoboxで正常に動作することが確認できてから
* `g.Pane`に関しては、リサイズ可能にするかどうかユーザー側で設定できるようにする

