### PR TITLE
Resolved dependencies around SurfaceAtlas

### DIFF
--- a/src/__tests__/DynamicFontSpec.ts
+++ b/src/__tests__/DynamicFontSpec.ts
@@ -23,7 +23,7 @@ describe("test DynamicFont", () => {
 		expect(font.strokeWidth).toBe(1);
 		expect(font.strokeColor).toBe("red");
 		expect(font.strokeOnly).toBe(true);
-		expect(font._atlasSet.getAtlasSize()).toEqual({
+		expect(font._atlasSet.getAtlasUsedSize()).toEqual({
 			height: 512,
 			width: 512
 		});
@@ -64,7 +64,7 @@ describe("test DynamicFont", () => {
 			maxAtlasHeight: 4000,
 			maxAtlasNum: 5
 		});
-		expect(font._atlasSet.getAtlasSize()).toEqual({
+		expect(font._atlasSet.getAtlasUsedSize()).toEqual({
 			height: 2000,
 			width: 1000
 		});

--- a/src/__tests__/SurfaceAtlasSetSpec.ts
+++ b/src/__tests__/SurfaceAtlasSetSpec.ts
@@ -9,7 +9,7 @@ describe("test SurfaceAtlasSet", () => {
 		surfaceAtlasSet = new SurfaceAtlasSet({ resourceFactory: runtime.game.resourceFactory });
 		expect(surfaceAtlasSet._surfaceAtlases).toEqual([]);
 		expect(surfaceAtlasSet.getMaxAtlasNum()).toEqual(SurfaceAtlasSet.INITIAL_MAX_SURFACEATLAS_NUM);
-		expect(surfaceAtlasSet.getAtlasSize()).toEqual({ width: 512, height: 512 });
+		expect(surfaceAtlasSet.getAtlasUsedSize()).toEqual({ width: 512, height: 512 });
 	});
 
 	it("初期化 パラメータあり", () => {
@@ -27,7 +27,7 @@ describe("test SurfaceAtlasSet", () => {
 		surfaceAtlasSet = new SurfaceAtlasSet(surfaceAtlasSetParams);
 		expect(surfaceAtlasSet._surfaceAtlases).toEqual([]);
 		expect(surfaceAtlasSet.getMaxAtlasNum()).toEqual(111);
-		expect(surfaceAtlasSet.getAtlasSize()).toEqual({ width: 1, height: 1 });
+		expect(surfaceAtlasSet.getAtlasUsedSize()).toEqual({ width: 1, height: 1 });
 	});
 
 	describe("removeLeastFrequentlyUsedAtlas", () => {

--- a/src/commons/SurfaceAtlas.ts
+++ b/src/commons/SurfaceAtlas.ts
@@ -118,6 +118,10 @@ export class SurfaceAtlas implements SurfaceAtlasLike {
 	 * サーフェスを追加する。
 	 *
 	 * @param surface 追加するサーフェス
+	 * @param offsetX サーフェス内におけるX方向のオフセット位置。0以上の数値でなければならない
+	 * @param offsetY サーフェス内におけるY方向のオフセット位置。0以上の数値でなければならない
+	 * @param width サーフェス内における矩形の幅。0より大きい数値でなければならない
+	 * @param height サーフェス内における矩形の高さ。0より大きい数値でなければならない
 	 */
 	addSurface(surface: SurfaceLike, offsetX: number, offsetY: number, width: number, height: number): SurfaceAtlasSlotLike {
 		const slot = this._acquireSurfaceAtlasSlot(width, height);

--- a/src/commons/SurfaceAtlas.ts
+++ b/src/commons/SurfaceAtlas.ts
@@ -155,7 +155,7 @@ export class SurfaceAtlas implements SurfaceAtlasLike {
 	/**
 	 * このSurfaceAtlasの大きさを取得する。
 	 */
-	getAtlasSize(): CommonSize {
+	getAtlasUsedSize(): CommonSize {
 		return this._usedRectangleAreaSize;
 	}
 

--- a/src/commons/SurfaceAtlas.ts
+++ b/src/commons/SurfaceAtlas.ts
@@ -1,5 +1,3 @@
-import { GlyphLike } from "../interfaces/GlyphLike";
-import { ResourceFactoryLike } from "../interfaces/ResourceFactoryLike";
 import { SurfaceAtlasLike } from "../interfaces/SurfaceAtlasLike";
 import { SurfaceAtlasSlotLike } from "../interfaces/SurfaceAtlasSlotLike";
 import { SurfaceLike } from "../interfaces/SurfaceLike";
@@ -117,19 +115,19 @@ export class SurfaceAtlas implements SurfaceAtlasLike {
 	}
 
 	/**
-	 * サーフェスの追加。
+	 * サーフェスを追加する。
 	 *
-	 * @param glyph グリフのサーフェスが持つ情報をSurfaceAtlasへ配置
+	 * @param surface 追加するサーフェス
 	 */
-	addSurface(glyph: GlyphLike): SurfaceAtlasSlotLike {
-		var slot = this._acquireSurfaceAtlasSlot(glyph.width, glyph.height);
+	addSurface(surface: SurfaceLike, offsetX: number, offsetY: number, width: number, height: number): SurfaceAtlasSlotLike {
+		const slot = this._acquireSurfaceAtlasSlot(width, height);
 		if (!slot) {
 			return null;
 		}
 
-		var renderer = this._surface.renderer();
+		const renderer = this._surface.renderer();
 		renderer.begin();
-		renderer.drawImage(glyph.surface, glyph.x, glyph.y, glyph.width, glyph.height, slot.x, slot.y);
+		renderer.drawImage(surface, offsetX, offsetY, width, height, slot.x, slot.y);
 		renderer.end();
 
 		return slot;
@@ -151,20 +149,10 @@ export class SurfaceAtlas implements SurfaceAtlasLike {
 	}
 
 	/**
-	 * _surfaceを複製する。
-	 *
-	 * 複製されたSurfaceは文字を格納するのに必要な最低限のサイズになる。
+	 * このSurfaceAtlasの大きさを取得する。
 	 */
-	duplicateSurface(resourceFactory: ResourceFactoryLike): SurfaceLike {
-		const src = this._surface;
-		const dst = resourceFactory.createSurface(this._usedRectangleAreaSize.width, this._usedRectangleAreaSize.height);
-
-		const renderer = dst.renderer();
-		renderer.begin();
-		renderer.drawImage(src, 0, 0, this._usedRectangleAreaSize.width, this._usedRectangleAreaSize.height, 0, 0);
-		renderer.end();
-
-		return dst;
+	getAtlasSize(): CommonSize {
+		return this._usedRectangleAreaSize;
 	}
 
 	getAccessScore(): number {

--- a/src/commons/SurfaceAtlasSet.ts
+++ b/src/commons/SurfaceAtlasSet.ts
@@ -145,7 +145,7 @@ export class SurfaceAtlasSet implements SurfaceAtlasSetLike, Destroyable {
 		for (let i = 0; i < this._surfaceAtlases.length; ++i) {
 			const index = (this._currentAtlasIndex + i) % this._surfaceAtlases.length;
 			const atlas = this._surfaceAtlases[index];
-			const slot = atlas.addSurface(glyph);
+			const slot = atlas.addSurface(glyph.surface, glyph.x, glyph.y, glyph.width, glyph.height);
 
 			if (slot) {
 				this._currentAtlasIndex = index;

--- a/src/commons/SurfaceAtlasSet.ts
+++ b/src/commons/SurfaceAtlasSet.ts
@@ -250,7 +250,7 @@ export class SurfaceAtlasSet implements SurfaceAtlasSetLike, Destroyable {
 	 * このメソッドは、このSurfaceAtlasSetに紐づいている `DynamnicFont` の `glyphForCharacter()` から暗黙に呼び出される。
 	 * 通常、ゲーム開発者がこのメソッドを呼び出す必要はない。
 	 */
-	getAtlasSize(): CommonSize {
+	getAtlasUsedSize(): CommonSize {
 		return this._atlasSize;
 	}
 

--- a/src/domain/DynamicFont.ts
+++ b/src/domain/DynamicFont.ts
@@ -321,7 +321,7 @@ export class DynamicFont extends Font {
 		// そのために this.size をコンストラクタの第４引数に与えることにする。
 		const missingGlyph = glyphAreaMap[missingGlyphCharCodePoint];
 		const atlas = this._atlasSet.getAtlas(0);
-		const size = atlas.getAtlasSize();
+		const size = atlas.getAtlasUsedSize();
 		const surface = this._resourceFactory.createSurface(size.width, size.height);
 		const renderer = surface.renderer();
 		renderer.begin();

--- a/src/domain/DynamicFont.ts
+++ b/src/domain/DynamicFont.ts
@@ -319,15 +319,21 @@ export class DynamicFont extends Font {
 		// デフォルト値である。ここでは必ず与えているのでデフォルト値としては利用されない。
 		// しかし defaultGlyphHeight は BitmapFont#size にも用いられる。
 		// そのために this.size をコンストラクタの第４引数に与えることにする。
-		let missingGlyph = glyphAreaMap[missingGlyphCharCodePoint];
-		const surface = this._atlasSet.getAtlas(0).duplicateSurface(this._resourceFactory);
+		const missingGlyph = glyphAreaMap[missingGlyphCharCodePoint];
+		const atlas = this._atlasSet.getAtlas(0);
+		const size = atlas.getAtlasSize();
+		const surface = this._resourceFactory.createSurface(size.width, size.height);
+		const renderer = surface.renderer();
+		renderer.begin();
+		renderer.drawImage(atlas._surface, 0, 0, size.width, size.height, 0, 0);
+		renderer.end();
 
 		const bitmapFont = new BitmapFont({
 			src: surface,
 			map: glyphAreaMap,
 			defaultGlyphWidth: 0,
 			defaultGlyphHeight: this.size,
-			missingGlyph: missingGlyph
+			missingGlyph
 		});
 		return bitmapFont;
 	}

--- a/src/interfaces/SurfaceAtlasLike.ts
+++ b/src/interfaces/SurfaceAtlasLike.ts
@@ -23,6 +23,10 @@ export interface SurfaceAtlasLike extends Destroyable {
 	 * サーフェスを追加する。
 	 *
 	 * @param surface 追加するサーフェス
+	 * @param offsetX サーフェス内におけるX方向のオフセット位置。0以上の数値でなければならない
+	 * @param offsetY サーフェス内におけるY方向のオフセット位置。0以上の数値でなければならない
+	 * @param width サーフェス内における矩形の幅。0より大きい数値でなければならない
+	 * @param height サーフェス内における矩形の高さ。0より大きい数値でなければならない
 	 */
 	addSurface(surface: SurfaceLike, offsetX: number, offsetY: number, width: number, height: number): SurfaceAtlasSlotLike;
 

--- a/src/interfaces/SurfaceAtlasLike.ts
+++ b/src/interfaces/SurfaceAtlasLike.ts
@@ -33,5 +33,5 @@ export interface SurfaceAtlasLike extends Destroyable {
 	/**
 	 * サーフェスアトラスの大きさを取得する。
 	 */
-	getAtlasSize(): CommonSize;
+	getAtlasUsedSize(): CommonSize;
 }

--- a/src/interfaces/SurfaceAtlasLike.ts
+++ b/src/interfaces/SurfaceAtlasLike.ts
@@ -1,6 +1,5 @@
+import { CommonSize } from "../types/commons";
 import { Destroyable } from "../types/Destroyable";
-import { GlyphLike } from "./GlyphLike";
-import { ResourceFactoryLike } from "./ResourceFactoryLike";
 import { SurfaceAtlasSlotLike } from "./SurfaceAtlasSlotLike";
 import { SurfaceLike } from "./SurfaceLike";
 
@@ -8,8 +7,6 @@ import { SurfaceLike } from "./SurfaceLike";
  * サーフェスアトラス。
  *
  * 与えられたサーフェスの指定された領域をコピーし一枚のサーフェスにまとめる。
- *
- * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
  */
 export interface SurfaceAtlasLike extends Destroyable {
 	/**
@@ -23,16 +20,14 @@ export interface SurfaceAtlasLike extends Destroyable {
 	_accessScore: number;
 
 	/**
-	 * サーフェスの追加。
+	 * サーフェスを追加する。
 	 *
-	 * @param glyph グリフのサーフェスが持つ情報をSurfaceAtlasへ配置
+	 * @param surface 追加するサーフェス
 	 */
-	addSurface(glyph: GlyphLike): SurfaceAtlasSlotLike;
+	addSurface(surface: SurfaceLike, offsetX: number, offsetY: number, width: number, height: number): SurfaceAtlasSlotLike;
 
 	/**
-	 * _surfaceを複製する。
-	 *
-	 * 複製されたSurfaceは文字を格納するのに必要な最低限のサイズになる。
+	 * サーフェスアトラスの大きさを取得する。
 	 */
-	duplicateSurface(resourceFactory: ResourceFactoryLike): SurfaceLike;
+	getAtlasSize(): CommonSize;
 }

--- a/src/interfaces/SurfaceAtlasSetLike.ts
+++ b/src/interfaces/SurfaceAtlasSetLike.ts
@@ -87,7 +87,7 @@ export interface SurfaceAtlasSetLike extends Destroyable {
 	 * このメソッドは、このSurfaceAtlasSetに紐づいている `DynamnicFont` の `glyphForCharacter()` から暗黙に呼び出される。
 	 * 通常、ゲーム開発者がこのメソッドを呼び出す必要はない。
 	 */
-	getAtlasSize(): CommonSize;
+	getAtlasUsedSize(): CommonSize;
 
 	/**
 	 * サーフェスアトラスにグリフを追加する。


### PR DESCRIPTION
## このpull requestが解決する内容
SurfaceAtlas 周辺の依存関係を整理します。

### 修正前
![surface_atlas_before](https://user-images.githubusercontent.com/16933898/67838567-ec217e80-fb34-11e9-8d86-591b2f1ccd30.png)

### 修正後
![surface_atlas_after](https://user-images.githubusercontent.com/16933898/67838578-ef1c6f00-fb34-11e9-97e6-d84b41616fff.png)

## 破壊的な変更を含んでいるか?
- あり
  - `SurfaceAtlasSlotLike#addSurface()` の引数が変更されます
  - `SurfaceAtlasSlotLike#duplicateSurface()` が削除されます
  - `SurfaceAtlasSlotLike#getAtlasUsedSize()` が追加されます

