### PR TITLE
fix require() for virtual paths altering their locations

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -36,9 +36,9 @@ namespace g {
 			// 2. If X begins with './' or '/' or '../'
 
 			if (currentModule) {
-				if (!currentModule._dirname)
+				if (!currentModule._virtualDirname)
 					throw ExceptionFactory.createAssertionError("g._require: require from DynamicAsset is not supported");
-				resolvedPath = PathUtil.resolvePath(currentModule._dirname, path);
+				resolvedPath = PathUtil.resolvePath(currentModule._virtualDirname, path);
 			} else {
 				if (!(/^\.\//.test(path)))
 					throw ExceptionFactory.createAssertionError("g._require: entry point path must start with './'");
@@ -160,12 +160,18 @@ namespace g {
 		/**
 		 * @private
 		 */
+		_virtualDirname: string;
+
+		/**
+		 * @private
+		 */
 		_g: ScriptAssetExecuteEnvironment;
 
 		constructor(game: Game, id: string, path: string) {
-			// `DynamicAsset` の場合は `virtualPath` がない(require()させない)
+			var dirname = PathUtil.resolveDirname(path);
+			// `virtualPath` と `virtualDirname` は　`DynamicAsset` の場合は `undefined` になる。
 			var virtualPath = game._assetManager._liveAbsolutePathTable[path];
-			var dirname = virtualPath ? PathUtil.resolveDirname(virtualPath) : undefined;
+			var virtualDirname = virtualPath ? PathUtil.resolveDirname(virtualPath) : undefined;
 
 			var _g: ScriptAssetExecuteEnvironment = Object.create(g, {
 				game: {
@@ -194,8 +200,9 @@ namespace g {
 			this.parent = null; // Node.js と互換
 			this.loaded = false;
 			this.children = [];
-			this.paths = dirname ? PathUtil.makeNodeModulePaths(dirname) : [];
+			this.paths = virtualDirname ? PathUtil.makeNodeModulePaths(virtualDirname) : [];
 			this._dirname = dirname;
+			this._virtualDirname = virtualDirname;
 			this._g = _g;
 
 			// メソッドとしてではなく単体で呼ばれるのでメソッドにせずここで実体を代入する


### PR DESCRIPTION
## このpull requestが解決する内容

`g.Module#require()` で扱いが混乱している `virtualPath` の扱いを改めます。

#### 実パスと仮想パス
歴史的経緯から、 game.json のアセット定義には `"path"` (実パス) とは別に「仮想パス」 `"virtualPath"` を宣言することができます。

仮想パスは、 `require()` の解決時に使われるパスです。たとえば script/foo.js をスクリプトアセットとして使う時、 path は `"script/foo.js"` になりますが、これに仮想パスとして `"script/bar.js"` を与えておくことができます。すると Akashic Engine においては、そのファイルは script/ ディレクトリ直下からは `require("./bar")` でアクセスできます (`"./foo"` ではなく)。

#### 現状

この機能のため、 `g._require()` は virtualPath を扱う必要がありますが、現実装では path と virtualPath 両方を扱う処理になっています。これらの混在は混乱の原因になっており、実ベースディレクトリに仮想相対パスをつなげるミスがあります。(このPRで修正します)

- 探索処理は 仮想パスで行う
- 見つかったスクリプトのキャッシュ `g.Game#_scriptCaches` は実パスをキーに保持する

#### 対応

根本的には、そもそもスクリプトキャッシュを保持するキーが実パスでなければならない理由はありません。そこでこのPRでは、 `g._require()` の実装を見直し、仮想パスに統一します。

## 破壊的な変更を含んでいるか?

- なし
