### PR TITLE
単体テストの実行範囲を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## Unreleased changes
+* 内部で使用しているテストフレームワークの変更
+
 ## 2.4.11
 
 不具合修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## Unreleased changes
+## 2.4.12
 * 内部で使用しているテストフレームワークの変更
 
 ## 2.4.11

--- a/jest.config.js
+++ b/jest.config.js
@@ -142,7 +142,7 @@ module.exports = {
   //   "**/?(*.)+(spec|test).[tj]s?(x)"
   // ],
   // testMatch: ["./**/*[sS]pec.js"],
-  testMatch: ["./**/SceneSpec.js"],
+  testMatch: ["./**/*[sS]pec.js"],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   // testPathIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "devDependencies": {


### PR DESCRIPTION
## このpull requestが解決する内容
* jestによる単体テストがspec/SceneSpec.jsのみに限定されてしまっていたので、specディレクトリ以下の全ての`spec/~Spec.js`に対してjestが走るように修正

## 破壊的な変更を含んでいるか?
* なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

