### PR TITLE
Add g.Game#_destroy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog
 
+## 1.12.9
+ * `g.Game#_destroy()` を追加
+
+### エンジン開発者への影響
+
+ * `g.Game#_destroy()` を追加
+    * エンジン開発者はこのメソッドを呼び出すことで、ゲームを破棄することができます。
+
 ## 1.12.8
 不具合修正
  * `moduleMainScripts` のファイルパスを `AssetManager#_liveAssetVirtualPathTable` から参照するように修正

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "1.12.8",
+  "version": "1.12.9",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "devDependencies": {

--- a/spec/GameSpec.js
+++ b/spec/GameSpec.js
@@ -29,6 +29,20 @@ describe("test Game", function() {
 		expect(game).toHaveProperty("_initialScene");
 	});
 
+	it("_destroy()", function() {
+		var game = new mock.Game({ width: 320, height: 270 }, undefined, "foo");
+		game._destroy();
+		expect(game.db).toBe(undefined);
+		expect(game.renderers).toBe(undefined);
+		expect(game.scenes).toBe(undefined);
+		expect(game.random).toBe(undefined);
+		expect(game.events).toBe(undefined);
+		expect(game.modified).toBe(false);
+		expect(game.external).toEqual({});  // external は触らない
+		expect(game.vars).toEqual({});  // vars も触らない
+		expect(game.playId).toBe(undefined);
+	});
+
 	it("global assets", function (done) {
 		var game = new mock.Game({
 			width: 320,

--- a/spec/LoggerSpec.js
+++ b/spec/LoggerSpec.js
@@ -55,4 +55,13 @@ describe("Logger", function() {
 		runtime.game.logger.debug("debug-no-cause");
 		expect(loggedCount).toBe(8);
 	});
+
+	it("destroy()", function() {
+		var runtime = skeletonRuntime({ width: 320, height: 320 });
+		var self = runtime.game.logger;
+		expect(self.destroyed()).toBe(false);
+		runtime.game.logger.destroy();
+		expect(self.destroyed()).toBe(true);
+		expect(self.logging).toBe(undefined);
+	});
 });

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -39,7 +39,7 @@ namespace g {
 	/**
 	 * デバッグ/エラー用のログ出力機構。
 	 */
-	export class Logger {
+	export class Logger implements Destroyable {
 		/**
 		 * この `Logger` に紐づく `Game` 。
 		 */
@@ -57,6 +57,16 @@ namespace g {
 		constructor(game: Game) {
 			this.game = game;
 			this.logging = new Trigger<Log>();
+		}
+
+		destroy(): void {
+			this.game = undefined;
+			this.logging.destroy();
+			this.logging = undefined;
+		}
+
+		destroyed(): boolean {
+			return !this.game;
 		}
 
 		/**


### PR DESCRIPTION
## このpull requestが解決する内容

掲題どおり。

現実装には再起動用の `_reset()` がありますが、これはあくまでも再起動用で、グローバルアセットの読み込み状況などは保持したままでした。リークを防ぐため、宣言しているプロパティを明示的に破棄・クリアするメソッドを加えます。

残しているのは vars, external (エンジン外に開放されている) と、無害な一部プロパティ (fps, width, height) のみです。(特に fps はゼロにするとゼロ除算の地雷を踏みそうなので念のため残しておきます)。

内部メソッドの追加であり、ゲーム開発者には影響しません。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

