### PR TITLE
Update sharing of surfaceAtlas

### DIFF
--- a/spec/DynamicFontSpec.js
+++ b/spec/DynamicFontSpec.js
@@ -33,7 +33,7 @@ describe("test DynamicFont", function() {
 				maxAtlasWidth: 512,
 				maxAtlasHeight: 512
 		});
-		expect(font._atlasSet.maxAtlasNum).toEqual(g.SurfaceAtlasSet.INITIAL_SURFACEATLAS_MAX_SIZE);
+		expect(font._atlasSet.maxAtlasNum).toEqual(g.SurfaceAtlasSet.INITIAL_MAX_SURFACEATLAS_NUM);
 	});
 	it("初期化 - Given hint", function() {
 		var runtime = skeletonRuntime();

--- a/spec/DynamicFontSpec.js
+++ b/spec/DynamicFontSpec.js
@@ -33,7 +33,7 @@ describe("test DynamicFont", function() {
 				maxAtlasWidth: 512,
 				maxAtlasHeight: 512
 		});
-		expect(font._atlasSet.maxAtlasNum).toEqual(g.SurfaceAtlasSet.INITIAL_MAX_SURFACEATLAS_NUM);
+		expect(font._atlasSet.getMaxAtlasNum()).toEqual(g.SurfaceAtlasSet.INITIAL_MAX_SURFACEATLAS_NUM);
 	});
 	it("初期化 - Given hint", function() {
 		var runtime = skeletonRuntime();
@@ -69,7 +69,7 @@ describe("test DynamicFont", function() {
 				maxAtlasHeight: 4000,
 				maxAtlasNum: 5
 		});
-		expect(font._atlasSet.maxAtlasNum).toEqual(5);
+		expect(font._atlasSet.getMaxAtlasNum()).toEqual(5);
 	});
 	it("初期化 - ParameterObject, 文字列配列によるフォントファミリ指定", function() {
 		const runtime = skeletonRuntime();

--- a/spec/DynamicFontSpec.js
+++ b/spec/DynamicFontSpec.js
@@ -28,12 +28,12 @@ describe("test DynamicFont", function() {
 		expect(font.strokeColor).toBe("red");
 		expect(font.strokeOnly).toBe(true);
 		expect(font.hint).toEqual({
-				initialAtlasWidth: 2048,
-				initialAtlasHeight: 2048,
-				maxAtlasWidth: 2048,
-				maxAtlasHeight: 2048,
-				maxAtlasNum: 1
+				initialAtlasWidth: 512,
+				initialAtlasHeight: 512,
+				maxAtlasWidth: 512,
+				maxAtlasHeight: 512
 		});
+		expect(font._atlasSet.maxAtlasSize).toEqual(g.SurfaceAtlasSet.INITIAL_SURFACEATLAS_SIZE);
 	});
 	it("初期化 - Given hint", function() {
 		var runtime = skeletonRuntime();
@@ -69,6 +69,7 @@ describe("test DynamicFont", function() {
 				maxAtlasHeight: 4000,
 				maxAtlasNum: 5
 		});
+		expect(font._atlasSet.maxAtlasSize).toEqual(5);
 	});
 	it("初期化 - ParameterObject, 文字列配列によるフォントファミリ指定", function() {
 		const runtime = skeletonRuntime();

--- a/spec/DynamicFontSpec.js
+++ b/spec/DynamicFontSpec.js
@@ -98,4 +98,40 @@ describe("test DynamicFont", function() {
 		expect(font.fontFamily).toBe(param.fontFamily);
 		expect(font.size).toBe(font.size);
 	});
+
+	describe("destroy", function () {
+		it("DynamicFontがオーナーのSurfaceAtlasSetはDynamoicFontのdestroyで破棄される", function () {
+			const df = new g.DynamicFont({
+				game: skeletonRuntime().game,
+				fontFamily: "Mock明朝",
+				size: 20,
+				hint: {
+					maxAtlasNum: 2,
+					maxAtlasWidth: 100,
+					baselineHeight: 20
+				}
+			});
+			df.destroy();
+			expect(df._atlasSet.destroyed()).toBeTruthy();
+		});
+		it("DynamicFont以外がオーナーのSurfaceAtlasSetはDynamoicFontのdestroyで破棄されない", function () {
+			const df = new g.DynamicFont({
+				game: skeletonRuntime().game,
+				fontFamily: "Mock明朝",
+				size: 20,
+			});
+			df.destroy();
+			expect(df._atlasSet.destroyed()).toBeFalsy();
+
+			const sas = new g.SurfaceAtlasSet({game: skeletonRuntime().game});
+			const df2 = new g.DynamicFont({
+				game: skeletonRuntime().game,
+				fontFamily: "Mock明朝",
+				size: 20,
+				surfaceAtlasSet: sas
+			});
+			df2.destroy();
+			expect(df2._atlasSet.destroyed()).toBeFalsy();
+		});
+	});
 });

--- a/spec/DynamicFontSpec.js
+++ b/spec/DynamicFontSpec.js
@@ -33,7 +33,7 @@ describe("test DynamicFont", function() {
 				maxAtlasWidth: 512,
 				maxAtlasHeight: 512
 		});
-		expect(font._atlasSet.maxAtlasSize).toEqual(g.SurfaceAtlasSet.INITIAL_SURFACEATLAS_SIZE);
+		expect(font._atlasSet.maxAtlasNum).toEqual(g.SurfaceAtlasSet.INITIAL_SURFACEATLAS_MAX_SIZE);
 	});
 	it("初期化 - Given hint", function() {
 		var runtime = skeletonRuntime();
@@ -69,7 +69,7 @@ describe("test DynamicFont", function() {
 				maxAtlasHeight: 4000,
 				maxAtlasNum: 5
 		});
-		expect(font._atlasSet.maxAtlasSize).toEqual(5);
+		expect(font._atlasSet.maxAtlasNum).toEqual(5);
 	});
 	it("初期化 - ParameterObject, 文字列配列によるフォントファミリ指定", function() {
 		const runtime = skeletonRuntime();

--- a/spec/DynamicFontSpec.js
+++ b/spec/DynamicFontSpec.js
@@ -27,12 +27,11 @@ describe("test DynamicFont", function() {
 		expect(font.strokeWidth).toBe(1);
 		expect(font.strokeColor).toBe("red");
 		expect(font.strokeOnly).toBe(true);
-		expect(font.hint).toEqual({
-				initialAtlasWidth: 512,
-				initialAtlasHeight: 512,
-				maxAtlasWidth: 512,
-				maxAtlasHeight: 512
+		expect(font._atlasSet.getAtlasSize()).toEqual({
+				height: 512,
+				width: 512
 		});
+
 		expect(font._atlasSet.getMaxAtlasNum()).toEqual(g.SurfaceAtlasSet.INITIAL_MAX_SURFACEATLAS_NUM);
 	});
 	it("初期化 - Given hint", function() {
@@ -68,6 +67,10 @@ describe("test DynamicFont", function() {
 				maxAtlasWidth: 3000,
 				maxAtlasHeight: 4000,
 				maxAtlasNum: 5
+		});
+		expect(font._atlasSet.getAtlasSize()).toEqual({
+			height: 2000,
+			width: 1000
 		});
 		expect(font._atlasSet.getMaxAtlasNum()).toEqual(5);
 	});

--- a/spec/SurfaceAtlasSetSpec.js
+++ b/spec/SurfaceAtlasSetSpec.js
@@ -1,0 +1,73 @@
+describe("test SurfaceAtlasSet", function() {
+	var g = require('../lib/main.node.js');
+	var skeletonRuntime = require("./helpers/skeleton");
+	var surfaceAtlasSet;
+	beforeEach(function() {
+	});
+	afterEach(function() {
+	});
+	it("初期化", function() {
+		var runtime = skeletonRuntime();
+		surfaceAtlasSet = new g.SurfaceAtlasSet({ game: runtime.game});
+		expect(surfaceAtlasSet._surfaceAtlases).toEqual([]);
+		expect(surfaceAtlasSet.maxAtlasSize).toEqual(g.SurfaceAtlasSet.INITIAL_SURFACEATLAS_SIZE);
+	});
+
+	describe("removeLowUseAtlas", function () {
+		it("_accessScoreが低いSurfaceAtlasが保持配列から削除される", function() {
+			for(var i = 0; i < 10; i++) {
+				var atlas = new g.SurfaceAtlas(new g.Surface(1,1));
+				atlas._accessScore = i;
+				surfaceAtlasSet.addAtlas(atlas);
+			}
+
+			var removedAtlas = surfaceAtlasSet.removeLowUseAtlas();
+			var ret = surfaceAtlasSet._surfaceAtlases.find(atlas => {
+				return atlas._accessScore === 0;
+			})
+			expect(ret).toEqual(undefined);
+			expect(removedAtlas._accessScore).toEqual(0);
+			expect(surfaceAtlasSet.atlasLength).toEqual(9);
+		});
+	});
+
+	describe("addToAtlas", function () {
+		it("追加対象のSurfaceに空き領域がない場合、nullが返る", function () {
+			var glyph = new g.Glyph(300, 0, 0, 10, 10);
+			var ret = surfaceAtlasSet.addToAtlas(glyph);
+			expect(ret).toBeNull();
+		});
+		it("正常にグリフが追加された場合、追加したSurfaceAtlasが返る", function () {
+			var glyph = new g.Glyph(300, 0, 0, 1, 1);
+			glyph.surface = new g.Surface(1, 1);
+
+			var atlas = new g.SurfaceAtlas(new g.Surface(100, 100));
+			spyOn(atlas, "addSurface").and.callFake(() => { return { x: 1, y: 1 } });
+			surfaceAtlasSet.addAtlas(atlas);
+
+			var ret = surfaceAtlasSet.addToAtlas(glyph);
+			expect(ret instanceof g.SurfaceAtlas).toBeTruthy();
+		});
+	});
+
+	describe("reallocateAtlas", function () {
+		it("SurfaceAtlasの保持数が最大値未満の場合、SurfaceAtlasが追加される", function () {
+			surfaceAtlasSet.maxAtlasSize = surfaceAtlasSet.atlasLength + 1;
+			var currentLength = surfaceAtlasSet.atlasLength;
+
+			surfaceAtlasSet._resourceFactory = {
+				createSurfaceAtlas: function (width, height) {
+					return new g.SurfaceAtlas(new g.Surface(10, 10))}
+			}
+			surfaceAtlasSet.reallocateAtlas({}, {width: 10, height: 10});
+			expect(surfaceAtlasSet.atlasLength).toEqual(currentLength + 1);
+		});
+		it("SurfaceAtlasの保持数が最大値の場合、SurfaceAtlasを1つ削除後に追加される", function () {
+			spyOn(surfaceAtlasSet, "removeLowUseAtlas").and.callThrough();
+			surfaceAtlasSet.reallocateAtlas({}, { width: 10, height: 10 });
+
+			expect(surfaceAtlasSet.removeLowUseAtlas).toHaveBeenCalled();
+			expect(surfaceAtlasSet.atlasLength).toEqual(surfaceAtlasSet.maxAtlasSize);
+		});
+	});
+});

--- a/spec/SurfaceAtlasSetSpec.js
+++ b/spec/SurfaceAtlasSetSpec.js
@@ -45,7 +45,7 @@ describe("test SurfaceAtlasSet", function() {
 			});
 
 			var removedObj = surfaceAtlasSet._removeLeastFrequentlyUsedAtlas(1);
-			var removedAtlas = removedObj.surfaceAtlas;
+			var removedAtlas = removedObj.surfaceAtlases;
 			var ret = surfaceAtlasSet._surfaceAtlases.find(atlas => {
 				return atlas._accessScore === 0;
 			})
@@ -83,17 +83,17 @@ describe("test SurfaceAtlasSet", function() {
 				createSurfaceAtlas: function (width, height) {
 					return new g.SurfaceAtlas(new g.Surface(10, 10))}
 			}
-			surfaceAtlasSet._reallocateAtlas({}, {width: 10, height: 10});
+			surfaceAtlasSet._reallocateAtlas();
 			expect(surfaceAtlasSet.getAtlasNum()).toEqual(currentLength + 1);
 		});
 		it("SurfaceAtlasの保持数が最大値の場合、削除処理が呼ばれる。", function () {
 			spyOn(surfaceAtlasSet, "_removeLeastFrequentlyUsedAtlas").and.callFake(() => {
 				var glyph = new g.Glyph(300, 0, 0, 10, 10);
 				var atlas = new g.SurfaceAtlas(new g.Surface(10, 10))
-				return { surfaceAtlas: [atlas], glyphs: [[glyph]] };
+				return { surfaceAtlases: [atlas], glyphs: [[glyph]] };
 			});
 
-			surfaceAtlasSet._reallocateAtlas({}, { width: 10, height: 10 });
+			surfaceAtlasSet._reallocateAtlas();
 			expect(surfaceAtlasSet._removeLeastFrequentlyUsedAtlas).toHaveBeenCalled();
 		});
 	});

--- a/spec/SurfaceAtlasSetSpec.js
+++ b/spec/SurfaceAtlasSetSpec.js
@@ -52,10 +52,10 @@ describe("test SurfaceAtlasSet", function() {
 		});
 	});
 
-	describe("addToAtlas", function () {
+	describe("addGlyph", function () {
 		it("追加対象のSurfaceに空き領域がない場合、nullが返る", function () {
 			var glyph = new g.Glyph(300, 0, 0, 10, 10);
-			var ret = surfaceAtlasSet.addToAtlas(glyph);
+			var ret = surfaceAtlasSet.addGlyph(glyph);
 			expect(ret).toBeNull();
 		});
 		it("正常にグリフが追加された場合、追加したSurfaceAtlasが返る", function () {
@@ -66,7 +66,7 @@ describe("test SurfaceAtlasSet", function() {
 			spyOn(atlas, "addSurface").and.callFake(() => { return { x: 1, y: 1 } });
 			surfaceAtlasSet._surfaceAtlases.push(atlas);
 
-			var ret = surfaceAtlasSet.addToAtlas(glyph);
+			var ret = surfaceAtlasSet.addGlyph(glyph);
 			expect(ret instanceof g.SurfaceAtlas).toBeTruthy();
 		});
 	});

--- a/spec/SurfaceAtlasSetSpec.js
+++ b/spec/SurfaceAtlasSetSpec.js
@@ -80,12 +80,12 @@ describe("test SurfaceAtlasSet", function() {
 				createSurfaceAtlas: function (width, height) {
 					return new g.SurfaceAtlas(new g.Surface(10, 10))}
 			}
-			surfaceAtlasSet.reallocateAtlas({}, {width: 10, height: 10});
+			surfaceAtlasSet._reallocateAtlas({}, {width: 10, height: 10});
 			expect(surfaceAtlasSet.getAtlasNum()).toEqual(currentLength + 1);
 		});
 		it("SurfaceAtlasの保持数が最大値の場合、SurfaceAtlasを1つ削除後に追加される", function () {
 			spyOn(surfaceAtlasSet, "_removeLeastFrequentlyUsedAtlas").and.callThrough();
-			surfaceAtlasSet.reallocateAtlas({}, { width: 10, height: 10 });
+			surfaceAtlasSet._reallocateAtlas({}, { width: 10, height: 10 });
 
 			expect(surfaceAtlasSet._removeLeastFrequentlyUsedAtlas).toHaveBeenCalled();
 			expect(surfaceAtlasSet.getAtlasNum()).toEqual(surfaceAtlasSet.getMaxAtlasNum());
@@ -114,12 +114,12 @@ describe("test SurfaceAtlasSet", function() {
 		});
 
 		it("maxAtlasNumと現在のSurfaceAtlasの保持数が同数以上の場合、一つ削除され追加される", function () {
-			spyOn(surfaceAtlasSet, "_removeAtlas").and.callThrough();
+			spyOn(surfaceAtlasSet, "_deleteAtlas").and.callThrough();
 			const len = surfaceAtlasSet.getAtlasNum();
 			var atlas = new g.SurfaceAtlas(new g.Surface(1, 1));
 			surfaceAtlasSet.addAtlas(atlas);
 			expect(surfaceAtlasSet.getAtlasNum()).toEqual(surfaceAtlasSet.getMaxAtlasNum());
-			expect(surfaceAtlasSet._removeAtlas).toHaveBeenCalled();
+			expect(surfaceAtlasSet._deleteAtlas).toHaveBeenCalled();
 		});
 	});
 });

--- a/spec/SurfaceAtlasSetSpec.js
+++ b/spec/SurfaceAtlasSetSpec.js
@@ -10,7 +10,7 @@ describe("test SurfaceAtlasSet", function() {
 		var runtime = skeletonRuntime();
 		surfaceAtlasSet = new g.SurfaceAtlasSet({ game: runtime.game});
 		expect(surfaceAtlasSet._surfaceAtlases).toEqual([]);
-		expect(surfaceAtlasSet.maxAtlasNum).toEqual(g.SurfaceAtlasSet.INITIAL_MAX_SURFACEATLAS_NUM);
+		expect(surfaceAtlasSet.getMaxAtlasNum()).toEqual(g.SurfaceAtlasSet.INITIAL_MAX_SURFACEATLAS_NUM);
 	});
 
 	describe("removeLeastFrequentlyUsedAtlas", function () {
@@ -21,7 +21,7 @@ describe("test SurfaceAtlasSet", function() {
 				surfaceAtlasSet.addAtlas(atlas);
 			}
 
-			var removedAtlas = surfaceAtlasSet.removeLeastFrequentlyUsedAtlas();
+			var removedAtlas = surfaceAtlasSet.removeLeastFrequentlyUsedAtlas(1);
 			var ret = surfaceAtlasSet._surfaceAtlases.find(atlas => {
 				return atlas._accessScore === 0;
 			})
@@ -52,7 +52,7 @@ describe("test SurfaceAtlasSet", function() {
 
 	describe("reallocateAtlas", function () {
 		it("SurfaceAtlasの保持数が最大値未満の場合、SurfaceAtlasが追加される", function () {
-			surfaceAtlasSet.maxAtlasNum = surfaceAtlasSet.getAtlasNum() + 1;
+			surfaceAtlasSet.changeMaxAtlasNum(surfaceAtlasSet.getAtlasNum() + 1 );
 			var currentLength = surfaceAtlasSet.getAtlasNum();
 
 			surfaceAtlasSet._resourceFactory = {
@@ -67,19 +67,19 @@ describe("test SurfaceAtlasSet", function() {
 			surfaceAtlasSet.reallocateAtlas({}, { width: 10, height: 10 });
 
 			expect(surfaceAtlasSet.removeLeastFrequentlyUsedAtlas).toHaveBeenCalled();
-			expect(surfaceAtlasSet.getAtlasNum()).toEqual(surfaceAtlasSet.maxAtlasNum);
+			expect(surfaceAtlasSet.getAtlasNum()).toEqual(surfaceAtlasSet.getMaxAtlasNum());
 		});
 	});
 
 	describe("set maxAtlasNum", function () {
 		it("現在のSurfaceAtlasの保持数より値が大きい場合、maxAtlasNumの値が設定される", function () {
-			surfaceAtlasSet.maxAtlasNum = 15;
-			expect(surfaceAtlasSet.maxAtlasNum).toEqual(15);
+			surfaceAtlasSet.changeMaxAtlasNum(15);
+			expect(surfaceAtlasSet.getMaxAtlasNum()).toEqual(15);
 
 		});
 		it("現在のSurfaceAtlasの保持数より値が小さい場合、maxAtlasNumの値が設定される", function () {
-			surfaceAtlasSet.maxAtlasNum = 5;
-			expect(surfaceAtlasSet.maxAtlasNum).toEqual(5);
+			surfaceAtlasSet.changeMaxAtlasNum(5);
+			expect(surfaceAtlasSet.getAtlasNum()).toEqual(5);
 			expect(surfaceAtlasSet.getAtlasNum()).toEqual(5);
 		});
 

--- a/spec/SurfaceAtlasSetSpec.js
+++ b/spec/SurfaceAtlasSetSpec.js
@@ -44,7 +44,8 @@ describe("test SurfaceAtlasSet", function() {
 				atlas._accessScore = index;
 			});
 
-			var removedAtlas = surfaceAtlasSet._removeLeastFrequentlyUsedAtlas(1);
+			var removedObj = surfaceAtlasSet._removeLeastFrequentlyUsedAtlas(1);
+			var removedAtlas = removedObj.surfaceAtlas;
 			var ret = surfaceAtlasSet._surfaceAtlases.find(atlas => {
 				return atlas._accessScore === 0;
 			})
@@ -85,12 +86,15 @@ describe("test SurfaceAtlasSet", function() {
 			surfaceAtlasSet._reallocateAtlas({}, {width: 10, height: 10});
 			expect(surfaceAtlasSet.getAtlasNum()).toEqual(currentLength + 1);
 		});
-		it("SurfaceAtlasの保持数が最大値の場合、SurfaceAtlasを1つ削除後に追加される", function () {
-			spyOn(surfaceAtlasSet, "_removeLeastFrequentlyUsedAtlas").and.callThrough();
-			surfaceAtlasSet._reallocateAtlas({}, { width: 10, height: 10 });
+		it("SurfaceAtlasの保持数が最大値の場合、削除処理が呼ばれる。", function () {
+			spyOn(surfaceAtlasSet, "_removeLeastFrequentlyUsedAtlas").and.callFake(() => {
+				var glyph = new g.Glyph(300, 0, 0, 10, 10);
+				var atlas = new g.SurfaceAtlas(new g.Surface(10, 10))
+				return { surfaceAtlas: [atlas], glyphs: [[glyph]] };
+			});
 
+			surfaceAtlasSet._reallocateAtlas({}, { width: 10, height: 10 });
 			expect(surfaceAtlasSet._removeLeastFrequentlyUsedAtlas).toHaveBeenCalled();
-			expect(surfaceAtlasSet.getAtlasNum()).toEqual(surfaceAtlasSet.getMaxAtlasNum());
 		});
 	});
 

--- a/spec/SurfaceAtlasSetSpec.js
+++ b/spec/SurfaceAtlasSetSpec.js
@@ -10,7 +10,7 @@ describe("test SurfaceAtlasSet", function() {
 		var runtime = skeletonRuntime();
 		surfaceAtlasSet = new g.SurfaceAtlasSet({ game: runtime.game});
 		expect(surfaceAtlasSet._surfaceAtlases).toEqual([]);
-		expect(surfaceAtlasSet.maxAtlasNum).toEqual(g.SurfaceAtlasSet.INITIAL_SURFACEATLAS_MAX_SIZE);
+		expect(surfaceAtlasSet.maxAtlasNum).toEqual(g.SurfaceAtlasSet.INITIAL_MAX_SURFACEATLAS_NUM);
 	});
 
 	describe("removeLeastFrequentlyUsedAtlas", function () {
@@ -26,8 +26,8 @@ describe("test SurfaceAtlasSet", function() {
 				return atlas._accessScore === 0;
 			})
 			expect(ret).toEqual(undefined);
-			expect(removedAtlas._accessScore).toEqual(0);
-			expect(surfaceAtlasSet.atlasNum).toEqual(9);
+			expect(removedAtlas[0]._accessScore).toEqual(0);
+			expect(surfaceAtlasSet.getAtlasNum()).toEqual(9);
 		});
 	});
 
@@ -52,22 +52,36 @@ describe("test SurfaceAtlasSet", function() {
 
 	describe("reallocateAtlas", function () {
 		it("SurfaceAtlasの保持数が最大値未満の場合、SurfaceAtlasが追加される", function () {
-			surfaceAtlasSet.maxAtlasNum = surfaceAtlasSet.atlasNum + 1;
-			var currentLength = surfaceAtlasSet.atlasNum;
+			surfaceAtlasSet.maxAtlasNum = surfaceAtlasSet.getAtlasNum() + 1;
+			var currentLength = surfaceAtlasSet.getAtlasNum();
 
 			surfaceAtlasSet._resourceFactory = {
 				createSurfaceAtlas: function (width, height) {
 					return new g.SurfaceAtlas(new g.Surface(10, 10))}
 			}
 			surfaceAtlasSet.reallocateAtlas({}, {width: 10, height: 10});
-			expect(surfaceAtlasSet.atlasNum).toEqual(currentLength + 1);
+			expect(surfaceAtlasSet.getAtlasNum()).toEqual(currentLength + 1);
 		});
 		it("SurfaceAtlasの保持数が最大値の場合、SurfaceAtlasを1つ削除後に追加される", function () {
 			spyOn(surfaceAtlasSet, "removeLeastFrequentlyUsedAtlas").and.callThrough();
 			surfaceAtlasSet.reallocateAtlas({}, { width: 10, height: 10 });
 
 			expect(surfaceAtlasSet.removeLeastFrequentlyUsedAtlas).toHaveBeenCalled();
-			expect(surfaceAtlasSet.atlasNum).toEqual(surfaceAtlasSet.maxAtlasNum);
+			expect(surfaceAtlasSet.getAtlasNum()).toEqual(surfaceAtlasSet.maxAtlasNum);
 		});
+	});
+
+	describe("set maxAtlasNum", function () {
+		it("現在のSurfaceAtlasの保持数より値が大きい場合、maxAtlasNumの値が設定される", function () {
+			surfaceAtlasSet.maxAtlasNum = 15;
+			expect(surfaceAtlasSet.maxAtlasNum).toEqual(15);
+
+		});
+		it("現在のSurfaceAtlasの保持数より値が小さい場合、maxAtlasNumの値が設定される", function () {
+			surfaceAtlasSet.maxAtlasNum = 5;
+			expect(surfaceAtlasSet.maxAtlasNum).toEqual(5);
+			expect(surfaceAtlasSet.getAtlasNum()).toEqual(5);
+		});
+
 	});
 });

--- a/spec/SurfaceAtlasSetSpec.js
+++ b/spec/SurfaceAtlasSetSpec.js
@@ -42,7 +42,7 @@ describe("test SurfaceAtlasSet", function() {
 				atlas._accessScore = index;
 			});
 
-			var removedAtlas = surfaceAtlasSet.removeLeastFrequentlyUsedAtlas(1);
+			var removedAtlas = surfaceAtlasSet._removeLeastFrequentlyUsedAtlas(1);
 			var ret = surfaceAtlasSet._surfaceAtlases.find(atlas => {
 				return atlas._accessScore === 0;
 			})
@@ -84,10 +84,10 @@ describe("test SurfaceAtlasSet", function() {
 			expect(surfaceAtlasSet.getAtlasNum()).toEqual(currentLength + 1);
 		});
 		it("SurfaceAtlasの保持数が最大値の場合、SurfaceAtlasを1つ削除後に追加される", function () {
-			spyOn(surfaceAtlasSet, "removeLeastFrequentlyUsedAtlas").and.callThrough();
+			spyOn(surfaceAtlasSet, "_removeLeastFrequentlyUsedAtlas").and.callThrough();
 			surfaceAtlasSet.reallocateAtlas({}, { width: 10, height: 10 });
 
-			expect(surfaceAtlasSet.removeLeastFrequentlyUsedAtlas).toHaveBeenCalled();
+			expect(surfaceAtlasSet._removeLeastFrequentlyUsedAtlas).toHaveBeenCalled();
 			expect(surfaceAtlasSet.getAtlasNum()).toEqual(surfaceAtlasSet.getMaxAtlasNum());
 		});
 	});

--- a/spec/SurfaceAtlasSetSpec.js
+++ b/spec/SurfaceAtlasSetSpec.js
@@ -10,10 +10,10 @@ describe("test SurfaceAtlasSet", function() {
 		var runtime = skeletonRuntime();
 		surfaceAtlasSet = new g.SurfaceAtlasSet({ game: runtime.game});
 		expect(surfaceAtlasSet._surfaceAtlases).toEqual([]);
-		expect(surfaceAtlasSet.maxAtlasSize).toEqual(g.SurfaceAtlasSet.INITIAL_SURFACEATLAS_SIZE);
+		expect(surfaceAtlasSet.maxAtlasNum).toEqual(g.SurfaceAtlasSet.INITIAL_SURFACEATLAS_MAX_SIZE);
 	});
 
-	describe("removeLowUseAtlas", function () {
+	describe("removeLeastFrequentlyUsedAtlas", function () {
 		it("_accessScoreが低いSurfaceAtlasが保持配列から削除される", function() {
 			for(var i = 0; i < 10; i++) {
 				var atlas = new g.SurfaceAtlas(new g.Surface(1,1));
@@ -21,13 +21,13 @@ describe("test SurfaceAtlasSet", function() {
 				surfaceAtlasSet.addAtlas(atlas);
 			}
 
-			var removedAtlas = surfaceAtlasSet.removeLowUseAtlas();
+			var removedAtlas = surfaceAtlasSet.removeLeastFrequentlyUsedAtlas();
 			var ret = surfaceAtlasSet._surfaceAtlases.find(atlas => {
 				return atlas._accessScore === 0;
 			})
 			expect(ret).toEqual(undefined);
 			expect(removedAtlas._accessScore).toEqual(0);
-			expect(surfaceAtlasSet.atlasLength).toEqual(9);
+			expect(surfaceAtlasSet.atlasNum).toEqual(9);
 		});
 	});
 
@@ -52,22 +52,22 @@ describe("test SurfaceAtlasSet", function() {
 
 	describe("reallocateAtlas", function () {
 		it("SurfaceAtlasの保持数が最大値未満の場合、SurfaceAtlasが追加される", function () {
-			surfaceAtlasSet.maxAtlasSize = surfaceAtlasSet.atlasLength + 1;
-			var currentLength = surfaceAtlasSet.atlasLength;
+			surfaceAtlasSet.maxAtlasNum = surfaceAtlasSet.atlasNum + 1;
+			var currentLength = surfaceAtlasSet.atlasNum;
 
 			surfaceAtlasSet._resourceFactory = {
 				createSurfaceAtlas: function (width, height) {
 					return new g.SurfaceAtlas(new g.Surface(10, 10))}
 			}
 			surfaceAtlasSet.reallocateAtlas({}, {width: 10, height: 10});
-			expect(surfaceAtlasSet.atlasLength).toEqual(currentLength + 1);
+			expect(surfaceAtlasSet.atlasNum).toEqual(currentLength + 1);
 		});
 		it("SurfaceAtlasの保持数が最大値の場合、SurfaceAtlasを1つ削除後に追加される", function () {
-			spyOn(surfaceAtlasSet, "removeLowUseAtlas").and.callThrough();
+			spyOn(surfaceAtlasSet, "removeLeastFrequentlyUsedAtlas").and.callThrough();
 			surfaceAtlasSet.reallocateAtlas({}, { width: 10, height: 10 });
 
-			expect(surfaceAtlasSet.removeLowUseAtlas).toHaveBeenCalled();
-			expect(surfaceAtlasSet.atlasLength).toEqual(surfaceAtlasSet.maxAtlasSize);
+			expect(surfaceAtlasSet.removeLeastFrequentlyUsedAtlas).toHaveBeenCalled();
+			expect(surfaceAtlasSet.atlasNum).toEqual(surfaceAtlasSet.maxAtlasNum);
 		});
 	});
 });

--- a/spec/SurfaceAtlasSetSpec.js
+++ b/spec/SurfaceAtlasSetSpec.js
@@ -18,11 +18,13 @@ describe("test SurfaceAtlasSet", function() {
 		var runtime = skeletonRuntime();
 		const surfaceAtlasSetParams = {
 			game: runtime.game,
-			initialAtlasWidth: 1,
-			initialAtlasHeight: 1,
-			maxAtlasWidth: 2,
-			maxAtlasHeight: 3,
-			maxSurfaceAtlasNum: 111
+			hint : {
+				initialAtlasWidth: 1,
+				initialAtlasHeight: 1,
+				maxAtlasWidth: 2,
+				maxAtlasHeight: 3,
+				maxAtlasNum: 111
+			}
 		};
 		surfaceAtlasSet = new g.SurfaceAtlasSet(surfaceAtlasSetParams);
 		expect(surfaceAtlasSet._surfaceAtlases).toEqual([]);

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -14,197 +14,6 @@ namespace g {
 	}
 
 	/**
-	 * SurfaceAtlasの空き領域管理クラス。
-	 *
-	 * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
-	 */
-	export class SurfaceAtlasSlot {
-		x: number;
-		y: number;
-		width: number;
-		height: number;
-		prev: SurfaceAtlasSlot;
-		next: SurfaceAtlasSlot;
-
-		constructor(x: number, y: number, width: number, height: number) {
-			this.x = x;
-			this.y = y;
-			this.width = width;
-			this.height = height;
-			this.prev = null;
-			this.next = null;
-		}
-	}
-
-	function getSurfaceAtlasSlot(slot: SurfaceAtlasSlot, width: number, height: number): SurfaceAtlasSlot {
-		while (slot) {
-			if (slot.width >= width && slot.height >= height) {
-				return slot;
-			}
-			slot = slot.next;
-		}
-
-		return null;
-	}
-
-	function calcAtlasSize(hint: DynamicFontHint): CommonSize {
-		var width = Math.ceil(Math.min(hint.initialAtlasWidth, hint.maxAtlasWidth));
-		var height = Math.ceil(Math.min(hint.initialAtlasHeight, hint.maxAtlasHeight));
-		return { width: width, height: height };
-	}
-
-	/**
-	 * サーフェスアトラス。
-	 *
-	 * 与えられたサーフェスの指定された領域をコピーし一枚のサーフェスにまとめる。
-	 *
-	 * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
-	 */
-	export class SurfaceAtlas implements Destroyable {
-		/**
-		 * @private
-		 */
-		_surface: Surface;
-
-		/**
-		 * @private
-		 */
-		_emptySurfaceAtlasSlotHead: SurfaceAtlasSlot;
-
-		/**
-		 * @private
-		 */
-		_accessScore: number;
-
-		/**
-		 * @private
-		 */
-		_usedRectangleAreaSize: CommonSize;
-
-		constructor(surface: Surface) {
-			this._surface = surface;
-			this._emptySurfaceAtlasSlotHead = new SurfaceAtlasSlot(0, 0, this._surface.width, this._surface.height);
-			this._accessScore = 0;
-			this._usedRectangleAreaSize = { width: 0, height: 0 };
-		}
-
-		/**
-		 * @private
-		 */
-		_acquireSurfaceAtlasSlot(width: number, height: number): SurfaceAtlasSlot {
-			// Renderer#drawImage()でサーフェス上の一部を描画するとき、
-			// 指定した部分に隣接する画素がにじみ出る現象が確認されている。
-			// ここれではそれを避けるため1pixelの余白を与えている。
-			width += 1;
-			height += 1;
-
-			var slot = getSurfaceAtlasSlot(this._emptySurfaceAtlasSlotHead, width, height);
-
-			if (! slot) {
-				return null;
-			}
-
-			var remainWidth = slot.width - width;
-			var remainHeight = slot.height - height;
-			var left: SurfaceAtlasSlot;
-			var right: SurfaceAtlasSlot;
-			if (remainWidth <= remainHeight) {
-				left  = new SurfaceAtlasSlot(slot.x + width, slot.y,          remainWidth, height);
-				right = new SurfaceAtlasSlot(slot.x,         slot.y + height, slot.width,  remainHeight);
-			} else {
-				left  = new SurfaceAtlasSlot(slot.x,         slot.y + height, width,       remainHeight);
-				right = new SurfaceAtlasSlot(slot.x + width, slot.y,          remainWidth, slot.height);
-			}
-
-			left.prev = slot.prev;
-			left.next = right;
-			if (left.prev === null) { // left is head
-				this._emptySurfaceAtlasSlotHead = left;
-			} else {
-				left.prev.next = left;
-			}
-
-			right.prev = left;
-			right.next = slot.next;
-			if (right.next) {
-				right.next.prev = right;
-			}
-
-			const acquiredSlot = new SurfaceAtlasSlot(slot.x, slot.y, width, height);
-
-			this._updateUsedRectangleAreaSize(acquiredSlot);
-
-			return acquiredSlot;
-		}
-
-		/**
-		 * @private
-		 */
-		_updateUsedRectangleAreaSize(slot: SurfaceAtlasSlot): void {
-			const slotRight = slot.x + slot.width;
-			const slotBottom = slot.y + slot.height;
-			if (slotRight > this._usedRectangleAreaSize.width) {
-				this._usedRectangleAreaSize.width = slotRight;
-			}
-			if (slotBottom > this._usedRectangleAreaSize.height) {
-				this._usedRectangleAreaSize.height = slotBottom;
-			}
-		}
-
-		/**
-		 * サーフェスの追加。
-		 *
-		 * @param surface サーフェスアトラス上に配置される画像のサーフェス。
-		 * @param rect サーフェス上の領域を表す矩形。この領域内の画像がサーフェスアトラス上に複製・配置される。
-		 */
-		addSurface(surface: Surface, rect: CommonArea): SurfaceAtlasSlot {
-			var slot = this._acquireSurfaceAtlasSlot(rect.width, rect.height);
-			if (! slot) {
-				return null;
-			}
-
-			var renderer = this._surface.renderer();
-			renderer.begin();
-			renderer.drawImage(surface, rect.x, rect.y, rect.width, rect.height, slot.x, slot.y);
-			renderer.end();
-
-			return slot;
-		}
-
-		 /**
- 		 * このSurfaceAtlasの破棄を行う。
- 		 * 以後、このSurfaceを利用することは出来なくなる。
- 		 */
-		destroy(): void {
-			this._surface.destroy();
-		}
-
-		/**
-		 * このSurfaceAtlasが破棄済であるかどうかを判定する。
-		 */
-		destroyed(): boolean {
-			return this._surface.destroyed();
-		}
-
-		/**
-		 * _surfaceを複製する。
-		 *
-		 * 複製されたSurfaceは文字を格納するのに必要な最低限のサイズになる。
-		 */
-		duplicateSurface(resourceFactory: ResourceFactory): Surface {
-			const src = this._surface;
-			const dst = resourceFactory.createSurface(this._usedRectangleAreaSize.width, this._usedRectangleAreaSize.height);
-
-			const renderer = dst.renderer();
-			renderer.begin();
-			renderer.drawImage(src, 0, 0, this._usedRectangleAreaSize.width, this._usedRectangleAreaSize.height, 0, 0);
-			renderer.end();
-
-			return dst;
-		}
-	}
-
-	/**
 	 * `DynamicFont` のコンストラクタに渡すことができるパラメータ。
 	 * 各メンバの詳細は `DynamicFont` の同名メンバの説明を参照すること。
 	 */
@@ -379,22 +188,22 @@ namespace g {
 		/**
 		 * @private
 		 */
-		_atlases: SurfaceAtlas[];
-
-		/**
-		 * @private
-		 */
-		_currentAtlasIndex: number;
-
-		/**
-		 * @private
-		 */
 		_destroyed: boolean;
 
 		/**
 		 * @private
 		 */
 		_atlasSize: CommonSize;
+
+		/**
+		 * @private
+		 */
+		_atlasSet: SurfaceAtlasSet;
+
+		/**
+		 * @private
+		 */
+		_isGameOfAtrasSet: boolean;
 
 		/**
 		 * 各種パラメータを指定して `DynamicFont` のインスタンスを生成する。
@@ -414,20 +223,25 @@ namespace g {
 				this._resourceFactory.createGlyphFactory(this.fontFamily, this.size, this.hint.baselineHeight,
 					this.fontColor, this.strokeWidth, this.strokeColor, this.strokeOnly, this.fontWeight);
 			this._glyphs = {};
-			this._atlases = [];
-			this._currentAtlasIndex = 0;
 			this._destroyed = false;
 
+			// prams.hintのプロパティが存在する場合、DynamicFontが管理するSurfaceAtlasSetを使用し、hintが存在しなければgameが持つ共通のSurfaceAtlasSetを使用する
+			this._isGameOfAtrasSet = Object.keys(this.hint).length === 0;
+			this._atlasSet = this._isGameOfAtrasSet ? param.game.surfaceAtlasSet : new SurfaceAtlasSet(param.game);
 			// 指定がないとき、やや古いモバイルデバイスでも確保できると言われる
 			// 縦横512pxのテクスチャ一枚のアトラスにまとめる形にする
 			this.hint.initialAtlasWidth = this.hint.initialAtlasWidth ? this.hint.initialAtlasWidth : 512;
 			this.hint.initialAtlasHeight = this.hint.initialAtlasHeight ? this.hint.initialAtlasHeight : 512;
 			this.hint.maxAtlasWidth = this.hint.maxAtlasWidth ? this.hint.maxAtlasWidth : 512;
 			this.hint.maxAtlasHeight = this.hint.maxAtlasHeight ? this.hint.maxAtlasHeight : 512;
-			this.hint.maxAtlasNum = this.hint.maxAtlasNum ? this.hint.maxAtlasNum : 1;
+			if (this.hint.maxAtlasNum) {
+				this._atlasSet.maxAtlasSize = this.hint.maxAtlasNum;
+			}
 
-			this._atlasSize = calcAtlasSize(this.hint);
-			this._atlases.push(this._resourceFactory.createSurfaceAtlas(this._atlasSize.width, this._atlasSize.height));
+			this._atlasSize = this._calcAtlasSize(this.hint);
+			if (this._atlasSet.atlasLength === 0 ) {
+				this._atlasSet.addAtlas(this._resourceFactory.createSurfaceAtlas(this._atlasSize.width, this._atlasSize.height));
+			}
 
 			if (this.hint.presetChars) {
 				for (let i = 0, len = this.hint.presetChars.length; i < len; i++) {
@@ -438,6 +252,15 @@ namespace g {
 					this.glyphForCharacter(code);
 				}
 			}
+		}
+
+		/**
+		 * @private
+		 */
+		_calcAtlasSize(hint: DynamicFontHint): CommonSize {
+			var width = Math.ceil(Math.min(hint.initialAtlasWidth, hint.maxAtlasWidth));
+			var height = Math.ceil(Math.min(hint.initialAtlasHeight, hint.maxAtlasHeight));
+			return { width: width, height: height };
 		}
 
 		/**
@@ -466,12 +289,12 @@ namespace g {
 						return null;
 					}
 
-					let atlas = this._addToAtlas(glyph);
+					let atlas = this._atlasSet.addToAtlas(glyph);
 					if (! atlas) {
-						this._reallocateAtlas();
+						this._atlasSet.reallocateAtlas(this._glyphs, this._atlasSize);
 
 						// retry
-						atlas = this._addToAtlas(glyph);
+						atlas = this._atlasSet.addToAtlas(glyph);
 						if (! atlas) {
 							return null;
 						}
@@ -485,8 +308,8 @@ namespace g {
 			// スコア更新
 			// NOTE: LRUを捨てる方式なら単純なタイムスタンプのほうがわかりやすいかもしれない
 			// NOTE: 正確な時刻は必要ないはずで、インクリメンタルなカウンタで代用すればDate()生成コストは省略できる
-			for (var i = 0; i < this._atlases.length; i++) {
-				var atlas = this._atlases[i];
+			for (var i = 0; i < this._atlasSet.atlasLength; i++) {
+				var atlas = this._atlasSet.getAtlasFromIndex(i);
 				if (atlas === glyph._atlas) {
 					atlas._accessScore += 1;
 				}
@@ -505,7 +328,7 @@ namespace g {
 		 * @param missingGlyph `BitmapFont#map` に存在しないコードポイントの代わりに表示するべき文字。最初の一文字が用いられる。
 		 */
 		asBitmapFont(missingGlyphChar?: string): BitmapFont {
-			if (this._atlases.length !== 1) {
+			if (this._atlasSet.atlasLength !== 1) {
 				return null;
 			}
 
@@ -538,7 +361,8 @@ namespace g {
 			// しかし defaultGlyphHeight は BitmapFont#size にも用いられる。
 			// そのために this.size をコンストラクタの第４引数に与えることにする。
 			let missingGlyph = glyphAreaMap[missingGlyphCharCodePoint];
-			const surface = this._atlases[0].duplicateSurface(this._resourceFactory);
+			const surface = this._atlasSet.getAtlasFromIndex(0).duplicateSurface(this._resourceFactory);
+
 			const bitmapFont = new BitmapFont({
 				src: surface,
 				map: glyphAreaMap,
@@ -549,86 +373,9 @@ namespace g {
 			return bitmapFont;
 		}
 
-		/**
-		 * @private
-		 */
-		_removeLowUseAtlas(): SurfaceAtlas {
-			var minScore = Number.MAX_VALUE;
-			var lowScoreAtlasIndex = -1;
-			for (var i = 0; i < this._atlases.length; i++) {
-				if (this._atlases[i]._accessScore <= minScore) {
-					minScore = this._atlases[i]._accessScore;
-					lowScoreAtlasIndex = i;
-				}
-			}
-
-			let removedAtlas = this._atlases.splice(lowScoreAtlasIndex, 1)[0];
-
-			return removedAtlas;
-		}
-
-		/**
-		 * @private
-		 */
-		_reallocateAtlas(): void {
-			if (this._atlases.length >= this.hint.maxAtlasNum) {
-				let atlas = this._removeLowUseAtlas();
-				let glyphs = this._glyphs;
-
-				for (let key in glyphs) {
-					if (glyphs.hasOwnProperty(key)) {
-						var glyph = glyphs[key];
-						if (glyph.surface === atlas._surface) {
-							glyph.surface = null;
-							glyph.isSurfaceValid = false;
-							glyph._atlas = null;
-						}
-					}
-				}
-				atlas.destroy();
-			}
-
-			this._atlases.push(this._resourceFactory.createSurfaceAtlas(this._atlasSize.width, this._atlasSize.height));
-			this._currentAtlasIndex = this._atlases.length - 1;
-		}
-
-		/**
-		 * @private
-		 */
-		_addToAtlas(glyph: Glyph): SurfaceAtlas {
-			let atlas: SurfaceAtlas = null;
-			let slot: SurfaceAtlasSlot = null;
-			let area = {
-				x: glyph.x,
-				y: glyph.y,
-				width: glyph.width,
-				height: glyph.height
-			};
-			for (let i = 0; i < this._atlases.length; i++) {
-				let index = (this._currentAtlasIndex + i) % this._atlases.length;
-				atlas = this._atlases[index];
-				slot = atlas.addSurface(glyph.surface, area);
-				if (slot) {
-					this._currentAtlasIndex = index;
-					break;
-				}
-			}
-
-			if (! slot) {
-				return null;
-			}
-
-			glyph.surface.destroy();
-			glyph.surface = atlas._surface;
-			glyph.x = slot.x;
-			glyph.y = slot.y;
-
-			return atlas;
-		}
-
 		destroy(): void {
-			for (var i = 0; i < this._atlases.length; i++) {
-				this._atlases[i].destroy();
+			for (var i = 0; i < this._atlasSet.atlasLength; i++) {
+				this._atlasSet.getAtlasFromIndex(i).destroy();
 			}
 			this._glyphs = null;
 			this._glyphFactory = null;

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -250,7 +250,7 @@ namespace g {
 					initialAtlasHeight: this.hint.initialAtlasHeight,
 					maxAtlasWidth: this.hint.maxAtlasWidth,
 					maxAtlasHeight: this.hint.maxAtlasHeight,
-					maxSurfaceAtlasNum: this.hint.maxAtlasNum ? this.hint.maxAtlasNum : undefined
+					maxSurfaceAtlasNum: this.hint.maxAtlasNum
 				});
 			}
 
@@ -294,19 +294,19 @@ namespace g {
 
 				if (glyph.surface) { // 空白文字でなければアトラス化する
 					const atlasSize = this._atlasSet.getAtlasSize();
-					// グリフがアトラスより大きいとき、`_addToAtlas()`は失敗する。
+					// グリフがアトラスより大きいとき、`_atlasSet.addGlyph()`は失敗する。
 					// `_reallocateAtlas()`でアトラス増やしてもこれは解決できない。
 					// 無駄な空き領域探索とアトラスの再確保を避けるためにここでリターンする。
 					if (glyph.width > atlasSize.width || glyph.height > atlasSize.height) {
 						return null;
 					}
 
-					let atlas = this._atlasSet.addToAtlas(glyph);
+					let atlas = this._atlasSet.addGlyph(glyph);
 					if (! atlas) {
 						this._atlasSet.reallocateAtlas();
 
 						// retry
-						atlas = this._atlasSet.addToAtlas(glyph);
+						atlas = this._atlasSet.addGlyph(glyph);
 						if (! atlas) {
 							return null;
 						}

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -235,7 +235,8 @@ namespace g {
 			this._destroyed = false;
 			this._isDestroyExecutable = false;
 
-			this._useCommonAtlasSet = Object.keys(this.hint).length === 0;
+			const hintLength = Object.keys(this.hint).length;
+			this._useCommonAtlasSet = hintLength === 0 || (hintLength === 1 && "baselineHeight" in this.hint);
 
 			if (param.surfaceAtlasSet) {
 				this._atlasSet = param.surfaceAtlasSet;
@@ -243,17 +244,14 @@ namespace g {
 				this._atlasSet = param.game.surfaceAtlasSet;
 			} else {
 				this._isDestroyExecutable = true;
-				const surfaceAtlasSetParams: SurfaceAtlasSetParameterObject = {
+				this._atlasSet = new SurfaceAtlasSet({
 					game: param.game,
 					initialAtlasWidth: this.hint.initialAtlasWidth,
 					initialAtlasHeight: this.hint.initialAtlasHeight,
 					maxAtlasWidth: this.hint.maxAtlasWidth,
-					maxAtlasHeight: this.hint.maxAtlasHeight
-				};
-				if (this.hint.maxAtlasNum) {
-					surfaceAtlasSetParams.maxSurfaceAtlasNum = this.hint.maxAtlasNum;
-				}
-				this._atlasSet = new SurfaceAtlasSet(surfaceAtlasSetParams);
+					maxAtlasHeight: this.hint.maxAtlasHeight,
+					maxSurfaceAtlasNum: this.hint.maxAtlasNum ? this.hint.maxAtlasNum : undefined
+				});
 			}
 
 			this._atlasSet.register(this);

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -419,11 +419,11 @@ namespace g {
 			this._destroyed = false;
 
 			// 指定がないとき、やや古いモバイルデバイスでも確保できると言われる
-			// 縦横2048pxのテクスチャ一枚のアトラスにまとめる形にする
-			this.hint.initialAtlasWidth = this.hint.initialAtlasWidth ? this.hint.initialAtlasWidth : 2048;
-			this.hint.initialAtlasHeight = this.hint.initialAtlasHeight ? this.hint.initialAtlasHeight : 2048;
-			this.hint.maxAtlasWidth = this.hint.maxAtlasWidth ? this.hint.maxAtlasWidth : 2048;
-			this.hint.maxAtlasHeight = this.hint.maxAtlasHeight ? this.hint.maxAtlasHeight : 2048;
+			// 縦横512pxのテクスチャ一枚のアトラスにまとめる形にする
+			this.hint.initialAtlasWidth = this.hint.initialAtlasWidth ? this.hint.initialAtlasWidth : 512;
+			this.hint.initialAtlasHeight = this.hint.initialAtlasHeight ? this.hint.initialAtlasHeight : 512;
+			this.hint.maxAtlasWidth = this.hint.maxAtlasWidth ? this.hint.maxAtlasWidth : 512;
+			this.hint.maxAtlasHeight = this.hint.maxAtlasHeight ? this.hint.maxAtlasHeight : 512;
 			this.hint.maxAtlasNum = this.hint.maxAtlasNum ? this.hint.maxAtlasNum : 1;
 
 			this._atlasSize = calcAtlasSize(this.hint);

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -202,7 +202,7 @@ namespace g {
 		/**
 		 * @private
 		 */
-		_isDestroyExecutable: boolean;
+		_hasExternalSurfaceAtlasSet: boolean;
 
 		/**
 		 * @private
@@ -228,7 +228,7 @@ namespace g {
 					this.fontColor, this.strokeWidth, this.strokeColor, this.strokeOnly, this.fontWeight);
 			this._glyphs = {};
 			this._destroyed = false;
-			this._isDestroyExecutable = false;
+			this._hasExternalSurfaceAtlasSet = false;
 
 			if (param.surfaceAtlasSet) {
 				this._atlasSet = param.surfaceAtlasSet;
@@ -239,7 +239,7 @@ namespace g {
 				if (useCommonAtlasSet) {
 					this._atlasSet = param.game.surfaceAtlasSet;
 				} else {
-					this._isDestroyExecutable = true;
+					this._hasExternalSurfaceAtlasSet = true;
 					this._atlasSet = new SurfaceAtlasSet({
 						game: param.game,
 						initialAtlasWidth: this.hint.initialAtlasWidth,
@@ -378,7 +378,7 @@ namespace g {
 
 		destroy(): void {
 			this._atlasSet.unregister(this);
-			if (this._isDestroyExecutable) {
+			if (this._hasExternalSurfaceAtlasSet) {
 				this._atlasSet.destroy();
 			}
 			this._glyphs = null;

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -16,8 +16,9 @@ namespace g {
 	/**
 	 * `DynamicFont` のコンストラクタに渡すことができるパラメータ。
 	 * 各メンバの詳細は `DynamicFont` の同名メンバの説明を参照すること。
-	 * DynamicFontHintが存在する場合、DynamicFontが管理するSurfaceAtlasSetを使用する。
-	 * DynamicFontHintが存在しない場合、gameが持つ共通のSurfaceAtlasSetを使用する。
+	 * パラメータのsurfaceAtlasSetが存在する場合は、パラメータのsurfaceAtlasSetを使用する。
+	 * surfaceAtlasSetが存在せず、DynamicFontHintが存在する場合、DynamicFontが管理するSurfaceAtlasSetを使用する。
+	 * surfaceAtlasSetが存在せず、DynamicFontHintが存在しない場合、gameが持つ共通のSurfaceAtlasSetを使用する。
 	 */
 	export interface DynamicFontParameterObject {
 		/**
@@ -78,7 +79,7 @@ namespace g {
 		 * サーフェスアトラスセット
 		 * @default undefined
 		 */
-		atlasSet?: SurfaceAtlasSet;
+		surfaceAtlasSet?: SurfaceAtlasSet;
 	}
 
 	/**
@@ -230,8 +231,8 @@ namespace g {
 
 			this._useCommonAtlasSet = Object.keys(this.hint).length === 0;
 
-			if (param.atlasSet) {
-				this._atlasSet = param.atlasSet;
+			if (param.surfaceAtlasSet) {
+				this._atlasSet = param.surfaceAtlasSet;
 			} else if (this._useCommonAtlasSet) {
 				this._atlasSet = param.game.surfaceAtlasSet;
 			} else {

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -202,7 +202,7 @@ namespace g {
 		/**
 		 * @private
 		 */
-		_hasExternalSurfaceAtlasSet: boolean;
+		_isSurfaceAtlasSetOwner: boolean;
 
 		/**
 		 * @private
@@ -228,7 +228,7 @@ namespace g {
 					this.fontColor, this.strokeWidth, this.strokeColor, this.strokeOnly, this.fontWeight);
 			this._glyphs = {};
 			this._destroyed = false;
-			this._hasExternalSurfaceAtlasSet = false;
+			this._isSurfaceAtlasSetOwner = false;
 
 			if (param.surfaceAtlasSet) {
 				this._atlasSet = param.surfaceAtlasSet;
@@ -239,7 +239,7 @@ namespace g {
 				if (useCommonAtlasSet) {
 					this._atlasSet = param.game.surfaceAtlasSet;
 				} else {
-					this._hasExternalSurfaceAtlasSet = true;
+					this._isSurfaceAtlasSetOwner = true;
 					this._atlasSet = new SurfaceAtlasSet({
 						game: param.game,
 						initialAtlasWidth: this.hint.initialAtlasWidth,
@@ -312,7 +312,7 @@ namespace g {
 			// NOTE: LRUを捨てる方式なら単純なタイムスタンプのほうがわかりやすいかもしれない
 			// NOTE: 正確な時刻は必要ないはずで、インクリメンタルなカウンタで代用すればDate()生成コストは省略できる
 			for (var i = 0; i < this._atlasSet.getAtlasNum(); i++) {
-				var atlas = this._atlasSet.getAtlasByIndex(i);
+				var atlas = this._atlasSet.getAtlas(i);
 				if (atlas === glyph._atlas) {
 					atlas._accessScore += 1;
 				}
@@ -364,7 +364,7 @@ namespace g {
 			// しかし defaultGlyphHeight は BitmapFont#size にも用いられる。
 			// そのために this.size をコンストラクタの第４引数に与えることにする。
 			let missingGlyph = glyphAreaMap[missingGlyphCharCodePoint];
-			const surface = this._atlasSet.getAtlasByIndex(0).duplicateSurface(this._resourceFactory);
+			const surface = this._atlasSet.getAtlas(0).duplicateSurface(this._resourceFactory);
 
 			const bitmapFont = new BitmapFont({
 				src: surface,
@@ -378,7 +378,7 @@ namespace g {
 
 		destroy(): void {
 			this._atlasSet.unregister(this);
-			if (this._hasExternalSurfaceAtlasSet) {
+			if (this._isSurfaceAtlasSetOwner) {
 				this._atlasSet.destroy();
 			}
 			this._glyphs = null;

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -233,13 +233,6 @@ namespace g {
 		}
 
 		/**
-		 * グリフ情報を取得する。
-		 */
-		getGlyphs(): { [key: number]: Glyph } {
-			return this._glyphs;
-		}
-
-		/**
 		 * グリフの取得。
 		 *
 		 * 取得に失敗するとnullが返る。
@@ -270,11 +263,9 @@ namespace g {
 			// スコア更新
 			// NOTE: LRUを捨てる方式なら単純なタイムスタンプのほうがわかりやすいかもしれない
 			// NOTE: 正確な時刻は必要ないはずで、インクリメンタルなカウンタで代用すればDate()生成コストは省略できる
+			glyph._atlas._accessScore += 1;
 			for (var i = 0; i < this._atlasSet.getAtlasNum(); i++) {
 				var atlas = this._atlasSet.getAtlas(i);
-				if (atlas === glyph._atlas) {
-					atlas._accessScore += 1;
-				}
 				atlas._accessScore /= 2;
 			}
 

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -242,7 +242,7 @@ namespace g {
 			this.hint.maxAtlasWidth = this.hint.maxAtlasWidth ? this.hint.maxAtlasWidth : 512;
 			this.hint.maxAtlasHeight = this.hint.maxAtlasHeight ? this.hint.maxAtlasHeight : 512;
 			if (this.hint.maxAtlasNum) {
-				this._atlasSet.maxAtlasNum = this.hint.maxAtlasNum;
+				this._atlasSet.changeMaxAtlasNum(this.hint.maxAtlasNum);
 			}
 
 			this._atlasSize = calcAtlasSize(this.hint);

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -22,6 +22,8 @@ namespace g {
 	/**
 	 * `DynamicFont` のコンストラクタに渡すことができるパラメータ。
 	 * 各メンバの詳細は `DynamicFont` の同名メンバの説明を参照すること。
+	 * DynamicFontHintが存在する場合、DynamicFontが管理するSurfaceAtlasSetを使用する。
+	 * DynamicFontHintが存在しない場合、gameが持つ共通のSurfaceAtlasSetを使用する。
 	 */
 	export interface DynamicFontParameterObject {
 		/**
@@ -140,8 +142,6 @@ namespace g {
 
 		/**
 		 * ヒント。
-		 * ヒントが存在する場合、DynamicFontが管理するSurfaceAtlasSetを使用する。
-		 * ヒントが存在しない場合、gameが持つ共通のSurfaceAtlasSetを使用する。
 		 */
 		hint: DynamicFontHint;
 
@@ -246,7 +246,7 @@ namespace g {
 			}
 
 			this._atlasSize = calcAtlasSize(this.hint);
-			if (this._atlasSet.atlasNum === 0 ) {
+			if (this._atlasSet.getAtlasNum() === 0 ) {
 				this._atlasSet.addAtlas(this._resourceFactory.createSurfaceAtlas(this._atlasSize.width, this._atlasSize.height));
 			}
 
@@ -306,7 +306,7 @@ namespace g {
 			// スコア更新
 			// NOTE: LRUを捨てる方式なら単純なタイムスタンプのほうがわかりやすいかもしれない
 			// NOTE: 正確な時刻は必要ないはずで、インクリメンタルなカウンタで代用すればDate()生成コストは省略できる
-			for (var i = 0; i < this._atlasSet.atlasNum; i++) {
+			for (var i = 0; i < this._atlasSet.getAtlasNum(); i++) {
 				var atlas = this._atlasSet.getAtlasByIndex(i);
 				if (atlas === glyph._atlas) {
 					atlas._accessScore += 1;
@@ -326,7 +326,7 @@ namespace g {
 		 * @param missingGlyph `BitmapFont#map` に存在しないコードポイントの代わりに表示するべき文字。最初の一文字が用いられる。
 		 */
 		asBitmapFont(missingGlyphChar?: string): BitmapFont {
-			if (this._atlasSet.atlasNum !== 1) {
+			if (this._atlasSet.getAtlasNum() !== 1) {
 				return null;
 			}
 
@@ -372,7 +372,7 @@ namespace g {
 		}
 
 		destroy(): void {
-			for (var i = 0; i < this._atlasSet.atlasNum; i++) {
+			for (var i = 0; i < this._atlasSet.getAtlasNum(); i++) {
 				this._atlasSet.getAtlasByIndex(i).destroy();
 			}
 			this._glyphs = null;

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -219,7 +219,6 @@ namespace g {
 				this._atlasSet = param.game.surfaceAtlasSet;
 			}
 
-			this._atlasSet.register(this);
 			this._atlasSet.addAtlas();
 
 			if (this.hint.presetChars) {
@@ -337,7 +336,6 @@ namespace g {
 		}
 
 		destroy(): void {
-			this._atlasSet.unregister(this);
 			if (this._isSurfaceAtlasSetOwner) {
 				this._atlasSet.destroy();
 			}

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -287,7 +287,7 @@ namespace g {
 		lastOmittedLocalTickCount: number;
 
 		/**
-		 * サーフェスアトラスを管理する。
+		 * ゲーム全体で共有するサーフェスアトラス。
 		 */
 		surfaceAtlasSet: SurfaceAtlasSet;
 

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -287,6 +287,11 @@ namespace g {
 		lastOmittedLocalTickCount: number;
 
 		/**
+		 * サーフェスアトラスを管理する。
+		 */
+		surfaceAtlasSet: SurfaceAtlasSet;
+
+		/**
 		 * イベントとTriggerのマップ。
 		 * @private
 		 */
@@ -479,6 +484,7 @@ namespace g {
 			this.defaultAudioSystemId = "sound";
 			this.storage = new Storage(this);
 			this.assets = {};
+			this.surfaceAtlasSet = new SurfaceAtlasSet(this);
 
 			// TODO: (GAMEDEV-666) この三つのイベントはGame自身がデフォルトのイベントハンドラを持って処理する必要があるかも
 			this.join = new Trigger<JoinEvent>();

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -484,7 +484,7 @@ namespace g {
 			this.defaultAudioSystemId = "sound";
 			this.storage = new Storage(this);
 			this.assets = {};
-			this.surfaceAtlasSet = new SurfaceAtlasSet({game: this});
+			this.surfaceAtlasSet = undefined;
 
 			// TODO: (GAMEDEV-666) この三つのイベントはGame自身がデフォルトのイベントハンドラを持って処理する必要があるかも
 			this.join = new Trigger<JoinEvent>();
@@ -953,6 +953,11 @@ namespace g {
 
 			this._isTerminated = false;
 			this.vars = {};
+
+			if (this.surfaceAtlasSet)
+				this.surfaceAtlasSet.destroy();
+			this.surfaceAtlasSet = new SurfaceAtlasSet({ game: this });
+
 
 			switch (this._configuration.defaultLoadingScene) {
 			case "none":

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -484,7 +484,7 @@ namespace g {
 			this.defaultAudioSystemId = "sound";
 			this.storage = new Storage(this);
 			this.assets = {};
-			this.surfaceAtlasSet = new SurfaceAtlasSet(this);
+			this.surfaceAtlasSet = new SurfaceAtlasSet({game: this});
 
 			// TODO: (GAMEDEV-666) この三つのイベントはGame自身がデフォルトのイベントハンドラを持って処理する必要があるかも
 			this.join = new Trigger<JoinEvent>();

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1055,6 +1055,8 @@ namespace g {
 			this._focusingCamera = undefined;
 			this._configuration = undefined;
 			this._sceneChangeRequests = [];
+			this.surfaceAtlasSet.destroy();
+			this.surfaceAtlasSet = undefined;
 		}
 
 		/**

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -958,7 +958,6 @@ namespace g {
 				this.surfaceAtlasSet.destroy();
 			this.surfaceAtlasSet = new SurfaceAtlasSet({ game: this });
 
-
 			switch (this._configuration.defaultLoadingScene) {
 			case "none":
 				// Note: 何も描画しない実装として利用している

--- a/src/SurfaceAtlasSet.ts
+++ b/src/SurfaceAtlasSet.ts
@@ -270,7 +270,8 @@ namespace g {
 		 * @private
 		 */
 		_removeAtlas(): void {
-			// addAtlas() から呼ばれる場合、最大保持数と現在の_surfaceAtlasesの保持数が同じ場合、削除後に追加となるので diff が0の場合は1とする。
+			// addAtlas() から呼ばれる場合では、保持している_surfaceAtlasesの数が最大値以上の判定後に削除処理を行い
+			// その後に追加となるので diff が 0 の場合は 1 とする。
 			const diff = Math.max(this._surfaceAtlases.length - this._maxAtlasNum, 1);
 			const removedAtlases = this.removeLeastFrequentlyUsedAtlas(diff);
 			removedAtlases.forEach((atlas) => atlas.destroy());
@@ -279,7 +280,7 @@ namespace g {
 		/**
 		 * サーフェスアトラスを追加する。
 		 *
-		 * 保持している_surfaceAtlasesの数が最大値と同じ場合、削除してから追加する。
+		 * 保持している_surfaceAtlasesの数が最大値以上の場合、削除してから追加する。
 		 */
 		addAtlas(): void {
 			// removeLeastFrequentlyUsedAtlas()では、SurfaceAtlas#_accessScoreの一番小さい値を持つSurfaceAtlasを削除するため、

--- a/src/SurfaceAtlasSet.ts
+++ b/src/SurfaceAtlasSet.ts
@@ -399,7 +399,7 @@ namespace g {
 		 * サーフェスアトラスにグリフを追加する。
 		 * @param glyph グリフ
 		 */
-		addToAtlas(glyph: Glyph): SurfaceAtlas {
+		addGlyph(glyph: Glyph): SurfaceAtlas {
 			let atlas: SurfaceAtlas = null;
 			let slot: SurfaceAtlasSlot = null;
 			let area = {

--- a/src/SurfaceAtlasSet.ts
+++ b/src/SurfaceAtlasSet.ts
@@ -211,7 +211,7 @@ namespace g {
 
 		constructor(game: Game) {
 			this._surfaceAtlases = [];
-			this.maxAtlasNum = SurfaceAtlasSet.INITIAL_MAX_SURFACEATLAS_NUM;
+			this._maxAtlasNum = SurfaceAtlasSet.INITIAL_MAX_SURFACEATLAS_NUM;
 			this._resourceFactory = game.resourceFactory;
 		}
 
@@ -238,7 +238,7 @@ namespace g {
 		/**
 		 * 最大サーフェスアトラス保持数取得する。
 		 */
-		get maxAtlasNum(): number {
+		getMaxAtlasNum(): number {
 			return this._maxAtlasNum;
 		}
 		/**
@@ -248,7 +248,7 @@ namespace g {
 		 * removeLeastFrequentlyUsedAtlas()で設定値まで減らします。
 		 * @param value 設定値
 		 */
-		set maxAtlasNum(value: number) {
+		changeMaxAtlasNum(value: number): void {
 			this._maxAtlasNum = value;
 			if (this._surfaceAtlases.length > this._maxAtlasNum) {
 				const diff = this._surfaceAtlases.length - this._maxAtlasNum;
@@ -316,7 +316,7 @@ namespace g {
 		 * @param atlasSize サーフェスアトラスが保持していSurfaceのサイズ
 		 */
 		reallocateAtlas(_glyphs: { [key: number]: Glyph }, atlasSize: CommonSize): void {
-			if (this._surfaceAtlases.length >= this.maxAtlasNum) {
+			if (this._surfaceAtlases.length >= this._maxAtlasNum) {
 				let atlas = this.removeLeastFrequentlyUsedAtlas(1)[0];
 				let glyphs = _glyphs;
 

--- a/src/SurfaceAtlasSet.ts
+++ b/src/SurfaceAtlasSet.ts
@@ -22,6 +22,18 @@ namespace g {
 		}
 	}
 
+	function getSurfaceAtlasSlot(slot: SurfaceAtlasSlot, width: number, height: number): SurfaceAtlasSlot {
+		while (slot) {
+			if (slot.width >= width && slot.height >= height) {
+				return slot;
+			}
+			slot = slot.next;
+		}
+
+		return null;
+	}
+
+
 	/**
 	 * サーフェスアトラス。
 	 *
@@ -67,7 +79,7 @@ namespace g {
 			width += 1;
 			height += 1;
 
-			var slot = this._getSurfaceAtlasSlot(this._emptySurfaceAtlasSlotHead, width, height);
+			var slot = getSurfaceAtlasSlot(this._emptySurfaceAtlasSlotHead, width, height);
 
 			if (!slot) {
 				return null;
@@ -118,20 +130,6 @@ namespace g {
 			if (slotBottom > this._usedRectangleAreaSize.height) {
 				this._usedRectangleAreaSize.height = slotBottom;
 			}
-		}
-
-		/**
-		 * @private
-		 */
-		_getSurfaceAtlasSlot(slot: SurfaceAtlasSlot, width: number, height: number): SurfaceAtlasSlot {
-			while (slot) {
-				if (slot.width >= width && slot.height >= height) {
-					return slot;
-				}
-				slot = slot.next;
-			}
-
-			return null;
 		}
 
 		/**

--- a/src/SurfaceAtlasSet.ts
+++ b/src/SurfaceAtlasSet.ts
@@ -246,24 +246,21 @@ namespace g {
 		 *
 		 * 設定された値が、現在保持している_surfaceAtlasesの数より大きい場合、
 		 * removeLeastFrequentlyUsedAtlas()で設定値まで減らします。
-		 * 引数の値が、1未満の場合は1を設定し、小数点は切り捨てます。
 		 * @param value 設定値
 		 */
 		set maxAtlasNum(value: number) {
-			if (0 >= value ) value = 1;
-
-			this._maxAtlasNum = Math.floor(value);
+			this._maxAtlasNum = value;
 			if (this._surfaceAtlases.length > this._maxAtlasNum) {
 				const diff = this._surfaceAtlases.length - this._maxAtlasNum;
 				const removedAtlases = this.removeLeastFrequentlyUsedAtlas(diff);
-				removedAtlases.forEach((atlas: SurfaceAtlas) => atlas.destroy() );
+				removedAtlases.forEach((atlas) => atlas.destroy() );
 			}
 		}
 
 		/**
 		 * 使用度の低いサーフェスアトラスを配列から削除する。
 		 */
-		removeLeastFrequentlyUsedAtlas(removedNum: number = 1): SurfaceAtlas[] {
+		removeLeastFrequentlyUsedAtlas(removedNum: number): SurfaceAtlas[] {
 			const removedAtlases = [];
 
 			for (var n = 0; n < removedNum; n++) {

--- a/src/SurfaceAtlasSet.ts
+++ b/src/SurfaceAtlasSet.ts
@@ -365,6 +365,8 @@ namespace g {
 
 		/**
 		 * このSurfaceAtlasSetに紐付くDynamicFontを登録する。
+		 *
+		 * このメソッドはDynamicFontから暗黙に呼び出される。ゲーム開発者がこのメソッドを明示的に呼び出す必要はない。
 		 * @param dynamicFont 登録するDynamicFont
 		 */
 		register(dynamicFont: DynamicFont): void {
@@ -375,6 +377,8 @@ namespace g {
 
 		/**
 		 * このSurfaceAtlasSetからDynamicFontの登録を削除する。
+		 *
+		 * このメソッドはDynamicFontから暗黙に呼び出される。ゲーム開発者がこのメソッドを明示的に利用する必要はない。
 		 * @param dynamicFont 削除するDynamicFont
 		 */
 		unregister(dynamicFont: DynamicFont): void {
@@ -388,6 +392,9 @@ namespace g {
 		 * サーフェスアトラスを追加する。
 		 *
 		 * 保持している_surfaceAtlasesの数が最大値以上の場合、削除してから追加する。
+		 *
+		 * このメソッドは、このSurfaceAtlasSetに紐づいている `DynamnicFont` の `constructor` から暗黙に呼び出される。
+		 * 通常、ゲーム開発者がこのメソッドを呼び出す必要はない。
 		 */
 		addAtlas(): void {
 			// removeLeastFrequentlyUsedAtlas()では、SurfaceAtlas#_accessScoreの一番小さい値を持つSurfaceAtlasを削除するため、
@@ -400,6 +407,9 @@ namespace g {
 
 		/**
 		 * 引数で指定されたindexのサーフェスアトラスを取得する。
+		 *
+		 * このメソッドは、このSurfaceAtlasSetに紐づいている `DynamnicFont` の `glyphForCharacter()` から暗黙に呼び出される。
+		 * 通常、ゲーム開発者がこのメソッドを呼び出す必要はない。
 		 * @param index 取得対象のインデックス
 		 */
 		getAtlas(index: number): SurfaceAtlas {
@@ -408,6 +418,9 @@ namespace g {
 
 		/**
 		 * サーフェスアトラスの保持数を取得する。
+		 *
+		 * このメソッドは、このSurfaceAtlasSetに紐づいている `DynamnicFont` の `glyphForCharacter()` から暗黙に呼び出される。
+		 * 通常、ゲーム開発者がこのメソッドを呼び出す必要はない。
 		 */
 		getAtlasNum(): number {
 			return this._surfaceAtlases.length;
@@ -437,6 +450,9 @@ namespace g {
 
 		/**
 		 * サーフェスアトラスのサイズを取得する。
+		 *
+		 * このメソッドは、このSurfaceAtlasSetに紐づいている `DynamnicFont` の `glyphForCharacter()` から暗黙に呼び出される。
+		 * 通常、ゲーム開発者がこのメソッドを呼び出す必要はない。
 		 */
 		getAtlasSize(): CommonSize {
 			return this._atlasSize;
@@ -444,6 +460,9 @@ namespace g {
 
 		/**
 		 * サーフェスアトラスにグリフを追加する。
+		 *
+		 * このメソッドは、このSurfaceAtlasSetに紐づいている `DynamnicFont` の `glyphForCharacter()` から暗黙に呼び出される。
+		 * 通常、ゲーム開発者がこのメソッドを呼び出す必要はない。
 		 * @param glyph グリフ
 		 */
 		addGlyph(glyph: Glyph): SurfaceAtlas {

--- a/src/SurfaceAtlasSet.ts
+++ b/src/SurfaceAtlasSet.ts
@@ -270,16 +270,20 @@ namespace g {
 		 * @private
 		 */
 		_removeAtlas(): void {
-			let diff = this._surfaceAtlases.length - this._maxAtlasNum;
-			diff = diff === 0 ? 1 : diff;
+			// addAtlas() から呼ばれる場合、最大保持数と現在の_surfaceAtlasesの保持数が同じ場合、削除後に追加となるので diff が0の場合は1とする。
+			const diff = Math.max(this._surfaceAtlases.length - this._maxAtlasNum, 1);
 			const removedAtlases = this.removeLeastFrequentlyUsedAtlas(diff);
 			removedAtlases.forEach((atlas) => atlas.destroy());
 		}
 
 		/**
 		 * サーフェスアトラスを追加する。
+		 *
+		 * 保持している_surfaceAtlasesの数が最大値と同じ場合、削除してから追加する。
 		 */
 		addAtlas(): void {
+			// removeLeastFrequentlyUsedAtlas()では、SurfaceAtlas#_accessScoreの一番小さい値を持つSurfaceAtlasを削除するため、
+			// SurfaceAtlas作成時は_accessScoreは0となっているため、削除判定後に作成,追加処理を行う。
 			if (this._surfaceAtlases.length >= this._maxAtlasNum) {
 				this._removeAtlas();
 			}
@@ -312,7 +316,7 @@ namespace g {
 		 * 最大アトラス保持数設定する。
 		 *
 		 * 設定された値が、現在保持している_surfaceAtlasesの数より大きい場合、
-		 * removeLeastFrequentlyUsedAtlas()で設定値まで減らします。
+		 * removeLeastFrequentlyUsedAtlas()で設定値まで削除する。
 		 * @param value 設定値
 		 */
 		changeMaxAtlasNum(value: number): void {
@@ -335,10 +339,10 @@ namespace g {
 		removeLeastFrequentlyUsedAtlas(removedNum: number): SurfaceAtlas[] {
 			const removedAtlases = [];
 
-			for (var n = 0; n < removedNum; n++) {
+			for (var n = 0; n < removedNum; ++n) {
 				var minScore = Number.MAX_VALUE;
 				var lowScoreAtlasIndex = -1;
-				for (var i = 0; i < this._surfaceAtlases.length; i++) {
+				for (var i = 0; i < this._surfaceAtlases.length; ++i) {
 					if (this._surfaceAtlases[i]._accessScore <= minScore) {
 						minScore = this._surfaceAtlases[i]._accessScore;
 						lowScoreAtlasIndex = i;
@@ -384,12 +388,11 @@ namespace g {
 
 		/**
 		 * サーフェスアトラスの再割り当てを行う。
-		 * @param _glyphs グリフ配列
+		 * @param glyphs グリフ配列
 		 */
-		reallocateAtlas(_glyphs: { [key: number]: Glyph }): void {
+		reallocateAtlas(glyphs: { [key: number]: Glyph }): void {
 			if (this._surfaceAtlases.length >= this._maxAtlasNum) {
 				let atlas = this.removeLeastFrequentlyUsedAtlas(1)[0];
-				let glyphs = _glyphs;
 
 				for (let key in glyphs) {
 					if (glyphs.hasOwnProperty(key)) {

--- a/src/SurfaceAtlasSet.ts
+++ b/src/SurfaceAtlasSet.ts
@@ -242,6 +242,21 @@ namespace g {
 	}
 
 	/**
+	 * 削除対象のデータ
+	 */
+	export interface RemoveAtlasData {
+		/**
+		 * 削除対象のSurfaceAtlas
+		 */
+		surfaceAtlas: SurfaceAtlas[];
+
+		/**
+		 * 削除対象のグリフ
+		 */
+		glyphs: Glyph[][];
+	}
+
+	/**
 	 * DynamicFontで使用される、SurfaceAtlasを管理する。
 	 */
 	export class SurfaceAtlasSet implements Destroyable {
@@ -254,6 +269,11 @@ namespace g {
 		 * @private
 		 */
 		_surfaceAtlases: SurfaceAtlas[];
+
+		/**
+		 * @private
+		 */
+		_atlasGlyphsTable: Glyph[][];
 
 		/**
 		 * @private
@@ -274,11 +294,6 @@ namespace g {
 		 * @private
 		 */
 		_currentAtlasIndex: number;
-
-		/**
-		 * @private
-		 */
-		_atlasGlyphsTable: Glyph[][];
 
 		constructor(params: SurfaceAtlasSetParameterObject) {
 			this._surfaceAtlases = [];
@@ -313,7 +328,7 @@ namespace g {
 		 * 使用度の低いサーフェスアトラスを配列から削除する。
 		 * @private
 		 */
-		_removeLeastFrequentlyUsedAtlas(removedNum: number): {surfaceAtlas: SurfaceAtlas[], glyphs: Glyph[][]} {
+		_removeLeastFrequentlyUsedAtlas(removedNum: number): RemoveAtlasData {
 			const removedAtlases = [];
 			const removedGlyphs = [];
 
@@ -372,11 +387,9 @@ namespace g {
 
 				for (let i = 0; i < glyphs.length; i++) {
 					const glyph = glyphs[i];
-					if (glyph.surface === atlas._surface) {
-						glyph.surface = null;
-						glyph.isSurfaceValid = false;
-						glyph._atlas = null;
-					}
+					glyph.surface = null;
+					glyph.isSurfaceValid = false;
+					glyph._atlas = null;
 				}
 				atlas.destroy();
 			}

--- a/src/SurfaceAtlasSet.ts
+++ b/src/SurfaceAtlasSet.ts
@@ -192,9 +192,9 @@ namespace g {
 	 */
 	export class SurfaceAtlasSet {
 		/**
-		 * SurfaceAtlas保持数初期値
+		 * SurfaceAtlas最大保持数初期値
 		 */
-		static INITIAL_SURFACEATLAS_SIZE: number = 10;
+		static INITIAL_SURFACEATLAS_MAX_SIZE: number = 10;
 
 		/**
 		 * @private
@@ -204,7 +204,7 @@ namespace g {
 		/**
 		 * @private
 		 */
-		_maxAtlasSize: number;
+		_maxAtlasNum: number;
 
 		/**
 		 * @private
@@ -213,7 +213,7 @@ namespace g {
 
 		constructor(game: Game) {
 			this._surfaceAtlases = [];
-			this.maxAtlasSize = SurfaceAtlasSet.INITIAL_SURFACEATLAS_SIZE;
+			this.maxAtlasNum = SurfaceAtlasSet.INITIAL_SURFACEATLAS_MAX_SIZE;
 			this._resourceFactory = game.resourceFactory;
 		}
 
@@ -228,32 +228,32 @@ namespace g {
 		 * 引数で指定されたindexのサーフェスアトラスを取得する。
 		 * @param index 取得対象のインデックス
 		 */
-		getAtlasFromIndex(index: number): SurfaceAtlas {
+		getAtlasByIndex(index: number): SurfaceAtlas {
 			return this._surfaceAtlases[index];
 		}
 		/**
 		 * サーフェスアトラスの保持数を取得する。
 		 */
-		get atlasLength(): number {
+		get atlasNum(): number {
 			return this._surfaceAtlases.length;
 		}
 		/**
 		 * 最大サーフェスアトラス保持数取得する。
 		 */
-		get maxAtlasSize(): number {
-			return this._maxAtlasSize;
+		get maxAtlasNum(): number {
+			return this._maxAtlasNum;
 		}
 		/**
 		 * 最大アトラス保持数設定する。
 		 */
-		set maxAtlasSize(value: number) {
-			this._maxAtlasSize = value;
+		set maxAtlasNum(value: number) {
+			this._maxAtlasNum = value;
 		}
 
 		/**
 		 * 使用度の低いサーフェスアトラスを配列から削除する。
 		 */
-		removeLowUseAtlas(): SurfaceAtlas {
+		removeLeastFrequentlyUsedAtlas(): SurfaceAtlas {
 			var minScore = Number.MAX_VALUE;
 			var lowScoreAtlasIndex = -1;
 			for (var i = 0; i < this._surfaceAtlases.length; i++) {
@@ -304,8 +304,8 @@ namespace g {
 		 * @param atlasSize サーフェスアトラスが保持していSurfaceのサイズ
 		 */
 		reallocateAtlas(_glyphs: { [key: number]: Glyph }, atlasSize: CommonSize): void {
-			if (this._surfaceAtlases.length >= this.maxAtlasSize) {
-				let atlas = this.removeLowUseAtlas();
+			if (this._surfaceAtlases.length >= this.maxAtlasNum) {
+				let atlas = this.removeLeastFrequentlyUsedAtlas();
 				let glyphs = _glyphs;
 
 				for (let key in glyphs) {

--- a/src/SurfaceAtlasSet.ts
+++ b/src/SurfaceAtlasSet.ts
@@ -1,0 +1,327 @@
+namespace g {
+	/**
+	 * SurfaceAtlasの空き領域管理クラス。
+	 *
+	 * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
+	 */
+	export class SurfaceAtlasSlot {
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+		prev: SurfaceAtlasSlot;
+		next: SurfaceAtlasSlot;
+
+		constructor(x: number, y: number, width: number, height: number) {
+			this.x = x;
+			this.y = y;
+			this.width = width;
+			this.height = height;
+			this.prev = null;
+			this.next = null;
+		}
+	}
+
+	/**
+	 * サーフェスアトラス。
+	 *
+	 * 与えられたサーフェスの指定された領域をコピーし一枚のサーフェスにまとめる。
+	 *
+	 * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
+	 */
+	export class SurfaceAtlas implements Destroyable {
+		/**
+		 * @private
+		 */
+		_surface: Surface;
+
+		/**
+		 * @private
+		 */
+		_emptySurfaceAtlasSlotHead: SurfaceAtlasSlot;
+
+		/**
+		 * @private
+		 */
+		_accessScore: number;
+
+		/**
+		 * @private
+		 */
+		_usedRectangleAreaSize: CommonSize;
+
+		constructor(surface: Surface) {
+			this._surface = surface;
+			this._emptySurfaceAtlasSlotHead = new SurfaceAtlasSlot(0, 0, this._surface.width, this._surface.height);
+			this._accessScore = 0;
+			this._usedRectangleAreaSize = { width: 0, height: 0 };
+		}
+
+		/**
+		 * @private
+		 */
+		_acquireSurfaceAtlasSlot(width: number, height: number): SurfaceAtlasSlot {
+			// Renderer#drawImage()でサーフェス上の一部を描画するとき、
+			// 指定した部分に隣接する画素がにじみ出る現象が確認されている。
+			// ここれではそれを避けるため1pixelの余白を与えている。
+			width += 1;
+			height += 1;
+
+			var slot = this._getSurfaceAtlasSlot(this._emptySurfaceAtlasSlotHead, width, height);
+
+			if (!slot) {
+				return null;
+			}
+
+			var remainWidth = slot.width - width;
+			var remainHeight = slot.height - height;
+			var left: SurfaceAtlasSlot;
+			var right: SurfaceAtlasSlot;
+			if (remainWidth <= remainHeight) {
+				left = new SurfaceAtlasSlot(slot.x + width, slot.y, remainWidth, height);
+				right = new SurfaceAtlasSlot(slot.x, slot.y + height, slot.width, remainHeight);
+			} else {
+				left = new SurfaceAtlasSlot(slot.x, slot.y + height, width, remainHeight);
+				right = new SurfaceAtlasSlot(slot.x + width, slot.y, remainWidth, slot.height);
+			}
+
+			left.prev = slot.prev;
+			left.next = right;
+			if (left.prev === null) { // left is head
+				this._emptySurfaceAtlasSlotHead = left;
+			} else {
+				left.prev.next = left;
+			}
+
+			right.prev = left;
+			right.next = slot.next;
+			if (right.next) {
+				right.next.prev = right;
+			}
+
+			const acquiredSlot = new SurfaceAtlasSlot(slot.x, slot.y, width, height);
+
+			this._updateUsedRectangleAreaSize(acquiredSlot);
+
+			return acquiredSlot;
+		}
+
+		/**
+		 * @private
+		 */
+		_updateUsedRectangleAreaSize(slot: SurfaceAtlasSlot): void {
+			const slotRight = slot.x + slot.width;
+			const slotBottom = slot.y + slot.height;
+			if (slotRight > this._usedRectangleAreaSize.width) {
+				this._usedRectangleAreaSize.width = slotRight;
+			}
+			if (slotBottom > this._usedRectangleAreaSize.height) {
+				this._usedRectangleAreaSize.height = slotBottom;
+			}
+		}
+
+		/**
+		 * @private
+		 */
+		_getSurfaceAtlasSlot(slot: SurfaceAtlasSlot, width: number, height: number): SurfaceAtlasSlot {
+			while (slot) {
+				if (slot.width >= width && slot.height >= height) {
+					return slot;
+				}
+				slot = slot.next;
+			}
+
+			return null;
+		}
+
+		/**
+		 * サーフェスの追加。
+		 *
+		 * @param surface サーフェスアトラス上に配置される画像のサーフェス。
+		 * @param rect サーフェス上の領域を表す矩形。この領域内の画像がサーフェスアトラス上に複製・配置される。
+		 */
+		addSurface(surface: Surface, rect: CommonArea): SurfaceAtlasSlot {
+			var slot = this._acquireSurfaceAtlasSlot(rect.width, rect.height);
+			if (!slot) {
+				return null;
+			}
+
+			var renderer = this._surface.renderer();
+			renderer.begin();
+			renderer.drawImage(surface, rect.x, rect.y, rect.width, rect.height, slot.x, slot.y);
+			renderer.end();
+
+			return slot;
+		}
+
+		/**
+			* このSurfaceAtlasの破棄を行う。
+			* 以後、このSurfaceを利用することは出来なくなる。
+			*/
+		destroy(): void {
+			this._surface.destroy();
+		}
+
+		/**
+		 * このSurfaceAtlasが破棄済であるかどうかを判定する。
+		 */
+		destroyed(): boolean {
+			return this._surface.destroyed();
+		}
+
+		/**
+		 * _surfaceを複製する。
+		 *
+		 * 複製されたSurfaceは文字を格納するのに必要な最低限のサイズになる。
+		 */
+		duplicateSurface(resourceFactory: ResourceFactory): Surface {
+			const src = this._surface;
+			const dst = resourceFactory.createSurface(this._usedRectangleAreaSize.width, this._usedRectangleAreaSize.height);
+
+			const renderer = dst.renderer();
+			renderer.begin();
+			renderer.drawImage(src, 0, 0, this._usedRectangleAreaSize.width, this._usedRectangleAreaSize.height, 0, 0);
+			renderer.end();
+
+			return dst;
+		}
+	}
+
+	/**
+	 * DynamicFontで使用される、SurfaceAtlasを管理する。
+	 */
+	export class SurfaceAtlasSet {
+		/**
+		 * SurfaceAtlas保持数初期値
+		 */
+		static INITIAL_SURFACEATLAS_SIZE: number = 10;
+
+		/**
+		 * @private
+		 */
+		_surfaceAtlases: SurfaceAtlas[];
+
+		/**
+		 * @private
+		 */
+		_maxAtlasSize: number;
+
+		/**
+		 * @private
+		 */
+		_resourceFactory: ResourceFactory;
+
+		constructor(game: Game) {
+			this._surfaceAtlases = [];
+			this.maxAtlasSize = SurfaceAtlasSet.INITIAL_SURFACEATLAS_SIZE;
+			this._resourceFactory = game.resourceFactory;
+		}
+
+		/**
+		 * サーフェスアトラスを追加する。
+		 * @param surfaceAtlas SurfaceAtlas
+		 */
+		addAtlas(surfaceAtlas: SurfaceAtlas): void {
+			this._surfaceAtlases.push(surfaceAtlas);
+		}
+		/**
+		 * 引数で指定されたindexのサーフェスアトラスを取得する。
+		 * @param index 取得対象のインデックス
+		 */
+		getAtlasFromIndex(index: number): SurfaceAtlas {
+			return this._surfaceAtlases[index];
+		}
+		/**
+		 * サーフェスアトラスの保持数を取得する。
+		 */
+		get atlasLength(): number {
+			return this._surfaceAtlases.length;
+		}
+		/**
+		 * 最大サーフェスアトラス保持数取得する。
+		 */
+		get maxAtlasSize(): number {
+			return this._maxAtlasSize;
+		}
+		/**
+		 * 最大アトラス保持数設定する。
+		 */
+		set maxAtlasSize(value: number) {
+			this._maxAtlasSize = value;
+		}
+
+		/**
+		 * 使用度の低いサーフェスアトラスを配列から削除する。
+		 */
+		removeLowUseAtlas(): SurfaceAtlas {
+			var minScore = Number.MAX_VALUE;
+			var lowScoreAtlasIndex = -1;
+			for (var i = 0; i < this._surfaceAtlases.length; i++) {
+				if (this._surfaceAtlases[i]._accessScore <= minScore) {
+					minScore = this._surfaceAtlases[i]._accessScore;
+					lowScoreAtlasIndex = i;
+				}
+			}
+			let removedAtlas = this._surfaceAtlases.splice(lowScoreAtlasIndex, 1)[0];
+
+			return removedAtlas;
+		}
+
+		/**
+		 * 最新のサーフェスアトラスにグリフを追加する。
+		 * @param glyph グリフ
+		 */
+		addToAtlas(glyph: Glyph): SurfaceAtlas {
+			let atlas: SurfaceAtlas = null;
+			let slot: SurfaceAtlasSlot = null;
+			let area = {
+				x: glyph.x,
+				y: glyph.y,
+				width: glyph.width,
+				height: glyph.height
+			};
+
+			if (this._surfaceAtlases.length > 0) {
+				atlas = this._surfaceAtlases[this._surfaceAtlases.length - 1];
+				slot = atlas.addSurface(glyph.surface, area);
+			}
+
+			if (!slot) {
+				return null;
+			}
+
+			glyph.surface.destroy();
+			glyph.surface = atlas._surface;
+			glyph.x = slot.x;
+			glyph.y = slot.y;
+
+			return atlas;
+		}
+
+		/**
+		 * サーフェスアトラスの再割り当てを行う。
+		 * @param _glyphs グリフ配列
+		 * @param atlasSize サーフェスアトラスが保持していSurfaceのサイズ
+		 */
+		reallocateAtlas(_glyphs: { [key: number]: Glyph }, atlasSize: CommonSize): void {
+			if (this._surfaceAtlases.length >= this.maxAtlasSize) {
+				let atlas = this.removeLowUseAtlas();
+				let glyphs = _glyphs;
+
+				for (let key in glyphs) {
+					if (glyphs.hasOwnProperty(key)) {
+						var glyph = glyphs[key];
+						if (glyph.surface === atlas._surface) {
+							glyph.surface = null;
+							glyph.isSurfaceValid = false;
+							glyph._atlas = null;
+						}
+					}
+				}
+				atlas.destroy();
+			}
+
+			this._surfaceAtlases.push(this._resourceFactory.createSurfaceAtlas(atlasSize.width, atlasSize.height));
+		}
+	}
+}

--- a/src/SurfaceAtlasSet.ts
+++ b/src/SurfaceAtlasSet.ts
@@ -248,7 +248,7 @@ namespace g {
 		/**
 		 * 削除対象のSurfaceAtlas
 		 */
-		surfaceAtlas: SurfaceAtlas[];
+		surfaceAtlases: SurfaceAtlas[];
 
 		/**
 		 * 削除対象のグリフ
@@ -318,7 +318,7 @@ namespace g {
 		 */
 		_deleteAtlas(delteNum: number): void {
 			const removedObject = this._removeLeastFrequentlyUsedAtlas(delteNum);
-			const removedAtlases = removedObject.surfaceAtlas;
+			const removedAtlases = removedObject.surfaceAtlases;
 			for (let i = 0; i < removedAtlases.length; ++i) {
 				removedAtlases[i].destroy();
 			}
@@ -346,7 +346,7 @@ namespace g {
 				removedGlyphs.push(this._atlasGlyphsTable.splice(lowScoreAtlasIndex, 1)[0]);
 			}
 
-			return {surfaceAtlas: removedAtlases, glyphs: removedGlyphs};
+			return {surfaceAtlases: removedAtlases, glyphs: removedGlyphs};
 		}
 
 		/**
@@ -382,7 +382,7 @@ namespace g {
 		_reallocateAtlas(): void {
 			if (this._surfaceAtlases.length >= this._maxAtlasNum) {
 				const removedObject = this._removeLeastFrequentlyUsedAtlas(1);
-				const atlas = removedObject.surfaceAtlas[0];
+				const atlas = removedObject.surfaceAtlases[0];
 				const glyphs = removedObject.glyphs[0];
 
 				for (let i = 0; i < glyphs.length; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@
 /// <reference path="OperationPluginManager.ts" />
 /// <reference path="executeEnvironmentVariables.ts" />
 /// <reference path="DynamicFont.ts" />
+/// <reference path="SurfaceAtlasSet.ts" />
 
 // non-ordered files
 /// <reference path="AudioSystemManager.ts" />

--- a/unreleased-changes/update_sharing_of_surfaceAtlas.md
+++ b/unreleased-changes/update_sharing_of_surfaceAtlas.md
@@ -1,0 +1,5 @@
+
+その他変更
+ * DynamicFontのメモリ節減対応
+    * `g.DynamicFont` で使用する `g.SurfaceAtlas` の `width`, `height` の初期値を2048から512へ変更。
+    * `g.DynamicFont` で使用する `g.SurfaceAtlas` を共有化。

--- a/unreleased-changes/update_sharing_of_surfaceAtlas.md
+++ b/unreleased-changes/update_sharing_of_surfaceAtlas.md
@@ -2,4 +2,4 @@
 その他変更
  * DynamicFontのメモリ節減対応
     * `g.DynamicFont` で使用する `g.SurfaceAtlas` の `width`, `height` の初期値を2048から512へ変更。
-    * `g.DynamicFont` で使用する `g.SurfaceAtlas` を共有化。
+    * `g.DynamicFont` で使用する `g.SurfaceAtlas` を共有化する機能を追加。


### PR DESCRIPTION
## このpull requestが解決する内容

`g.DynamicFont` のメモリ節減の為の修正です。

- `g.DynamicFont` で使用する `g.SurfaceAtlas` の `width`, `height` の初期値を `2048` から `512` へ変更

- `g.DynamicFont` で使用する `g.SurfaceAtlas` を共有化。
  - `g.SurfaceAtlas` を管理する `g.SurfaeAtlasSet` を新規追加
    - `g.DynamicFont.ts` に記述していた `SurfaceAtlasSlot` と`SurfaceAtlas` クラスを`g.SurfaeAtlasSet,ts`へ移動
  - `g.DynamicFont` のインスタンス化時のパラメータに `DynamicFontHint` が存在する場合は、`DynamicFont` が管理する`SurfaceAtlasSet`を使用する。
`DynamicFontHint` が存在しない場合は、`g.game` が管理する `SurfaceAtlasSet` を使用する。
また、パラメータオブジェクトに `SurfacAtlasSet` が存在する場合は、渡された `SurfaceAtlasSet` を私用する。


## 破壊的な変更を含んでいるか?

- なし
