### PR TITLE
add flexible cachableE cache size interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # ChangeLog
 
+## 2.1.2
+
+機能追加
+* `g.CacheableE#calculateCacheSize()` を追加
+
 ## 2.1.1
+
 不具合修正
  * `moduleMainScripts` のファイルパスを `AssetManager#_liveAssetVirtualPathTable` から参照するように修正
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "devDependencies": {

--- a/spec/helpers/mock.ts
+++ b/spec/helpers/mock.ts
@@ -154,11 +154,11 @@ export class Renderer extends g.Renderer {
 	}
 	setTransform(matrix: number[]): void {
 		throw new Error("not implemented");
-	};
+	}
 
 	setOpacity(opacity: number): void {
 		throw new Error("not implemented");
-	};
+	}
 
 	_getImageData(): ImageData {
 		return null;
@@ -402,7 +402,7 @@ export class GlyphFactory extends g.GlyphFactory {
 	            fontColor?: string, strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean, fontWeight?: g.FontWeight) {
 		super(fontFamily, fontSize, baselineHeight, fontColor, strokeWidth, strokeColor, strokeOnly, fontWeight);
 	}
-	create(code: number): g.Glyph { return <g.Glyph>undefined; };
+	create(code: number): g.Glyph { return <g.Glyph>undefined; }
 }
 
 export class ResourceFactory extends g.ResourceFactory {

--- a/src/CacheableE.ts
+++ b/src/CacheableE.ts
@@ -61,12 +61,12 @@ namespace g {
 		 * このメソッドはエンジンから暗黙に呼び出され、ゲーム開発者が呼び出す必要はない。
 		 */
 		renderSelf(renderer: Renderer, camera?: Camera): boolean {
-			const cacheSize = this.calcCacheSize();
 			if (this._renderedCamera !== camera) {
 				this.state &= ~EntityStateFlags.Cached;
 				this._renderedCamera = camera;
 			}
 			if (!(this.state & EntityStateFlags.Cached)) {
+				const cacheSize = this.calculateCacheSize();
 				var isNew = !this._cache || this._cache.width < Math.ceil(cacheSize.width) || this._cache.height < Math.ceil(cacheSize.height);
 				if (isNew) {
 					if (this._cache && !this._cache.destroyed()) {
@@ -85,8 +85,8 @@ namespace g {
 				this.state |= EntityStateFlags.Cached;
 				this._renderer.end();
 			}
-			if (this._cache && cacheSize.width > 0 && this.height > 0) {
-				renderer.drawImage(this._cache, 0, 0, cacheSize.width, this.height, 0, 0);
+			if (this._cache && this.width > 0 && this.height > 0) {
+				renderer.drawImage(this._cache, 0, 0, this._cache.width, this._cache.height, 0, 0);
 			}
 			return this._shouldRenderChildren;
 		}
@@ -113,8 +113,10 @@ namespace g {
 		/**
 		 * キャッシュのサイズを取得する。
 		 * 本クラスを継承したクラスでエンティティのサイズと異なるサイズを利用する場合、このメソッドをオーバーライドする。
+		 * このメソッドはエンジンから暗黙に呼び出され、ゲーム開発者が呼び出す必要はない。
+		 * このメソッドから得られる値を変更した場合、 `this.invalidate()` を呼び出す必要がある。
 		 */
-		calcCacheSize(): CommonSize {
+		calculateCacheSize(): CommonSize {
 			return {
 				width: this.width,
 				height: this.height

--- a/src/CacheableE.ts
+++ b/src/CacheableE.ts
@@ -36,6 +36,14 @@ namespace g {
 		_renderedCamera: Camera;
 
 		/**
+		 * 描画されるキャッシュサイズ。
+		 * このサイズは _cache のサイズよりも小さくなる場合がある。
+		 *
+		 * @private
+		 */
+		_cacheSize: CommonSize;
+
+		/**
 		 * 各種パラメータを指定して `CacheableE` のインスタンスを生成する。
 		 * @param param このエンティティに対するパラメータ
 		 */
@@ -67,6 +75,7 @@ namespace g {
 			}
 			if (!(this.state & EntityStateFlags.Cached)) {
 				const cacheSize = this.calculateCacheSize();
+				this._cacheSize = cacheSize;
 				var isNew = !this._cache || this._cache.width < Math.ceil(cacheSize.width) || this._cache.height < Math.ceil(cacheSize.height);
 				if (isNew) {
 					if (this._cache && !this._cache.destroyed()) {
@@ -85,8 +94,8 @@ namespace g {
 				this.state |= EntityStateFlags.Cached;
 				this._renderer.end();
 			}
-			if (this._cache && this.width > 0 && this.height > 0) {
-				renderer.drawImage(this._cache, 0, 0, this._cache.width, this._cache.height, 0, 0);
+			if (this._cache && this._cacheSize.width > 0 && this._cacheSize.height > 0) {
+				renderer.drawImage(this._cache, 0, 0, this._cacheSize.width, this._cacheSize.height, 0, 0);
 			}
 			return this._shouldRenderChildren;
 		}

--- a/src/CacheableE.ts
+++ b/src/CacheableE.ts
@@ -61,17 +61,18 @@ namespace g {
 		 * このメソッドはエンジンから暗黙に呼び出され、ゲーム開発者が呼び出す必要はない。
 		 */
 		renderSelf(renderer: Renderer, camera?: Camera): boolean {
+			const cacheSize = this.calcCacheSize();
 			if (this._renderedCamera !== camera) {
 				this.state &= ~EntityStateFlags.Cached;
 				this._renderedCamera = camera;
 			}
 			if (!(this.state & EntityStateFlags.Cached)) {
-				var isNew = !this._cache || this._cache.width < Math.ceil(this.width) || this._cache.height < Math.ceil(this.height);
+				var isNew = !this._cache || this._cache.width < Math.ceil(cacheSize.width) || this._cache.height < Math.ceil(cacheSize.height);
 				if (isNew) {
 					if (this._cache && !this._cache.destroyed()) {
 						this._cache.destroy();
 					}
-					this._cache = this.scene.game.resourceFactory.createSurface(Math.ceil(this.width), Math.ceil(this.height));
+					this._cache = this.scene.game.resourceFactory.createSurface(Math.ceil(cacheSize.width), Math.ceil(cacheSize.height));
 					this._renderer = this._cache.renderer();
 				}
 				this._renderer.begin();
@@ -84,8 +85,8 @@ namespace g {
 				this.state |= EntityStateFlags.Cached;
 				this._renderer.end();
 			}
-			if (this._cache && this.width > 0 && this.height > 0) {
-				renderer.drawImage(this._cache, 0, 0, this.width, this.height, 0, 0);
+			if (this._cache && cacheSize.width > 0 && this.height > 0) {
+				renderer.drawImage(this._cache, 0, 0, cacheSize.width, this.height, 0, 0);
 			}
 			return this._shouldRenderChildren;
 		}
@@ -107,6 +108,17 @@ namespace g {
 			this._cache = undefined;
 
 			super.destroy();
+		}
+
+		/**
+		 * キャッシュのサイズを取得する。
+		 * 本クラスを継承したクラスでエンティティのサイズと異なるサイズを利用する場合、このメソッドをオーバーライドする。
+		 */
+		calcCacheSize(): CommonSize {
+			return {
+				width: this.width,
+				height: this.height
+			};
 		}
 	}
 }

--- a/src/CacheableE.ts
+++ b/src/CacheableE.ts
@@ -74,14 +74,13 @@ namespace g {
 				this._renderedCamera = camera;
 			}
 			if (!(this.state & EntityStateFlags.Cached)) {
-				const cacheSize = this.calculateCacheSize();
-				this._cacheSize = cacheSize;
-				var isNew = !this._cache || this._cache.width < Math.ceil(cacheSize.width) || this._cache.height < Math.ceil(cacheSize.height);
+				this._cacheSize = this.calculateCacheSize();
+				var isNew = !this._cache || this._cache.width < Math.ceil(this._cacheSize.width) || this._cache.height < Math.ceil(this._cacheSize.height);
 				if (isNew) {
 					if (this._cache && !this._cache.destroyed()) {
 						this._cache.destroy();
 					}
-					this._cache = this.scene.game.resourceFactory.createSurface(Math.ceil(cacheSize.width), Math.ceil(cacheSize.height));
+					this._cache = this.scene.game.resourceFactory.createSurface(Math.ceil(this._cacheSize.width), Math.ceil(this._cacheSize.height));
 					this._renderer = this._cache.renderer();
 				}
 				this._renderer.begin();

--- a/src/ResourceFactory.ts
+++ b/src/ResourceFactory.ts
@@ -17,7 +17,7 @@ namespace g {
 
 		abstract createTextAsset(id: string, assetPath: string): TextAsset;
 
-		abstract createAudioPlayer(system: AudioSystem): AudioPlayer
+		abstract createAudioPlayer(system: AudioSystem): AudioPlayer;
 
 		abstract createScriptAsset(id: string, assetPath: string): ScriptAsset;
 


### PR DESCRIPTION
## このpull requestが解決する内容

現状の g.CacheableE が生成するキャッシュのサイズは `this.width, this.height` を固定値として利用しており、任意のサイズで生成することができません。
これまでこの方法で不便はありませんでしたが、 akashic-label で `this.width, this.height` と必ずしも一致しないキャッシュサイズを生成する必要のあるケースが起こるようになりました。 https://github.com/akashic-games/akashic-label/pull/20
このため、通常は `this.width, this.height` を利用し、必要に応じてキャッシュサイズを指定できる I/F を追加します。

<!-- Pull Requestの変更内容の概要を書いてください -->

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

