### PR TITLE
Stop SE during skipping

### DIFF
--- a/spec/AudioSystemSpec.js
+++ b/spec/AudioSystemSpec.js
@@ -196,11 +196,11 @@ describe("test AudioPlayer", function() {
 		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 
-		// 再生速度非サポートでも、非等倍になった時点で鳴っていた音は止めない
+		// 再生速度非サポートでも、非等倍になった時点で鳴っていた音を止める
 		system._setPlaybackRate(0.6);
 		expect(player1._playbackRate).toBe(0.6);
 		expect(playedCalled).toBe(1);
-		expect(stoppedCalled).toBe(0);
+		expect(stoppedCalled).toBe(1);
 
 		// 非等倍再生時、開始直後に止まる
 		player1.stop();

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -312,7 +312,7 @@ namespace g {
 				players[i]._changePlaybackRate(this._playbackRate);
 
 				// 再生速度非対応の場合のフォールバック: 即止める
-				if (this._playbackRate !== 1.0) {
+				if (!players[i]._supportsPlaybackRate() && this._playbackRate !== 1.0) {
 					players[i].stop();
 				}
 			}

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -320,10 +320,9 @@ namespace g {
 			if (e.player._supportsPlaybackRate())
 				return;
 
-			// 再生速度非対応の場合のフォールバック: 鳴らさず即止める
-			if (this._playbackRate !== 1.0) {
-				e.player.stop();
-			}
+			// 再生速度非対応の場合のフォールバック: 即ミュートにする。
+			const isMuted = this._playbackRate !== 1.0;
+			this._setMuted(isMuted);
 		}
 
 		/**

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -310,6 +310,11 @@ namespace g {
 			var players = this.players;
 			for (var i = 0; i < players.length; ++i) {
 				players[i]._changePlaybackRate(this._playbackRate);
+
+				// 再生速度非対応の場合のフォールバック: 即止める
+				if (this._playbackRate !== 1.0) {
+					players[i].stop();
+				}
 			}
 		}
 
@@ -320,9 +325,10 @@ namespace g {
 			if (e.player._supportsPlaybackRate())
 				return;
 
-			// 再生速度非対応の場合のフォールバック: 即ミュートにする。
-			const isMuted = this._playbackRate !== 1.0;
-			this._setMuted(isMuted);
+			// 再生速度非対応の場合のフォールバック: 鳴らさず即止める
+			if (this._playbackRate !== 1.0) {
+				e.player.stop();
+			}
 		}
 
 		/**

--- a/unreleased-changes/fix-sound-audiosystem.md
+++ b/unreleased-changes/fix-sound-audiosystem.md
@@ -1,4 +1,3 @@
 
 その他変更
- * 早送り中に `g.SoundAudioSystem#_onPlayerPlayed` で実行していた 効果音の停止をミュートへ変更。
-
+ * 早送り中は効果音(g.SoundAudioSystem)をいっさい鳴らさないように修正。

--- a/unreleased-changes/fix-sound-audiosystem.md
+++ b/unreleased-changes/fix-sound-audiosystem.md
@@ -1,0 +1,4 @@
+
+その他変更
+ * 早送り中に `g.SoundAudioSystem#_onPlayerPlayed` で実行していた 効果音の停止をミュートへ変更。
+


### PR DESCRIPTION
## このpull requestが解決する内容

- 早送り中は効果音を(`g.SoundAudioSystem`) をいっさい鳴らさないようにする。
この変更より、早送り前に再生されていた効果音も早送りに入った瞬間に聞こえなくなる。

## 破壊的な変更を含んでいるか?

- なし
