### PR TITLE
ドキュメント生成スクリプトの修正(v1用)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## Unreleased changes
+
+* ドキュメント生成方法の変更
+
 ## 1.12.10
 
 機能追加

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,8 +7,6 @@ var del = require("del");
 var tslint = require("gulp-tslint");
 var pkg = require("./package.json");
 var rename = require("gulp-rename");
-var fs = require('fs');
-var execSync = require('child_process').execSync;
 
 
 // test packages
@@ -99,31 +97,6 @@ gulp.task("test", ["testCompile"], function(cb) {
 				.pipe(istanbul.writeReports({ reporters: ["text", "cobertura", "lcov"] }))
 				.on("end", cb);
 		});
-});
-
-gulp.task("typedoc", function() {
-	fs.rename("node_modules/@types", "node_modules/@types.bak", function (err) {
-		if (err && err.code !== "ENOENT") {
-			throw err;
-		}
-
-		var command = "typedoc --excludePrivate --out ../doc/html/ --includeDeclarations ../lib/main.d.ts ../typings/console.d.ts ../typings/lib.core.d.ts";
-		var commandException;
-		try {
-			execSync(command, {cwd: "lib/"});
-		} catch (e) {
-			commandException = e;
-		}
-
-		fs.rename("node_modules/@types.bak", "node_modules/@types", function (err) {
-			if (commandException) {
-				throw commandException;
-			}
-			if (err && err.code !== "ENOENT") {
-				throw err;
-			}
-		});
-	});
 });
 
 gulp.task("default", ["compileAll"]);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "textlint-rule-no-mix-dearu-desumasu": "^1.4.0",
     "textlint-rule-prh": "^2.4.0",
     "tslint": "~3.7.4",
-    "typedoc": "^0.8.0",
+    "typedoc": "^0.11.1",
     "typescript": "~2.1.6"
   },
   "scripts": {
@@ -30,7 +30,7 @@
     "build": "gulp",
     "test": "gulp test && gulp lint && npm run textlint",
     "textlint": "textlint -f pretty-error doc/ && textlint -f pretty-error unreleased-changes/",
-    "doc": "npm run build && gulp typedoc",
+    "doc": "npm run build && typedoc --excludeExternals --externalPattern \"**/node_modules/**\" --excludePrivate --out doc/html/ --includeDeclarations lib/main.d.ts typings/console.d.ts typings/lib.core.d.ts",
     "jasmine": "jasmine"
   },
   "files": [


### PR DESCRIPTION
## このpull requestが解決する内容
* ドキュメント生成時にtypedocコマンドのオプションでドキュメント生成対象外のディレクトリを指定するように修正したので、`node_modules/@types`をリネームする必要がなくなりました
  * typedocのバージョンを上げないと対象外のディレクトリを指定する機能は使えなかったのでバージョンも上げました

## 破壊的な変更を含んでいるか?
* なし

## 見ていただきたいところ
* ドキュメント生成スクリプトのコマンド
  * gulpを利用しないようにしたが問題ないか？
    * akashicライブラリがgulpから脱却しているので合わせた+gulp内でコマンドを書き直すのが手間だったので