### PR TITLE
Update to add glyph.isSurfaceValid check before drawImage of Label

### DIFF
--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -255,6 +255,7 @@ namespace g {
 						return null;
 					}
 					glyph._atlas = atlas;
+					glyph._atlas._accessScore += 1;
 				}
 
 				this._glyphs[code] = glyph;
@@ -263,7 +264,6 @@ namespace g {
 			// スコア更新
 			// NOTE: LRUを捨てる方式なら単純なタイムスタンプのほうがわかりやすいかもしれない
 			// NOTE: 正確な時刻は必要ないはずで、インクリメンタルなカウンタで代用すればDate()生成コストは省略できる
-			glyph._atlas._accessScore += 1;
 			for (var i = 0; i < this._atlasSet.getAtlasNum(); i++) {
 				var atlas = this._atlasSet.getAtlas(i);
 				atlas._accessScore /= 2;

--- a/src/Label.ts
+++ b/src/Label.ts
@@ -184,6 +184,15 @@ namespace g {
 				var glyphScale = this.fontSize / this.font.size;
 				var glyphWidth = glyph.advanceWidth * glyphScale;
 
+				var code = glyph.code;
+				if (!glyph.isSurfaceValid) {
+					glyph = this.font.glyphForCharacter(code);
+					if (!glyph) {
+						this._outputOfWarnLogWithNoGlyph(code, "renderCache()");
+						continue;
+					}
+				}
+
 				if (glyph.surface) { // 非空白文字
 					textRenderer.save();
 					textRenderer.transform([glyphScale, 0, 0, glyphScale, 0, 0]);
@@ -258,11 +267,7 @@ namespace g {
 
 				var glyph = this.font.glyphForCharacter(code);
 				if (! glyph) {
-					const str = (code & 0xFFFF0000) ? String.fromCharCode((code & 0xFFFF0000) >>> 16, code & 0xFFFF) : String.fromCharCode(code);
-					this.game().logger.warn(
-						"Label#_invalidateSelf(): failed to get a glyph for '" + str + "' " +
-						"(BitmapFont might not have the glyph or DynamicFont might create a glyph larger than its atlas)."
-					);
+					this._outputOfWarnLogWithNoGlyph(code, "_invalidateSelf()");
 					continue;
 				}
 
@@ -285,6 +290,14 @@ namespace g {
 			}
 
 			this.height = maxHeight * glyphScale;
+		}
+
+		private _outputOfWarnLogWithNoGlyph(code: number, functionName: string): void {
+			const str = (code & 0xFFFF0000) ? String.fromCharCode((code & 0xFFFF0000) >>> 16, code & 0xFFFF) : String.fromCharCode(code);
+			this.game().logger.warn(
+				"Label#" + functionName + ": failed to get a glyph for '" + str + "' " +
+				"(BitmapFont might not have the glyph or DynamicFont might create a glyph larger than its atlas)."
+			);
 		}
 	}
 }

--- a/unreleased-changes/update-to-add-check-before-drawimage-of-label.md
+++ b/unreleased-changes/update-to-add-check-before-drawimage-of-label.md
@@ -1,0 +1,6 @@
+
+その他変更
+ * Labelの描画タイミングで、`glyph.surface` が存在しない場合の対応
+   - `drawImage` 前に、`glyph.isSurfaceValid` にてチェックを行い、破棄されていた場合、改めてglyphの作成を行うよう修正。
+
+


### PR DESCRIPTION
## このpull requestが解決する内容

LabelのdrawImage直前に `glyph.surface` が破棄されていて、存在しない surfaceをdrawしようとするケースがある。
drawImageの前に `glyph.isSurfaceValid` でcheckを行い、破棄されている場合は、glyphの作成を実行するよう修正。

## 破壊的な変更を含んでいるか?

- なし
