### PR TITLE
Fix g.AudioSystem#_reset()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 不具合修正
  * 明示的に `g.AudioSystem#createPlayer()` を利用し、音声が再生されていない状態でエンジンが `g.Game#_reset()` を行なった場合、環境によって例外が起きる問題を修正
+ * 音声を再生せずに呼び出された `g.AudioAsset#stop()` が、環境によって `stopped` をfireする問題を修正
 
 ## 2.3.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## (unreleased)
+
+不具合修正
+ * 明示的に `g.AudioSystem#createPlayer()` を利用し、音声が再生されていない状態でエンジンが `g.Game#_reset()` を行なった場合、環境によって例外が起きる問題を修正
+
 ## 2.3.6
 
 不具合修正

--- a/spec/AudioSystemSpec.js
+++ b/spec/AudioSystemSpec.js
@@ -31,21 +31,6 @@ describe("test AudioPlayer", function() {
 	});
 
 
-	it("AudioSystem#_reset", function () {
-		var game = new mock.Game({ width: 320, height: 320 });
-		var system = game.audio["sound"];
-		var asset = game.resourceFactory.createAudioAsset("dummy", "audio/dummy", 0, system, true, {});
-
-		system._setPlaybackRate(0.3);
-		system.requestDestroy(asset);
-		expect(system._playbackRate).toBe(0.3);
-		expect(system._destroyRequestedAssets["dummy"]).toBe(asset);
-
-		system._reset();
-		expect(system._playbackRate).toBe(1);
-		expect(system._destroyRequestedAssets).toEqual({});
-	});
-
 	it("AudioSystem#_setPlaybackRate", function () {
 		var game = new mock.Game({ width: 320, height: 320 });
 		var system = game.audio["sound"];
@@ -77,6 +62,41 @@ describe("test AudioPlayer", function() {
 		player1.stop();
 		expect(player1._muted).toBe(true);
 	});
+
+	it("SoundAudioSystem#_reset", function () {
+		var game = new mock.Game({ width: 320, height: 320 });
+		var system = game.audio["sound"];
+		var asset = game.resourceFactory.createAudioAsset("dummy", "audio/dummy", 0, system, true, {});
+		var player = system.createPlayer();
+
+		system._setPlaybackRate(0.3);
+		system.requestDestroy(asset);
+		expect(player._playbackRate).toBe(0.3);
+		expect(system._playbackRate).toBe(0.3);
+		expect(system._destroyRequestedAssets["dummy"]).toBe(asset);
+
+		system._reset();
+		expect(system._playbackRate).toBe(1);
+		expect(system._destroyRequestedAssets).toEqual({});
+	});
+
+	it("MusicAudioSystem#_reset", function () {
+		var game = new mock.Game({ width: 320, height: 320 });
+		var system = game.audio["music"];
+		var asset = game.resourceFactory.createAudioAsset("dummy", "audio/dummy", 0, system, true, {});
+		var player = system.createPlayer();
+
+		system._setPlaybackRate(0.3);
+		system.requestDestroy(asset);
+		expect(player._playbackRate).toBe(0.3);
+		expect(system._playbackRate).toBe(0.3);
+		expect(system._destroyRequestedAssets["dummy"]).toBe(asset);
+
+		system._reset();
+		expect(system._playbackRate).toBe(1);
+		expect(system._destroyRequestedAssets).toEqual({});
+	});
+
 
 	it("MusicAudioSystem#_setPlaybackRate", function () {
 		var game = new mock.Game({ width: 320, height: 320 });

--- a/spec/AudioSystemSpec.js
+++ b/spec/AudioSystemSpec.js
@@ -30,7 +30,6 @@ describe("test AudioPlayer", function() {
 		expect(system._destroyRequestedAssets[audio.id]).toEqual(audio);
 	});
 
-
 	it("AudioSystem#_setPlaybackRate", function () {
 		var game = new mock.Game({ width: 320, height: 320 });
 		var system = game.audio["sound"];
@@ -96,7 +95,6 @@ describe("test AudioPlayer", function() {
 		expect(system._playbackRate).toBe(1);
 		expect(system._destroyRequestedAssets).toEqual({});
 	});
-
 
 	it("MusicAudioSystem#_setPlaybackRate", function () {
 		var game = new mock.Game({ width: 320, height: 320 });

--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -84,11 +84,13 @@ namespace g {
 		/**
 		 * 再生を停止する。
 		 *
-		 * 再生中でない場合、何もしない。
 		 * 停止後、 `this.stopped` がfireされる。
+		 * 再生中でない場合、何もしない(`stopped` もfireされない)。
 		 */
 		stop(): void {
 			var audio = this.currentAudio;
+			if (!audio)
+				return;
 			this.currentAudio = undefined;
 			this.stopped.fire({
 				player: this,

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -234,7 +234,7 @@ namespace g {
 		 * @private
 		 */
 		_onPlayerStopped(e: AudioPlayerEvent): void {
-			if (e.audio && this._destroyRequestedAssets[e.audio.id]) {
+			if (this._destroyRequestedAssets[e.audio.id]) {
 				delete this._destroyRequestedAssets[e.audio.id];
 				e.audio.destroy();
 			}
@@ -326,8 +326,6 @@ namespace g {
 		 * @private
 		 */
 		_onPlayerStopped(e: AudioPlayerEvent): void {
-			if (!e.audio)
-				return;
 			var index = this.players.indexOf(e.player);
 			if (index < 0)
 				return;

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -162,6 +162,19 @@ namespace g {
 		/**
 		 * @private
 		 */
+		_reset(): void {
+			super._reset();
+			if (this._player) {
+				this._player.played.remove({ owner: this, func: this._onPlayerPlayed });
+				this._player.stopped.remove({ owner: this, func: this._onPlayerStopped });
+			}
+			this._player = undefined;
+			this._suppressingAudio = undefined;
+		}
+
+		/**
+		 * @private
+		 */
 		_onVolumeChanged(): void {
 			this.player.changeVolume(this._volume);
 		}
@@ -221,7 +234,7 @@ namespace g {
 		 * @private
 		 */
 		_onPlayerStopped(e: AudioPlayerEvent): void {
-			if (this._destroyRequestedAssets[e.audio.id]) {
+			if (e.audio && this._destroyRequestedAssets[e.audio.id]) {
 				delete this._destroyRequestedAssets[e.audio.id];
 				e.audio.destroy();
 			}
@@ -266,6 +279,19 @@ namespace g {
 		/**
 		 * @private
 		 */
+		_reset(): void {
+			super._reset();
+			for (var i = 0; i < this.players.length; ++i) {
+				var player = this.players[i];
+				player.played.remove({ owner: this, func: this._onPlayerPlayed });
+				player.stopped.remove({ owner: this, func: this._onPlayerStopped });
+			}
+			this.players = [];
+		}
+
+		/**
+		 * @private
+		 */
 		_onMutedChanged(): void {
 			var players = this.players;
 			for (var i = 0; i < players.length; ++i) {
@@ -300,14 +326,14 @@ namespace g {
 		 * @private
 		 */
 		_onPlayerStopped(e: AudioPlayerEvent): void {
+			if (!e.audio)
+				return;
 			var index = this.players.indexOf(e.player);
 			if (index < 0)
 				return;
 
 			e.player.stopped.remove({ owner: this, func: this._onPlayerStopped });
-
 			this.players.splice(index, 1);
-
 			if (this._destroyRequestedAssets[e.audio.id]) {
 				delete this._destroyRequestedAssets[e.audio.id];
 				e.audio.destroy();


### PR DESCRIPTION
## このpull requestが解決する内容

- `g.AudioSystem#createPlayer()` を明示的に呼び出し、
- その player が再生されていない状態で `g.AudioSystem#_reset()` が行われた時、
- 環境によって例外が生じる

問題を修正します。音声が再生されていない状態で `g.AudioPlayer#stop()` が呼び出されると、 `stopped` トリガーは  `audio` が `undefined` でfireされますが、その状態を考慮できていませんでした。ブラウザ環境では問題になっていませんでしたが、unit test で問題になったため修正します。

ついでにあまり問題にならないかとは思いますが、念のため `AudioSystem` の派生クラスのメンバも `_reset()` で破棄するように改めます。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

