### PR TITLE
fix: set systemId for audio assets unless specified

### DIFF
--- a/spec/AssetManagerSpec.js
+++ b/spec/AssetManagerSpec.js
@@ -7,6 +7,10 @@ describe("test AssetManager", function() {
 		height: 320,
 		fps: 30,
 		audio: {
+			"user": {
+				loop: false,
+				hint: { streaming: false }
+			},
 			"user2": {
 				loop: true,
 				hint: { streaming: true }
@@ -140,7 +144,7 @@ describe("test AssetManager", function() {
 		expect(manager.configuration.corge.systemId).toEqual("user");
 		expect(manager.configuration.corge.duration).toEqual(gameConfiguration.assets.corge.duration);
 		expect(manager.configuration.corge.loop).toEqual(false);
-		expect(manager.configuration.corge.hint).toEqual({});
+		expect(manager.configuration.corge.hint).toEqual({ streaming: false });
 
 		expect(manager.configuration.grault.systemId).toEqual("user2");
 		expect(manager.configuration.grault.duration).toEqual(gameConfiguration.assets.grault.duration);
@@ -198,6 +202,32 @@ describe("test AssetManager", function() {
 		expect(function () { new mock.Game({ width: 320, height: "320" /* not a number */, assets: legalConf }, "/foo/bar/"); }).toThrowError("AssertionError");
 		expect(function () { new mock.Game({ width: 320, height: 320, fps: "60" /* not a number */, assets: legalConf }, "/foo/bar/"); }).toThrowError("AssertionError");
 		expect(function () { new mock.Game({ width: 320, height: 320, fps: 120 /* out of (0-60] */, assets: legalConf }, "/foo/bar/"); }).toThrowError("AssertionError");
+	});
+
+	it("normalizes audio assets declarations", function () {
+		var configuration = {
+			width: 320,
+			height: 320,
+			fps: 30,
+			assets: {
+				foo: {
+					type: "audio",
+					path: "audio/foo",
+					virtualPath: "audio/foo"
+					// no systemId given: treated as "sound"
+				}
+			}
+		};
+		var game = new mock.Game(configuration, "/");
+		var manager = game._assetManager;
+		expect(manager.configuration.foo.type).toBe("audio");
+		expect(manager.configuration.foo.path).toBe("audio/foo");
+		expect(manager.configuration.foo.virtualPath).toBe("audio/foo");
+		expect(manager.configuration.foo.duration).toBe(0);
+		expect(manager.configuration.foo.global).toBe(false);
+		expect(manager.configuration.foo.hint).toEqual({ streaming: false });
+		expect(manager.configuration.foo.loop).toBe(false);
+		expect(manager.configuration.foo.systemId).toBe("sound");
 	});
 
 	it("loads/unloads an asset", function (done) {

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -281,12 +281,16 @@ namespace g {
 					// durationというメンバは後から追加したため、古いgame.jsonではundefinedになる場合がある
 					if (conf.duration === undefined)
 						conf.duration = 0;
+					if (!conf.systemId || !audioSystemConfMap[conf.systemId])
+						conf.systemId = this.game.defaultAudioSystemId;
 					const audioSystemConf = audioSystemConfMap[conf.systemId];
+					if (!audioSystemConf)
+						throw ExceptionFactory.createAssertionError("AssetManager#_normalize: unknown systemId for the audio asset: " + p);
 					if (conf.loop === undefined) {
-						conf.loop = !!audioSystemConf && !!audioSystemConf.loop;
+						conf.loop = !!audioSystemConf.loop;
 					}
 					if (conf.hint === undefined) {
-						conf.hint = audioSystemConf ? audioSystemConf.hint : {};
+						conf.hint = audioSystemConf.hint || { streaming: false };
 					}
 				}
 				if (conf.type === "video") {
@@ -331,7 +335,7 @@ namespace g {
 				asset.initialize(<ImageAssetHint>conf.hint);
 				return asset;
 			case "audio":
-				var system = conf.systemId ? this.game.audio[conf.systemId] : this.game.audio[this.game.defaultAudioSystemId];
+				var system = this.game.audio[conf.systemId] || this.game.audio[this.game.defaultAudioSystemId];
 				return resourceFactory.createAudioAsset(id, uri, conf.duration, system, conf.loop, <AudioAssetHint>conf.hint);
 			case "text":
 				return resourceFactory.createTextAsset(id, uri);


### PR DESCRIPTION
## このpull requestが解決する内容

実装が [仕様](https://akashic-games.github.io/guide/game-json.html) に沿っていませんでした。オーディオアセットの systemId は、省略された場合 `"sound"` 相当として扱われますが、 `hint` オプションの値が `"sound"` と食い違っていました。これを修正します。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

