### PR TITLE
g.FrameSpriteにアニメーションをループ再生するかどうか指定するパラメーターの追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased changes
+
+機能追加
+* g.FrameSpriteにアニメーションをループ再生するかどうか指定するパラメーターの追加
+
 ## 2.2.0
 
 機能追加

--- a/spec/FrameSpriteSpec.js
+++ b/spec/FrameSpriteSpec.js
@@ -1,6 +1,7 @@
 describe("test FrameSprite", function() {
 	var g = require('../lib/main.node.js');
 	var skeletonRuntime = require("./helpers/skeleton");
+	var mock = require("./helpers/mock");
 
 	beforeEach(function() {
 	});
@@ -9,7 +10,7 @@ describe("test FrameSprite", function() {
 	});
 	it("初期化", function() {
 		var runtime = skeletonRuntime();
-		var surface = new g.Surface(480, 480);
+		var surface = new mock.Surface(480, 480);
 		var frameSprite = new g.FrameSprite({
 			scene: runtime.scene,
 			src: surface,
@@ -30,7 +31,7 @@ describe("test FrameSprite", function() {
 
 	it("start", function() {
 		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 30 });
-		var surface = new g.Surface(480, 480);
+		var surface = new mock.Surface(480, 480);
 		var sp = new g.FrameSprite({
 			scene: runtime.scene,
 			src: surface,
@@ -57,7 +58,7 @@ describe("test FrameSprite", function() {
 
 	it("stop", function() {
 		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 30 });
-		var surface = new g.Surface(480, 480);
+		var surface = new mock.Surface(480, 480);
 		var sp = new g.FrameSprite({
 			scene: runtime.scene,
 			src: surface,
@@ -75,7 +76,7 @@ describe("test FrameSprite", function() {
 
 	it("destroy", function() {
 		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 30 });
-		var surface = new g.Surface(480, 480);
+		var surface = new mock.Surface(480, 480);
 		var sp = new g.FrameSprite({
 			scene: runtime.scene,
 			src: surface,
@@ -93,7 +94,7 @@ describe("test FrameSprite", function() {
 
 	it("frame/frameNumber", function() {
 		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 30 });
-		var surface = new g.Surface(480, 480);
+		var surface = new mock.Surface(480, 480);
 		var sp = new g.FrameSprite({
 			scene: runtime.scene,
 			src: surface,
@@ -159,7 +160,7 @@ describe("test FrameSprite", function() {
 
 	it("_free", function() {
 		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 30 });
-		var surface = new g.Surface(480, 480);
+		var surface = new mock.Surface(480, 480);
 		var sp = new g.FrameSprite({
 			scene: runtime.scene,
 			src: surface,
@@ -176,7 +177,7 @@ describe("test FrameSprite", function() {
 
 	it("createBySprite", function() {
 		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 30 });
-		var surface = new g.Surface(480, 480);
+		var surface = new mock.Surface(480, 480);
 		var sprite = new g.Sprite({
 			scene: runtime.scene,
 			src: surface,
@@ -191,7 +192,7 @@ describe("test FrameSprite", function() {
 
 	it("loop", function() {
 		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 30 });
-		var surface = new g.Surface(480, 480);
+		var surface = new mock.Surface(480, 480);
 		var sprite = new g.FrameSprite({
 			scene: runtime.scene,
 			src: surface,
@@ -227,7 +228,7 @@ describe("test FrameSprite", function() {
 
 	it("not loop", function() {
 		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 30 });
-		var surface = new g.Surface(480, 480);
+		var surface = new mock.Surface(480, 480);
 		var sprite = new g.FrameSprite({
 			scene: runtime.scene,
 			src: surface,
@@ -261,4 +262,3 @@ describe("test FrameSprite", function() {
 		expect(isFired).toBe(true);
 	});
 });
-

--- a/spec/FrameSpriteSpec.js
+++ b/spec/FrameSpriteSpec.js
@@ -188,5 +188,77 @@ describe("test FrameSprite", function() {
 		expect(frame.srcWidth).toBe(32);
 		expect(frame.srcHeight).toBe(48);
 	});
+
+	it("loop", function() {
+		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 30 });
+		var surface = new g.Surface(480, 480);
+		var sprite = new g.FrameSprite({
+			scene: runtime.scene,
+			src: surface,
+			width: 32,
+			height: 48,
+			frames: [10, 11, 12],
+			loop: true
+		});
+		var isFired = false;
+		sprite.finished.add(function() {
+			isFired = true;
+		});
+		sprite.start();
+		expect(sprite.frameNumber).toBe(0);
+		expect(sprite._lastUsedIndex).toBe(10);
+		expect(isFired).toBe(false);
+
+		runtime.game.tick();
+		expect(sprite.frameNumber).toBe(1);
+		expect(sprite._lastUsedIndex).toBe(11);
+		expect(isFired).toBe(false);
+
+		runtime.game.tick();
+		expect(sprite.frameNumber).toBe(2);
+		expect(sprite._lastUsedIndex).toBe(12);
+		expect(isFired).toBe(false);
+
+		runtime.game.tick();
+		expect(sprite.frameNumber).toBe(0);
+		expect(sprite._lastUsedIndex).toBe(10);
+		expect(isFired).toBe(false);
+	});
+
+	it("not loop", function() {
+		var runtime = skeletonRuntime({ width: 320, height: 320, fps: 30 });
+		var surface = new g.Surface(480, 480);
+		var sprite = new g.FrameSprite({
+			scene: runtime.scene,
+			src: surface,
+			width: 32,
+			height: 48,
+			frames: [10, 11, 12],
+			loop: false
+		});
+		var isFired = false;
+		sprite.finished.add(function() {
+			isFired = true;
+		});
+		sprite.start();
+		expect(sprite.frameNumber).toBe(0);
+		expect(sprite._lastUsedIndex).toBe(10);
+		expect(isFired).toBe(false);
+
+		runtime.game.tick();
+		expect(sprite.frameNumber).toBe(1);
+		expect(sprite._lastUsedIndex).toBe(11);
+		expect(isFired).toBe(false);
+
+		runtime.game.tick();
+		expect(sprite.frameNumber).toBe(2);
+		expect(sprite._lastUsedIndex).toBe(12);
+		expect(isFired).toBe(false);
+
+		runtime.game.tick();
+		expect(sprite.frameNumber).toBe(2);
+		expect(sprite._lastUsedIndex).toBe(12);
+		expect(isFired).toBe(true);
+	});
 });
 

--- a/src/CacheableE.ts
+++ b/src/CacheableE.ts
@@ -75,7 +75,9 @@ namespace g {
 			}
 			if (!(this.state & EntityStateFlags.Cached)) {
 				this._cacheSize = this.calculateCacheSize();
-				var isNew = !this._cache || this._cache.width < Math.ceil(this._cacheSize.width) || this._cache.height < Math.ceil(this._cacheSize.height);
+				var isNew = !this._cache
+					|| this._cache.width < Math.ceil(this._cacheSize.width)
+					|| this._cache.height < Math.ceil(this._cacheSize.height);
 				if (isNew) {
 					if (this._cache && !this._cache.destroyed()) {
 						this._cache.destroy();

--- a/src/FrameSprite.ts
+++ b/src/FrameSprite.ts
@@ -44,7 +44,7 @@ namespace g {
 		interval?: number;
 
 		/**
-		 * アニメーションをループ再生させるかどうか
+		 * アニメーションをループ再生させるか否か。
 		 * @default true
 		 */
 		loop?: boolean;
@@ -92,8 +92,8 @@ namespace g {
 		interval: number;
 
 		/**
-		 * アニメーションをループ再生させるかどうか
-		 * 初期値は true となっている
+		 * アニメーションをループ再生させるか否か。
+		 * 初期値は `true` である。
 		 */
 		loop: boolean;
 

--- a/src/FrameSprite.ts
+++ b/src/FrameSprite.ts
@@ -98,7 +98,8 @@ namespace g {
 		loop: boolean;
 
 		/**
-		 * アニメーション終了時にfireされる (ループ再生をOFFにしている時のみ)
+		 * アニメーション終了時にfireされるTrigger。
+		 * 本Triggerは loop: true の場合にのみfireされる。
 		 */
 		finished: Trigger<void>;
 

--- a/src/FrameSprite.ts
+++ b/src/FrameSprite.ts
@@ -42,6 +42,12 @@ namespace g {
 		 * @default (1000 / game.fps)
 		 */
 		interval?: number;
+
+		/**
+		 * アニメーションをループ再生させるかどうか
+		 * @default true
+		 */
+		loop?: boolean;
 	}
 
 	/**
@@ -86,6 +92,17 @@ namespace g {
 		interval: number;
 
 		/**
+		 * アニメーションをループ再生させるかどうか
+		 * 初期値は true となっている
+		 */
+		loop: boolean;
+
+		/**
+		 * アニメーション終了時にfireされる (ループ再生をOFFにしている時のみ)
+		 */
+		finished: Trigger<void>;
+
+		/**
 		 * @private
 		 */
 		_timer: Timer;
@@ -124,6 +141,8 @@ namespace g {
 			this.frames = "frames" in param ? param.frames : [0];
 			this.interval = param.interval;
 			this._timer = undefined;
+			this.loop = param.loop != null ? param.loop : true;
+			this.finished = new Trigger<void>();
 			this._modifiedSelf();
 		}
 
@@ -171,8 +190,16 @@ namespace g {
 		 * @private
 		 */
 		_onElapsed(): void {
-			if (++this.frameNumber >= this.frames.length)
-				this.frameNumber = 0;
+			if (this.frameNumber === this.frames.length - 1) {
+				if (this.loop) {
+					this.frameNumber = 0;
+				} else {
+					this.stop();
+					this.finished.fire();
+				}
+			} else {
+				this.frameNumber++;
+			}
 
 			this.modified();
 		}


### PR DESCRIPTION
## このpull requestが解決する内容
* g.FrameSpriteでアニメーションをループ再生させるかどうか選択できるようになる

## 破壊的な変更を含んでいるか?
* なし

## 見ていただきたいところ
* 上記の目的を達成するために、不足している部分はないか？
* 本修正によって懸念されるデグレや破壊的変更はないか？

