### PR TITLE
create glyph from string

### DIFF
--- a/src/BitmapFont.ts
+++ b/src/BitmapFont.ts
@@ -60,7 +60,8 @@ namespace g {
 		 * @param codeOrGraphemes 文字コード、もしくはgrapheme cluster
 		 */
 		glyphForCharacter(codeOrGraphemes: number | string): Glyph {
-			var g = this.map[codeOrGraphemes] || this.missingGlyph;
+			var code = (typeof codeOrGraphemes === "number") ? codeOrGraphemes : Util.charCodeAt(codeOrGraphemes, 0);
+			var g = this.map[code] || this.missingGlyph;
 
 			if (! g) {
 				return null;
@@ -73,7 +74,7 @@ namespace g {
 			var advanceWidth = g.advanceWidth === undefined ? w : g.advanceWidth;
 			var surface = (w === 0 || h === 0) ? undefined : this.surface;
 
-			return new Glyph(codeOrGraphemes, g.x, g.y, w, h, offsetX, offsetY, advanceWidth, surface, true);
+			return new Glyph(code, g.x, g.y, w, h, offsetX, offsetY, advanceWidth, surface, true);
 		}
 
 		/**

--- a/src/BitmapFont.ts
+++ b/src/BitmapFont.ts
@@ -56,11 +56,11 @@ namespace g {
 		}
 
 		/**
-		 * コードポイントに対応するグリフを返す。
-		 * @param code コードポイント
+		 * 文字コードに対応するグリフを返す。
+		 * @param codeOrGraphemes 文字コード、もしくはgrapheme cluster
 		 */
-		glyphForCharacter(code: number): Glyph {
-			var g = this.map[code] || this.missingGlyph;
+		glyphForCharacter(codeOrGraphemes: number | string): Glyph {
+			var g = this.map[codeOrGraphemes] || this.missingGlyph;
 
 			if (! g) {
 				return null;
@@ -73,7 +73,7 @@ namespace g {
 			var advanceWidth = g.advanceWidth === undefined ? w : g.advanceWidth;
 			var surface = (w === 0 || h === 0) ? undefined : this.surface;
 
-			return new Glyph(code, g.x, g.y, w, h, offsetX, offsetY, advanceWidth, surface, true);
+			return new Glyph(codeOrGraphemes, g.x, g.y, w, h, offsetX, offsetY, advanceWidth, surface, true);
 		}
 
 		/**

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -369,7 +369,7 @@ namespace g {
 		/**
 		 * @private
 		 */
-		_glyphs: {[key: number]: Glyph};
+		_glyphs: {[key: string]: Glyph};
 
 		/**
 		 * @private
@@ -449,13 +449,13 @@ namespace g {
 		 * - DynamicFont生成時に指定する文字サイズを小さくする
 		 * - アトラスの初期サイズ・最大サイズを大きくする
 		 *
-		 * @param code 文字コード
+		 * @param codeOrGraphemes 文字コード、もしくはgrapheme cluster
 		 */
-		glyphForCharacter(code: number): Glyph {
-			var glyph = this._glyphs[code];
+		glyphForCharacter(codeOrGraphemes: number | string): Glyph {
+			var glyph = this._glyphs[codeOrGraphemes];
 
 			if (! (glyph && glyph.isSurfaceValid)) {
-				glyph = this._glyphFactory.create(code);
+				glyph = this._glyphFactory.create(codeOrGraphemes);
 
 				if (glyph.surface) { // 空白文字でなければアトラス化する
 
@@ -479,7 +479,7 @@ namespace g {
 					glyph._atlas = atlas;
 				}
 
-				this._glyphs[code] = glyph;
+				this._glyphs[codeOrGraphemes] = glyph;
 			}
 
 			// スコア更新

--- a/src/Font.ts
+++ b/src/Font.ts
@@ -15,8 +15,8 @@ namespace g {
 		 *
 		 * 取得に失敗するとnullが返る。
 		 *
-		 * @param code 文字コード
+		 * @param codeOrGraphemes 文字コード、もしくはgrapheme cluster
 		 */
-		glyphForCharacter(code: number): Glyph;
+		glyphForCharacter(codeOrGraphemes: number | string): Glyph;
 	}
 }

--- a/src/Glyph.ts
+++ b/src/Glyph.ts
@@ -23,7 +23,7 @@ namespace g {
 
 		/**
 		 * 文字のgrapheme、もしくはgrapheme cluser。
-		 * この値が `undefined` ではない時、 `this.code` はnullである。
+		 * この値がgrapheme cluserである時、 `this.code` は `null` である。
 		 */
 		graphemes: string;
 
@@ -102,7 +102,7 @@ namespace g {
 		            surface?: Surface, isSurfaceValid: boolean = !!surface) {
 			if (typeof codeOrGraphemes === "number") {
 				this.code = codeOrGraphemes;
-				this.graphemes = null;
+				this.graphemes = Util.codeToStr(codeOrGraphemes);
 			} else {
 				this.code = null;
 				this.graphemes = codeOrGraphemes;

--- a/src/Glyph.ts
+++ b/src/Glyph.ts
@@ -22,7 +22,7 @@ namespace g {
 		code: number;
 
 		/**
-		 * 文字のgrapheme、もしくはgrapheme cluser。
+		 * 一文字以上のgrapheme cluser。
 		 * この値がgrapheme cluserである時、 `this.code` は `null` である。
 		 */
 		graphemes: string;

--- a/src/Glyph.ts
+++ b/src/Glyph.ts
@@ -22,6 +22,12 @@ namespace g {
 		code: number;
 
 		/**
+		 * 文字のgrapheme、もしくはgrapheme cluser。
+		 * この値が `undefined` ではない時、 `this.code` はnullである。
+		 */
+		graphemes: string;
+
+		/**
 		 * サーフェス上の文字のX座標。
 		 *
 		 * `this.surface` が `undefined` である時、この値は不定である。
@@ -91,10 +97,16 @@ namespace g {
 		/**
 		 * `Glyph` のインスタンスを生成する。
 		 */
-		constructor(code: number, x: number, y: number, width: number, height: number,
+		constructor(codeOrGraphemes: number | string, x: number, y: number, width: number, height: number,
 		            offsetX: number = 0, offsetY: number = 0, advanceWidth: number = width,
 		            surface?: Surface, isSurfaceValid: boolean = !!surface) {
-			this.code = code;
+			if (typeof codeOrGraphemes === "number") {
+				this.code = codeOrGraphemes;
+				this.graphemes = null;
+			} else {
+				this.code = null;
+				this.graphemes = codeOrGraphemes;
+			}
 			this.x = x;
 			this.y = y;
 			this.width = width;

--- a/src/GlyphFactory.ts
+++ b/src/GlyphFactory.ts
@@ -94,6 +94,6 @@ namespace g {
 		 *
 		 * @param code 文字コード
 		 */
-		abstract create(code: number): Glyph;
+		abstract create(code: number | string): Glyph;
 	}
 }

--- a/src/GlyphFactory.ts
+++ b/src/GlyphFactory.ts
@@ -94,6 +94,6 @@ namespace g {
 		 *
 		 * @param codeOrGraphemes 文字コード、もしくはgrapheme cluster
 		 */
-		abstract create(code: number | string): Glyph;
+		abstract create(codeOrGraphemes: number | string): Glyph;
 	}
 }

--- a/src/GlyphFactory.ts
+++ b/src/GlyphFactory.ts
@@ -92,7 +92,7 @@ namespace g {
 		 *
 		 * `DynamicFont` はこれを用いてグリフを生成する。
 		 *
-		 * @param code 文字コード
+		 * @param codeOrGraphemes 文字コード、もしくはgrapheme cluster
 		 */
 		abstract create(code: number | string): Glyph;
 	}

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -283,5 +283,14 @@ namespace g {
 				}
 			}
 		}
+
+		/**
+		 * 文字コードを文字列に変換する。
+		 * 
+		 * @param code 文字コード
+		 */
+		export function codeToStr(code: number): string {
+			return (code & 0xFFFF0000) ? String.fromCharCode((code & 0xFFFF0000) >>> 16, code & 0xFFFF) : String.fromCharCode(code);
+		}
 	}
 }


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
絵文字が合成された grapheme cluster を扱えるようにするため、 `GlyphFactory#create()` でstring型を受け取れるように修正します。

## 破壊的な変更を含んでいるか?

- あり
`Glyph#code` が `null` になるケースが発生します。
これは従来通りの使い方では起こりえませんが、grapheme clusterを引数に与えた場合に起こります。

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

