### PR TITLE
add padding for cache surfaces of g.CacheableE

### DIFF
--- a/src/CacheableE.ts
+++ b/src/CacheableE.ts
@@ -11,6 +11,13 @@ namespace g {
 	 */
 	export abstract class CacheableE extends E {
 		/**
+		 * _cache のパディングサイズ。
+		 *
+		 * @private
+		 */
+		static PADDING: number = 1;
+
+		/**
 		 * エンジンが子孫を描画すべきであれば`true`、でなければ`false`を本クラスを継承したクラスがセットする。
 		 * デフォルト値は`true`となる。
 		 * @private
@@ -69,34 +76,42 @@ namespace g {
 		 * このメソッドはエンジンから暗黙に呼び出され、ゲーム開発者が呼び出す必要はない。
 		 */
 		renderSelf(renderer: Renderer, camera?: Camera): boolean {
+			var padding = CacheableE.PADDING;
 			if (this._renderedCamera !== camera) {
 				this.state &= ~EntityStateFlags.Cached;
 				this._renderedCamera = camera;
 			}
 			if (!(this.state & EntityStateFlags.Cached)) {
 				this._cacheSize = this.calculateCacheSize();
-				var isNew = !this._cache
-					|| this._cache.width < Math.ceil(this._cacheSize.width)
-					|| this._cache.height < Math.ceil(this._cacheSize.height);
+				var w = Math.ceil(this._cacheSize.width) + padding * 2;
+				var h = Math.ceil(this._cacheSize.height) + padding * 2;
+				var isNew = !this._cache || (this._cache.width < w) || (this._cache.height < h);
 				if (isNew) {
 					if (this._cache && !this._cache.destroyed()) {
 						this._cache.destroy();
 					}
-					this._cache = this.scene.game.resourceFactory.createSurface(Math.ceil(this._cacheSize.width), Math.ceil(this._cacheSize.height));
+					this._cache = this.scene.game.resourceFactory.createSurface(w, h);
 					this._renderer = this._cache.renderer();
 				}
-				this._renderer.begin();
+
+				var cacheRenderer = this._renderer;
+				cacheRenderer.begin();
 				if (! isNew) {
-					this._renderer.clear();
+					cacheRenderer.clear();
 				}
 
-				this.renderCache(this._renderer, camera);
+				cacheRenderer.save();
+				cacheRenderer.translate(padding, padding);
+				this.renderCache(cacheRenderer, camera);
+				cacheRenderer.restore();
 
 				this.state |= EntityStateFlags.Cached;
-				this._renderer.end();
+				cacheRenderer.end();
 			}
 			if (this._cache && this._cacheSize.width > 0 && this._cacheSize.height > 0) {
-				renderer.drawImage(this._cache, 0, 0, this._cacheSize.width, this._cacheSize.height, 0, 0);
+				renderer.translate(-padding, -padding);
+				renderer.drawImage(this._cache, 0, 0, this._cacheSize.width + padding, this._cacheSize.height + padding, 0, 0);
+				renderer.translate(padding, padding);
 			}
 			return this._shouldRenderChildren;
 		}


### PR DESCRIPTION
## このpull requestが解決する内容

`g.Label` の描画先座標が整数でない場合に、文字とフォントサイズと環境によって描画内容の端が 1px 切れることがある問題を修正します。現象は最新 akashic-sandbox において、次のようなコンテンツを実行した時、少なくとも Mac Chrome 69 で再現します。

```
function main(param) {
  var game = g.game;
  var scene = new g.Scene({game: g.game});
  scene.loaded.add(function() {
    var font = new g.DynamicFont({ game, fontFamily: "sans-serif", size: 10 });
    var label = new g.Label({ scene, font, text: "hoge", fontSize: 50, parent: scene, x: 100, y: 0 });
    label.update.add(() => {
      label.x -= 0.3;  // 少数部分を使う
      if (label.x < 0)
        label.x = game.width;
      label.modified();
    });
  });
  g.game.pushScene(scene);
}
```

原因は `g.CacheableE` (`Label` の基底クラス) の確保するキャッシュサイズがグリフ領域ぴったりになっていることにあるようです。(canvas の非整数位置に描画した時、描画元の境界部分のアンチエイリアス処理をどうするかというブラウザ実装の問題)

正味「単に非整数位置への描画」を仕様上制限してしまってもいいような気もしますが、少なくとも現時点では「上下左右に 1px ずつパディングを作る」で改善する問題なので、救ってしまいます。(逆に処理負荷やメモリのコストが大きくなるようなら断念して制限にすべきだと思っています)

描画結果の問題で、単体で動作確認できないのでユニットテストは追加していません。このブランチを手元の sandbox に組み込んで、上記コードで動作確認を行いました。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

