### PR TITLE
fix g.Game#_reset() to reset AudioSystems

### DIFF
--- a/spec/AudioSystemSpec.js
+++ b/spec/AudioSystemSpec.js
@@ -30,6 +30,22 @@ describe("test AudioPlayer", function() {
 		expect(system._destroyRequestedAssets[audio.id]).toEqual(audio);
 	});
 
+
+	it("AudioSystem#_reset", function () {
+		var game = new mock.Game({ width: 320, height: 320 });
+		var system = game.audio["sound"];
+		var asset = game.resourceFactory.createAudioAsset("dummy", "audio/dummy", 0, system, true, {});
+
+		system._setPlaybackRate(0.3);
+		system.requestDestroy(asset);
+		expect(system._playbackRate).toBe(0.3);
+		expect(system._destroyRequestedAssets["dummy"]).toBe(asset);
+
+		system._reset();
+		expect(system._playbackRate).toBe(1);
+		expect(system._destroyRequestedAssets).toEqual({});
+	});
+
 	it("AudioSystem#_setPlaybackRate", function () {
 		var game = new mock.Game({ width: 320, height: 320 });
 		var system = game.audio["sound"];

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -60,6 +60,17 @@ namespace g {
 		/**
 		 * @private
 		 */
+		_reset(): void {
+			this.stopAll();
+			this._volume = 1;
+			this._destroyRequestedAssets = {};
+			this._muted = this.game._audioSystemManager._muted;
+			this._playbackRate = this.game._audioSystemManager._playbackRate;
+		}
+
+		/**
+		 * @private
+		 */
 		_setMuted(value: boolean): void {
 			var before = this._muted;
 			this._muted = !!value;

--- a/src/AudioSystemManager.ts
+++ b/src/AudioSystemManager.ts
@@ -30,6 +30,19 @@ namespace g {
 		/**
 		 * @private
 		 */
+		_reset(): void {
+			this._muted = false;
+			this._playbackRate = 1.0;
+			var systems = this._game.audio;
+			for (var id in systems) {
+				if (!systems.hasOwnProperty(id)) continue;
+				systems[id]._reset();
+			}
+		}
+
+		/**
+		 * @private
+		 */
 		_setMuted(muted: boolean): void {
 			if (this._muted === muted)
 				return;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -875,6 +875,7 @@ namespace g {
 					this.random = param.randGen;
 			}
 
+			this._audioSystemManager._reset();
 			this._loaded.removeAll({ func: this._start, owner: this });
 			this.join.removeAll();
 			this.leave.removeAll();

--- a/unreleased-changes/fix-audio-reset.md
+++ b/unreleased-changes/fix-audio-reset.md
@@ -1,0 +1,4 @@
+
+不具合修正
+ * `g.AudioAsset` の再生中に `g.Game#_reset()` されると、 `g.AudioAsset` がその後誤って破棄される問題を修正
+


### PR DESCRIPTION
## このpull requestが解決する内容

掲題どおり。 `g.Game#_reset()` で `game` インスタンスが使い回される時、 `audio` の状態がリセットされていませんでした。この不具合のため、 `_reset()` が呼び出された瞬間に音声が鳴っていた場合に問題がありました。

というのも `_reset()` された際、再生中の音声は即座には破棄されず、再生終了時に破棄するように予約されるためです。この予約状態をリセットしないまま `game` を使い回すと、次にそのオーディオアセットが鳴らされた時、再生が終了した瞬間にアセットが破棄されてしまっていました。

最低限のユニットテストを加えた他、手元のsandboxに結合して動作を確認しています。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

