### PR TITLE
BGMやSEをミュート状態にできるようにした

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## Unreleased changes
+
+不具合修正
+ * `AudioPlayer#_changeMuted()` で、BGM・SEをミュート状態にできるように修正
+
 ## 2.3.0
 
 機能追加

--- a/spec/AudioPlayerSpec.js
+++ b/spec/AudioPlayerSpec.js
@@ -29,4 +29,43 @@ describe("test AudioPlayer", function() {
 		expect(player.stopped.constructor).toBe(g.Trigger);
 		expect(player).toHaveUndefinedValue("currentAudio");
 	});
+
+	it("can chnage volume", function() {
+		var game = new mock.Game({ width: 320, height: 320 });
+		var system = new g.MusicAudioSystem("music", game);
+		var player = new mock.AudioPlayer(system);
+		var volumeAfterChanged = 0.3;
+		player.changeVolume(volumeAfterChanged);
+		expect(player.volume).toBe(volumeAfterChanged);
+		expect(player._volumeBeforeMuted).toBe(volumeAfterChanged);
+	});
+
+	it("can become mute mode and cancel mute mode", function() {
+		var game = new mock.Game({ width: 320, height: 320 });
+		var system = new g.MusicAudioSystem("music", game);
+		var player = new mock.AudioPlayer(system);
+		var volumeAfterChanged = 0.3;
+		player.changeVolume(volumeAfterChanged);
+		player._changeMuted(true);
+		expect(player.volume).toBe(0);
+		expect(player._volumeBeforeMuted).toBe(volumeAfterChanged);
+		player._changeMuted(false);
+		expect(player.volume).toBe(volumeAfterChanged);
+		expect(player._volumeBeforeMuted).toBe(volumeAfterChanged);
+	});
+
+	it("can change volume-before-muted in mute mode", function() {
+		var game = new mock.Game({ width: 320, height: 320 });
+		var system = new g.MusicAudioSystem("music", game);
+		var player = new mock.AudioPlayer(system);
+		var volumeAfterChanged = 0.3;
+		player.changeVolume(1);
+		player._changeMuted(true);
+		expect(player.volume).toBe(0);
+		expect(player._volumeBeforeMuted).toBe(1);
+		player.changeVolume(volumeAfterChanged);
+		player._changeMuted(false);
+		expect(player.volume).toBe(volumeAfterChanged);
+		expect(player._volumeBeforeMuted).toBe(volumeAfterChanged);
+	});
 });

--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -38,6 +38,13 @@ namespace g {
 		volume: number;
 
 		/**
+		 * mute直前のvolmeの値を保存する。
+		 *
+		 * この値は `_ changeMuted()` でのみ私用することを想定している。ゲーム開発者はこの値を変更してはならない。
+		 */
+		_volumeBeforeMuted: number;
+
+		/**
 		 * ミュート中か否か。
 		 * @private
 		 */
@@ -62,6 +69,7 @@ namespace g {
 			this.stopped = new Trigger<AudioPlayerEvent>();
 			this.currentAudio = undefined;
 			this.volume = system.volume;
+			this._volumeBeforeMuted = system.volume;
 			this._muted = system._muted;
 			this._playbackRate = system._playbackRate;
 			this._system = system;
@@ -114,6 +122,7 @@ namespace g {
 		// オーバーライド先のメソッドはこのメソッドを呼びださなければならない。
 		changeVolume(volume: number): void {
 			this.volume = volume;
+			this._volumeBeforeMuted = volume;
 		}
 
 		/**
@@ -128,6 +137,12 @@ namespace g {
 		 */
 		_changeMuted(muted: boolean): void {
 			this._muted = muted;
+			if (muted) {
+				this._volumeBeforeMuted = this.volume;
+				this.volume = 0;
+			} else {
+				this.volume = this._volumeBeforeMuted;
+			}
 		}
 
 		/**


### PR DESCRIPTION
## このpull requestが解決する内容
`AudioPlayer#_changeMuted()`で、実際にミュートするように動作していなかったので、ミュートするように修正した。

## 破壊的な変更を含んでいるか?
* なし

## やったこと
* `AudioPlayer#_changeMuted()`でミュートが行えるようにした
  * ミュート時は音量を0にして解除時にミュート前の音量に変更することで、ミュートを実現
    * また、ミュート時に音量が変更された場合、解除時にその変更後の音量になるようにした
* テストが落ちていたので通るように修正

