### PR TITLE
Modify default anchor point to (0, 0)

### DIFF
--- a/src/__tests__/CameraSpec.ts
+++ b/src/__tests__/CameraSpec.ts
@@ -93,7 +93,7 @@ describe("test Camera", () => {
 		cam.angle = angle;
 		cam.modified();
 		mat = cam.getMatrix();
-		expected.updateByInverse(320, 240, 1, 1, 10, 10, 100); // angle も逆方向に作用する
+		expected.updateByInverse(320, 240, 1, 1, 10, 10, 100, 0, 0); // angle も逆方向に作用する
 		expect(mat._matrix).toEqual(expected._matrix);
 	});
 
@@ -102,7 +102,7 @@ describe("test Camera", () => {
 		const cam = new Camera2D({ game: game, angle: 10, x: 10, y: 100, anchorX: 0.5, anchorY: 0.5 });
 		const expected = new PlainMatrix();
 		const mat = cam.getMatrix();
-		expected.updateByInverseWithAnchor(320, 240, 1, 1, 10, 10, 100, 0.5, 0.5);
+		expected.updateByInverse(320, 240, 1, 1, 10, 10, 100, 0.5, 0.5);
 		expect(mat._matrix).toEqual(expected._matrix);
 	});
 
@@ -135,7 +135,7 @@ describe("test Camera", () => {
 		cam._applyTransformToRenderer(renderer);
 		expect(renderer.methodCallHistory).toEqual(["transform"]);
 		const mat = new PlainMatrix();
-		mat.updateByInverse(320, 240, 1, 1, 10, 10, 100); // angle も逆方向に作用する
+		mat.updateByInverse(320, 240, 1, 1, 10, 10, 100, 0, 0); // angle も逆方向に作用する
 		expect(cam.getMatrix()._matrix).toEqual(mat._matrix);
 		expect(renderer.methodCallParamsHistory("transform")).toEqual([{ matrix: mat._matrix }]);
 	});

--- a/src/__tests__/ESpec.ts
+++ b/src/__tests__/ESpec.ts
@@ -74,7 +74,7 @@ describe("test E", () => {
 
 		// parameter object で初期化してもコンストラクタ内で modified() していないが、問題なく動作することを確認しておく
 		const mat = new PlainMatrix();
-		mat.update(5, 4, 2, 3, 0, 10, 20);
+		mat.update(5, 4, 2, 3, 0, 10, 20, 0, 0);
 		expect(e.getMatrix()._matrix).toEqual(mat._matrix);
 
 		e = new E({
@@ -548,8 +548,9 @@ describe("test E", () => {
 
 	it("findPointSource - rotated/scaled", () => {
 		e.touchable = true;
-		e.x = e.y = 100;
 		e.width = e.height = 100;
+		e.x = e.y = 100 + e.width / 2;
+		e.anchorX = e.anchorY = 0.5;
 
 		let found;
 		found = runtime.game.findPointSource({ x: 150, y: 150 });
@@ -1102,7 +1103,7 @@ describe("test E", () => {
 	it("calculateBoundingRect", () => {
 		const runtime = skeletonRuntime();
 		const scene = runtime.scene;
-		const e = new E({ scene: scene });
+		const e = new E({ scene });
 		e.width = 100;
 		e.height = 50;
 		e.scale(2);
@@ -1110,37 +1111,40 @@ describe("test E", () => {
 		e.modified();
 
 		const result = e.calculateBoundingRect();
-		expect(result.left).toBe(-50);
-		expect(result.right).toBe(150);
-		expect(result.top).toBe(-25);
-		expect(result.bottom).toBe(75);
+		expect(result.left).toBe(0);
+		expect(result.right).toBe(200);
+		expect(result.top).toBe(0);
+		expect(result.bottom).toBe(100);
 
-		const e2 = new E({ scene: scene });
+		const e2 = new E({ scene });
 		e2.width = 100;
 		e2.height = 50;
+		e2.anchor(0.5, 0.5);
 		e2.scale(2);
-		e2.moveTo(-100, -50);
+		e2.moveTo(-50, -10);
 		scene.append(e2);
 		e2.modified();
 
 		const result2 = e2.calculateBoundingRect();
 		expect(result2.left).toBe(-150);
 		expect(result2.right).toBe(50);
-		expect(result2.top).toBe(-75);
-		expect(result2.bottom).toBe(25);
+		expect(result2.top).toBe(-60);
+		expect(result2.bottom).toBe(40);
 
-		const e3 = new E({ scene: scene });
+		const e3 = new E({ scene });
 		e3.width = 300;
-		e3.height = 300;
+		e3.height = 400;
 		e3.scale(0.5);
+		e3.anchor(1, 1);
+		e3.moveTo(10, 20);
 		scene.append(e3);
 		e3.modified();
 
 		const result3 = e3.calculateBoundingRect();
-		expect(result3.left).toBe(300 / 4);
-		expect(result3.right).toBe((300 / 4) * 3);
-		expect(result3.top).toBe(300 / 4);
-		expect(result3.bottom).toBe((300 / 4) * 3);
+		expect(result3.left).toBe(-140);
+		expect(result3.right).toBe(10);
+		expect(result3.top).toBe(-180);
+		expect(result3.bottom).toBe(20);
 	});
 
 	it("calculateBoundingRect with camera", () => {

--- a/src/__tests__/HitTestSpec.ts
+++ b/src/__tests__/HitTestSpec.ts
@@ -51,100 +51,163 @@ describe("test E", () => {
 		expect(t).toBeUndefined();
 	});
 
-	it("拡大あり", () => {
-		const xp = 20;
-		const yp = 10;
+	it("拡大あり: アンカーポイントが左上", () => {
 		const scale = 2;
-		const w = (e.width * scale) / 4;
-		const h = (e.height * scale) / 4;
-		e.moveTo(xp, yp);
+		const fromX = 0;
+		const fromY = 0;
+		const toX = e.width * scale;
+		const toY = e.height * scale;
 		e.scale(scale);
-		for (let x = xp - w; x < e.width + w + xp; x++) {
-			for (let y = yp - h; y < e.height + h + yp; y++) {
-				const t = e.findPointSourceByPoint({ x: x, y: y });
+		for (let x = fromX; x < toX; x++) {
+			for (let y = fromY; y < toY; y++) {
+				const t = e.findPointSourceByPoint({ x, y });
 				expect(t.target).toBe(e);
 			}
 		}
 		let t = e.findPointSourceByPoint({
-			x: e.width + xp + w,
-			y: e.height + yp + h - 1
+			x: fromX,
+			y: fromY - 1
 		});
 		expect(t).toBeUndefined();
 		t = e.findPointSourceByPoint({
-			x: e.width + xp + w - 1,
-			y: e.height + yp + h
+			x: fromX - 1,
+			y: fromY
 		});
 		expect(t).toBeUndefined();
-		t = e.findPointSourceByPoint({ x: xp - w - 1, y: yp - h });
+		t = e.findPointSourceByPoint({ x: toX + 1, y: toY });
 		expect(t).toBeUndefined();
-		t = e.findPointSourceByPoint({ x: xp - w, y: yp - h - 1 });
+		t = e.findPointSourceByPoint({ x: toX, y: toY + 1 });
 		expect(t).toBeUndefined();
 	});
 
-	it("回転あり", () => {
-		const xp = 0;
-		const yp = 0;
-		const angle = 180;
-		e.moveTo(xp, yp);
-		e.angle = angle;
-		for (let x = xp + 0.1; x < e.width + xp; x++) {
-			for (let y = yp + 0.1; y < e.height + yp; y++) {
-				const t = e.findPointSourceByPoint({ x: x, y: y });
+	it("拡大あり: アンカーポイントが中央", () => {
+		const scale = 2;
+		const w = e.width * scale;
+		const h = e.height * scale;
+		const fromX = e.width / 2 - e.width * scale / 2;
+		const fromY = e.height / 2 - e.height * scale / 2;
+		const toX = fromX + w;
+		const toY = fromY + h;
+		e.moveTo(e.width / 2, e.height / 2);
+		e.anchor(0.5, 0.5);
+		e.scale(scale);
+		for (let x = fromX; x < toX; x++) {
+			for (let y = fromY; y < toY; y++) {
+				const t = e.findPointSourceByPoint({ x, y });
+				if (t.target == null)
+					console.log(x, y);
 				expect(t.target).toBe(e);
 			}
 		}
 		let t = e.findPointSourceByPoint({
-			x: e.width + xp + 0.1,
-			y: e.height + yp - 1
+			x: fromX,
+			y: fromY - 1
 		});
 		expect(t).toBeUndefined();
 		t = e.findPointSourceByPoint({
-			x: e.width + xp - 1,
-			y: e.height + yp + 0.1
+			x: fromX - 1,
+			y: fromY
 		});
 		expect(t).toBeUndefined();
-		t = e.findPointSourceByPoint({ x: xp - 1, y: yp });
+		t = e.findPointSourceByPoint({ x: toX + 1, y: toY });
 		expect(t).toBeUndefined();
-		t = e.findPointSourceByPoint({ x: xp, y: yp - 1 });
+		t = e.findPointSourceByPoint({ x: toX, y: toY + 1 });
+		expect(t).toBeUndefined();
+	});
+
+	it("回転あり: アンカーポイントが左上", () => {
+		const fromX = -e.height;
+		const fromY = 0;
+		const toX = 0;
+		const toY = e.width;
+		const angle = 90;
+		e.angle = angle;
+		for (let x = fromX + 0.1; x < toX; x++) {
+			for (let y = fromY + 0.1; y < toY; y++) {
+				const t = e.findPointSourceByPoint({ x, y });
+				if (t == null) console.log(x, y)
+				expect(t.target).toBe(e);
+			}
+		}
+		let t = e.findPointSourceByPoint({
+			x: fromX + 0.1,
+			y: fromY - 1
+		});
+		expect(t).toBeUndefined();
+		t = e.findPointSourceByPoint({
+			x: fromX - 1,
+			y: fromY + 0.1
+		});
+		expect(t).toBeUndefined();
+		t = e.findPointSourceByPoint({ x: toX + 1, y: toY });
+		expect(t).toBeUndefined();
+		t = e.findPointSourceByPoint({ x: toX, y: toY + 1 });
+		expect(t).toBeUndefined();
+	});
+
+	it("回転あり: アンカーポイントが中央", () => {
+		const fromX = 0;
+		const fromY = 0;
+		const toX = e.width;
+		const toY = e.height;
+		const angle = 180;
+		e.anchor(0.5, 0.5);
+		e.moveTo(e.width / 2, e.height/ 2);
+		e.angle = angle;
+		for (let x = fromX + 0.1; x < toX; x++) {
+			for (let y = fromY + 0.1; y < toY; y++) {
+				const t = e.findPointSourceByPoint({ x, y });
+				expect(t.target).toBe(e);
+			}
+		}
+		let t = e.findPointSourceByPoint({
+			x: fromX + 0.1,
+			y: fromY - 1
+		});
+		expect(t).toBeUndefined();
+		t = e.findPointSourceByPoint({
+			x: fromX - 1,
+			y: fromY + 0.1
+		});
+		expect(t).toBeUndefined();
+		t = e.findPointSourceByPoint({ x: toX + 1, y: toY });
+		expect(t).toBeUndefined();
+		t = e.findPointSourceByPoint({ x: toX, y: toY + 1 });
 		expect(t).toBeUndefined();
 	});
 
 	it("拡大+回転あり", () => {
-		const xp = 20;
-		const yp = 10;
-		const scale = 2;
-		const w = (e.width * scale) / 4;
-		const h = (e.height * scale) / 4;
 		const angle = 180;
-		e.moveTo(xp, yp);
+		const scale = 2;
+		const fromX = -e.width * scale;
+		const fromY = -e.height * scale;
+		const toX = 0;
+		const toY = 0;
 		e.scale(scale);
 		e.angle = angle;
-		for (let x = xp - w + 0.1; x < e.width + w + xp; x++) {
-			for (let y = yp - h + 0.1; y < e.height + h + yp; y++) {
-				const t = e.findPointSourceByPoint({ x: x, y: y });
+		for (let x = fromX + 0.1; x < toX; x++) {
+			for (let y = fromY + 0.1; y < toY; y++) {
+				const t = e.findPointSourceByPoint({ x, y });
 				expect(t.target).toBe(e);
 			}
 		}
 		let t = e.findPointSourceByPoint({
-			x: e.width + xp + w + 0.1,
-			y: e.height + yp + h - 1
+			x: fromX + 0.1,
+			y: fromY - 1
 		});
 		expect(t).toBeUndefined();
 		t = e.findPointSourceByPoint({
-			x: e.width + xp + w - 1,
-			y: e.height + yp + h + 0.1
+			x: fromX - 1,
+			y: fromY + 0.1
 		});
 		expect(t).toBeUndefined();
-		t = e.findPointSourceByPoint({ x: xp - w - 1, y: yp - h });
+		t = e.findPointSourceByPoint({ x: toX + 1, y: toY });
 		expect(t).toBeUndefined();
-		t = e.findPointSourceByPoint({ x: xp - w, y: yp - h - 1 });
+		t = e.findPointSourceByPoint({ x: toX, y: toY + 1 });
 		expect(t).toBeUndefined();
 	});
 
 	it("入れ子", () => {
-		const xp = 20;
-		const yp = 10;
-		e.moveTo(xp, yp);
 		e.scale(2);
 		const e2 = new E({ scene: runtime.scene });
 		e2.width = 10;
@@ -165,9 +228,6 @@ describe("test E", () => {
 	});
 
 	it("入れ子で両方有効", () => {
-		const xp = 20;
-		const yp = 10;
-		e.moveTo(xp, yp);
 		e.scale(2);
 		const e2 = new E({ scene: runtime.scene });
 		e2.width = 10;
@@ -189,9 +249,6 @@ describe("test E", () => {
 	});
 
 	it("入れ子のやつをappendしてその後remove", () => {
-		const xp = 20;
-		const yp = 10;
-		e.moveTo(xp, yp);
 		e.scale(2);
 		const e2 = new E({ scene: runtime.scene });
 		e2.width = 10;

--- a/src/__tests__/MatrixSpec.ts
+++ b/src/__tests__/MatrixSpec.ts
@@ -9,7 +9,7 @@ describe("test Matrix", () => {
 		m = new PlainMatrix();
 		expect(m._matrix).toEqual([1, 0, 0, 1, 0, 0]);
 
-		m = new PlainMatrix(0, 0, 2, 3, 45);
+		m = new PlainMatrix(0, 0, 2, 3, 45, 0.5, 0.5);
 		const revSqrt2 = 1 / Math.sqrt(2);
 		const expected = [2 * revSqrt2, 2 * revSqrt2, -3 * revSqrt2, 3 * revSqrt2, 0, 0];
 		expect(m._matrix).toBeNear(expected, 10);
@@ -24,13 +24,11 @@ describe("test Matrix", () => {
 		const rad = (angle * Math.PI) / 180;
 		const cosValue = Math.cos(rad);
 		const sinValue = Math.sin(rad);
-		m.update(10, 8, 2, 3, angle, 100, 50);
+		m.update(10, 8, 2, 3, angle, 100, 50, 0.5, 0.5);
 
 		const expected = new PlainMatrix();
 		const tmp = new PlainMatrix();
 
-		tmp._matrix = [1, 0, 0, 1, 10 / 2, 8 / 2];
-		expected.multiply(tmp);
 		tmp._matrix = [1, 0, 0, 1, 100, 50];
 		expected.multiply(tmp);
 		tmp._matrix = [cosValue, sinValue, -sinValue, cosValue, 0, 0];
@@ -49,7 +47,7 @@ describe("test Matrix", () => {
 		const rad = (angle * Math.PI) / 180;
 		const cosValue = Math.cos(rad);
 		const sinValue = Math.sin(rad);
-		m.updateByInverse(10, 8, 2, 3, angle, 100, 50);
+		m.updateByInverse(10, 8, 2, 3, angle, 100, 50, 0.5, 0.5);
 
 		const expected = new PlainMatrix();
 		const tmp = new PlainMatrix();
@@ -61,8 +59,6 @@ describe("test Matrix", () => {
 		tmp._matrix = [cosValue, -sinValue, sinValue, cosValue, 0, 0];
 		expected.multiply(tmp);
 		tmp._matrix = [1, 0, 0, 1, -100, -50];
-		expected.multiply(tmp);
-		tmp._matrix = [1, 0, 0, 1, -10 / 2, -8 / 2];
 		expected.multiply(tmp);
 
 		expect(m._matrix).toBeNear(expected._matrix, 10);

--- a/src/__tests__/Object2DSpec.ts
+++ b/src/__tests__/Object2DSpec.ts
@@ -20,8 +20,8 @@ describe("test Object2D", () => {
 		expect(e.scaleY).toEqual(1);
 		expect(e.angle).toEqual(0);
 		expect(e.compositeOperation).toBeUndefined();
-		expect(e.anchorX).toBeUndefined();
-		expect(e.anchorY).toBeUndefined();
+		expect(e.anchorX).toBe(0);
+		expect(e.anchorY).toBe(0);
 		expect(e._matrix).toBeUndefined();
 	});
 
@@ -36,8 +36,8 @@ describe("test Object2D", () => {
 		expect(e.scaleY).toEqual(1);
 		expect(e.angle).toEqual(0);
 		expect(e.compositeOperation).toBeUndefined();
-		expect(e.anchorX).toBeUndefined();
-		expect(e.anchorY).toBeUndefined();
+		expect(e.anchorX).toBe(0);
+		expect(e.anchorY).toBe(0);
 		expect(e._matrix).toBeUndefined();
 
 		e = new Object2D({
@@ -210,7 +210,7 @@ describe("test Object2D", () => {
 
 		e.scale(2);
 		e._matrix._modified = true;
-		scarecrow = new PlainMatrix(0, 0, 2, 2, 0);
+		scarecrow = new PlainMatrix(0, 0, 2, 2, 0, 1, 1);
 		expect(e.getMatrix()).toEqual(scarecrow);
 		expect(e._matrix._modified).toBe(false);
 
@@ -225,7 +225,7 @@ describe("test Object2D", () => {
 		e.anchor(1, 1);
 		e._matrix._modified = true;
 		const expected = new PlainMatrix();
-		expected.updateWithAnchor(20, 20, 1, 1, 0, 10, 10, 1, 1);
+		expected.update(20, 20, 1, 1, 0, 10, 10, 1, 1);
 		expect(e.getMatrix()._matrix).toEqual(expected._matrix);
 		expect(e._matrix._modified).toBe(false);
 	});

--- a/src/__tests__/SpriteFactorySpec.ts
+++ b/src/__tests__/SpriteFactorySpec.ts
@@ -32,12 +32,16 @@ describe("test SpriteFactory", () => {
 		e.width = 100;
 		e.height = 50;
 		e.opacity = 0.5;
+		e.anchorX = 0;
+		e.anchorY = 0;
 		scene.append(e);
 
 		const e2 = new E({ scene: scene });
 		e2.width = 200;
 		e2.height = 100;
 		e2.opacity = 0.1;
+		e.anchorX = 0;
+		e.anchorY = 0;
 		e2.scale(2);
 		scene.append(e2);
 

--- a/src/domain/Camera2D.ts
+++ b/src/domain/Camera2D.ts
@@ -150,7 +150,7 @@ export class Camera2D extends Object2D implements Camera {
 	 * @private
 	 */
 	_applyTransformToRenderer(renderer: RendererLike): void {
-		if (this.angle || this.scaleX !== 1 || this.scaleY !== 1 || this.anchorX != null || this.anchorY != null) {
+		if (this.angle || this.scaleX !== 1 || this.scaleY !== 1 || this.anchorX !== 0 || this.anchorY !== 0) {
 			// Note: this.scaleX/scaleYが0の場合描画した結果何も表示されない事になるが、特殊扱いはしない
 			renderer.transform(this.getMatrix()._matrix);
 		} else {
@@ -164,8 +164,8 @@ export class Camera2D extends Object2D implements Camera {
 	 */
 	_updateMatrix(): void {
 		// カメラの angle, x, y はエンティティと逆方向に作用することに注意。
-		if (this.anchorX != null && this.anchorY != null) {
-			this._matrix.updateByInverseWithAnchor(
+		if (this.angle || this.scaleX !== 1 || this.scaleY !== 1 || this.anchorX !== 0 || this.anchorY !== 0) {
+			this._matrix.updateByInverse(
 				this.width,
 				this.height,
 				this.scaleX,
@@ -176,8 +176,6 @@ export class Camera2D extends Object2D implements Camera {
 				this.anchorX,
 				this.anchorY
 			);
-		} else if (this.angle || this.scaleX !== 1 || this.scaleY !== 1) {
-			this._matrix.updateByInverse(this.width, this.height, this.scaleX, this.scaleY, this.angle, this.x, this.y);
 		} else {
 			this._matrix.reset(-this.x, -this.y);
 		}

--- a/src/domain/Matrix.ts
+++ b/src/domain/Matrix.ts
@@ -49,22 +49,10 @@ export interface Matrix {
 	 * @param angle 角度。単位は `degree` であり `radian` ではない
 	 * @param x x座標
 	 * @param y y座標
-	 */
-	update(width: number, height: number, scaleX: number, scaleY: number, angle: number, x: number, y: number): void;
-
-	/**
-	 * 2D object利用の一般的な値を基に変換行列の値をアンカーを用いて再計算する。
-	 * @param width 対象の横幅
-	 * @param heigth 対象の縦幅
-	 * @param scaleX 対象の横方向への拡大率
-	 * @param scaleY 対象の縦方向への拡大率
-	 * @param angle 角度。単位は `degree` であり `radian` ではない
-	 * @param x x座標
-	 * @param y y座標
 	 * @param anchorX アンカーの横位置。単位は相対値(左端が 0、中央が 0.5、右端が 1.0)である。
 	 * @param anchorY アンカーの縦位置。単位は相対値(上端が 0、中央が 0.5、下端が 1.0)である。
 	 */
-	updateWithAnchor(
+	update(
 		width: number,
 		height: number,
 		scaleX: number,
@@ -85,22 +73,10 @@ export interface Matrix {
 	 * @param angle 角度。単位は `degree` であり `radian` ではない
 	 * @param x x座標
 	 * @param y y座標
-	 */
-	updateByInverse(width: number, height: number, scaleX: number, scaleY: number, angle: number, x: number, y: number): void;
-
-	/**
-	 * `updateWithAnchor()` によって得られる行列の逆変換になるよう変換行列の値を再計算する。
-	 * @param width 対象の横幅
-	 * @param heigth 対象の縦幅
-	 * @param scaleX 対象の横方向への拡大率
-	 * @param scaleY 対象の縦方向への拡大率
-	 * @param angle 角度。単位は `degree` であり `radian` ではない
-	 * @param x x座標
-	 * @param y y座標
 	 * @param anchorX アンカーの横位置。単位は相対値(左端が 0、中央が 0.5、右端が 1.0)である。
 	 * @param anchorY アンカーの縦位置。単位は相対値(上端が 0、中央が 0.5、下端が 1.0)である。
 	 */
-	updateByInverseWithAnchor(
+	updateByInverse(
 		width: number,
 		height: number,
 		scaleX: number,
@@ -176,7 +152,7 @@ export class PlainMatrix {
 	 * @param anchorX アンカーの横位置。単位は相対値(左端が 0、中央が 0.5、右端が 1.0)である。
 	 * @param anchorY アンカーの縦位置。単位は相対値(上端が 0、中央が 0.5、下端が 1.0)である。
 	 */
-	constructor(width: number, height: number, scaleX: number, scaleY: number, angle: number, anchorX?: number, anchorY?: number);
+	constructor(width: number, height: number, scaleX: number, scaleY: number, angle: number, anchorX: number, anchorY: number);
 	/**
 	 * 指定の `Matrix` と同じ変換行列を表す `PlainMatrix` のインスタンスを生成する。
 	 */
@@ -198,11 +174,7 @@ export class PlainMatrix {
 		} else if (typeof widthOrSrc === "number") {
 			this._modified = false;
 			this._matrix = <[number, number, number, number, number, number]>new Array<number>(6);
-			if (anchorX != null && anchorY != null) {
-				this.updateWithAnchor(widthOrSrc, height, scaleX, scaleY, angle, 0, 0, anchorX, anchorY);
-			} else {
-				this.update(widthOrSrc, height, scaleX, scaleY, angle, 0, 0);
-			}
+			this.update(widthOrSrc, height, scaleX, scaleY, angle, 0, 0, anchorX, anchorY);
 		} else {
 			this._modified = widthOrSrc._modified;
 			this._matrix = [
@@ -216,40 +188,7 @@ export class PlainMatrix {
 		}
 	}
 
-	update(width: number, height: number, scaleX: number, scaleY: number, angle: number, x: number, y: number): void {
-		// ここで求める変換行列Mは、引数で指定された変形を、拡大・回転・平行移動の順に適用するものである。
-		// 変形の原点は引数で指定された矩形の中心、すなわち (width/2, height/2) の位置である。従って
-		//    M = A^-1 T R S A
-		// である。ただしここでA, S, R, Tは、それぞれ以下を表す変換行列である:
-		//    A: 矩形の中心を原点に移す(平行移動する)変換
-		//    S: X軸方向にscaleX倍、Y軸方向にscaleY倍する変換
-		//    R: angle度だけ回転する変換
-		//    T: x, yの値だけ平行移動する変換
-		// それらは次のように表せる:
-		//           1    0   -w           sx    0    0            c   -s    0            1    0    x
-		//    A = [  0    1   -h]    S = [  0   sy    0]    R = [  s    c    0]    T = [  0    1    y]
-		//           0    0    1            0    0    1            0    0    1            0    0    1
-		// ここで sx, sy は scaleX, scaleY であり、c, s は cos(theta), sin(theta)
-		// (ただし theta = angle * PI / 180)、w = (width / 2), h = (height / 2) である。
-		// 以下の実装は、M の各要素をそれぞれ計算して直接求めている。
-		var r = (angle * Math.PI) / 180;
-		var _cos = Math.cos(r);
-		var _sin = Math.sin(r);
-		var a = _cos * scaleX;
-		var b = _sin * scaleX;
-		var c = _sin * scaleY;
-		var d = _cos * scaleY;
-		var w = width / 2;
-		var h = height / 2;
-		this._matrix[0] = a;
-		this._matrix[1] = b;
-		this._matrix[2] = -c;
-		this._matrix[3] = d;
-		this._matrix[4] = -a * w + c * h + w + x;
-		this._matrix[5] = -b * w - d * h + h + y;
-	}
-
-	updateWithAnchor(
+	update(
 		width: number,
 		height: number,
 		scaleX: number,
@@ -292,35 +231,7 @@ export class PlainMatrix {
 		this._matrix[5] = -b * w - d * h + y;
 	}
 
-	updateByInverse(width: number, height: number, scaleX: number, scaleY: number, angle: number, x: number, y: number): void {
-		// ここで求める変換行列は、update() の求める行列Mの逆行列、M^-1である。update() のコメントに記述のとおり、
-		//    M = A^-1 T R S A
-		// であるから、
-		//    M^-1 = A^-1 S^-1 R^-1 T^-1 A
-		// それぞれは次のように表せる:
-		//              1    0    w             1/sx     0    0               c    s    0               1    0   -x
-		//    A^-1 = [  0    1    h]    S^-1 = [   0  1/sy    0]    R^-1 = [ -s    c    0]    T^-1 = [  0    1   -y]
-		//              0    0    1                0     0    1               0    0    1               0    0    1
-		// ここで各変数は update() のコメントのものと同様である。
-		// 以下の実装は、M^-1 の各要素をそれぞれ計算して直接求めている。
-		var r = (angle * Math.PI) / 180;
-		var _cos = Math.cos(r);
-		var _sin = Math.sin(r);
-		var a = _cos / scaleX;
-		var b = _sin / scaleY;
-		var c = _sin / scaleX;
-		var d = _cos / scaleY;
-		var w = width / 2;
-		var h = height / 2;
-		this._matrix[0] = a;
-		this._matrix[1] = -b;
-		this._matrix[2] = c;
-		this._matrix[3] = d;
-		this._matrix[4] = -a * (w + x) - c * (h + y) + w;
-		this._matrix[5] = b * (w + x) - d * (h + y) + h;
-	}
-
-	updateByInverseWithAnchor(
+	updateByInverse(
 		width: number,
 		height: number,
 		scaleX: number,
@@ -331,7 +242,7 @@ export class PlainMatrix {
 		anchorX: number,
 		anchorY: number
 	): void {
-		// ここで求める変換行列は、updateWithAnchor() の求める行列Mの逆行列、M^-1である。updateWithAnchor() のコメントに記述のとおり、
+		// ここで求める変換行列は、update() の求める行列Mの逆行列、M^-1である。update() のコメントに記述のとおり、
 		//    M = A^-1 T R S A
 		// であるから、
 		//    M^-1 = A^-1 S^-1 R^-1 T^-1 A
@@ -339,7 +250,7 @@ export class PlainMatrix {
 		//              1    0    w             1/sx     0    0               c    s    0               1    0   -x+w
 		//    A^-1 = [  0    1    h]    S^-1 = [   0  1/sy    0]    R^-1 = [ -s    c    0]    T^-1 = [  0    1   -y+h]
 		//              0    0    1                0     0    1               0    0    1               0    0    1
-		// ここで各変数は updateWithAnchor() のコメントのものと同様である。
+		// ここで各変数は update() のコメントのものと同様である。
 		// 以下の実装は、M^-1 の各要素をそれぞれ計算して直接求めている。
 		const r = (angle * Math.PI) / 180;
 		const _cos = Math.cos(r);

--- a/src/domain/Object2D.ts
+++ b/src/domain/Object2D.ts
@@ -68,10 +68,7 @@ export interface Object2DParameterObject {
 	 * オブジェクトのアンカーの横位置。アンカーについては以下の通り。
 	 * * アンカーとして設定した箇所がこのオブジェクトの基点 (位置、拡縮・回転の基点) となる。
 	 * * 単位は相対値 (左上端が (0, 0) 中央が (0.5, 0,5) 右下端が (1,1) ) である。
-	 * anchorXとanchorYの両方が省略された場合、このオブジェクトの位置 (x, y) は左上端を基準に決定され、拡縮・回転の基点は中央座標となる。
-	 * これは前バージョンとの互換性のための挙動である。
-	 * anchorX, anchorYのどちらかのみを指定した場合の動作は不定である。
-	 * @default undefined
+	 * @default 0
 	 */
 	anchorX?: number;
 
@@ -79,10 +76,7 @@ export interface Object2DParameterObject {
 	 * オブジェクトのアンカーの縦位置。アンカーについては以下の通り。
 	 * * アンカーとして設定した箇所がこのオブジェクトの基点 (位置、拡縮・回転の基点) となる。
 	 * * 単位は相対値 (左上端が (0, 0) 中央が (0.5, 0,5) 右下端が (1,1) ) である。
-	 * anchorXとanchorYの両方が省略された場合、このオブジェクトの位置 (x, y) は左上端を基準に決定され、拡縮・回転の基点は中央座標となる。
-	 * これは前バージョンとの互換性のための挙動である。
-	 * anchorX, anchorYのどちらかのみを指定した場合の動作は不定である。
-	 * @default undefined
+	 * @default 0
 	 */
 	anchorY?: number;
 }
@@ -159,25 +153,19 @@ export class Object2D implements CommonArea {
 	 * オブジェクトのアンカーの横位置。アンカーについては以下の通り。
 	 * * アンカーとして設定した箇所がこのオブジェクトの基点 (位置、拡縮・回転の基点) となる。
 	 * * 単位は相対値 (左上端が (0, 0) 中央が (0.5, 0,5) 右下端が (1,1) ) である。
-	 * anchorXとanchorYの両方が省略された場合、このオブジェクトの位置 (x, y) は左上端を基準に決定され、拡縮・回転の基点は中央座標となる。
-	 * これは前バージョンとの互換性のための挙動である。
-	 * anchorX, anchorYのどちらかのみを指定した場合の動作は不定である。
-	 * 初期値は `undefined` である。
+	 * 初期値は `0` である。
 	 * `E` や `Camera2D` においてこの値を変更した場合、 `modified()` を呼び出す必要がある。
 	 */
-	anchorX: number | undefined;
+	anchorX: number;
 
 	/**
 	 * オブジェクトのアンカーの縦位置。アンカーについては以下の通り。
 	 * * アンカーとして設定した箇所がこのオブジェクトの基点 (位置、拡縮・回転の基点) となる。
 	 * * 単位は相対値 (左上端が (0, 0) 中央が (0.5, 0,5) 右下端が (1,1) ) である。
-	 * anchorXとanchorYの両方が省略された場合、このオブジェクトの位置 (x, y) は左上端を基準に決定され、拡縮・回転の基点は中央座標となる。
-	 * これは前バージョンとの互換性のための挙動である。
-	 * anchorX, anchorYのどちらかのみを指定した場合の動作は不定である。
-	 * 初期値は `undefined` である。
+	 * 初期値は `0` である。
 	 * `E` や `Camera2D` においてこの値を変更した場合、 `modified()` を呼び出す必要がある。
 	 */
-	anchorY: number | undefined;
+	anchorY: number;
 
 	/**
 	 * 変換行列のキャッシュ。 `Object2D` は状態に変更があった時、本値の_modifiedをtrueにする必要がある。
@@ -212,8 +200,8 @@ export class Object2D implements CommonArea {
 			this.scaleY = 1;
 			this.angle = 0;
 			this.compositeOperation = undefined;
-			this.anchorX = undefined;
-			this.anchorY = undefined;
+			this.anchorX = 0;
+			this.anchorY = 0;
 			this._matrix = undefined;
 		} else {
 			this.x = param.x || 0;
@@ -225,8 +213,8 @@ export class Object2D implements CommonArea {
 			this.scaleY = "scaleY" in param ? param.scaleY : 1;
 			this.angle = param.angle || 0;
 			this.compositeOperation = param.compositeOperation;
-			this.anchorX = param.anchorX;
-			this.anchorY = param.anchorY;
+			this.anchorX = "anchorX" in param ? param.anchorX : 0;
+			this.anchorY = "anchorY" in param ? param.anchorY : 0;
 			this._matrix = undefined;
 		}
 	}
@@ -354,20 +342,8 @@ export class Object2D implements CommonArea {
 	 * @private
 	 */
 	_updateMatrix(): void {
-		if (this.anchorX != null && this.anchorY != null) {
-			this._matrix.updateWithAnchor(
-				this.width,
-				this.height,
-				this.scaleX,
-				this.scaleY,
-				this.angle,
-				this.x,
-				this.y,
-				this.anchorX,
-				this.anchorY
-			);
-		} else if (this.angle || this.scaleX !== 1 || this.scaleY !== 1) {
-			this._matrix.update(this.width, this.height, this.scaleX, this.scaleY, this.angle, this.x, this.y);
+		if (this.angle || this.scaleX !== 1 || this.scaleY !== 1 || this.anchorX !== 0 || this.anchorY !== 0) {
+			this._matrix.update(this.width, this.height, this.scaleX, this.scaleY, this.angle, this.x, this.y, this.anchorX, this.anchorY);
 		} else {
 			this._matrix.reset(this.x, this.y);
 		}

--- a/src/domain/Object2D.ts
+++ b/src/domain/Object2D.ts
@@ -213,8 +213,8 @@ export class Object2D implements CommonArea {
 			this.scaleY = "scaleY" in param ? param.scaleY : 1;
 			this.angle = param.angle || 0;
 			this.compositeOperation = param.compositeOperation;
-			this.anchorX = "anchorX" in param ? param.anchorX : 0;
-			this.anchorY = "anchorY" in param ? param.anchorY : 0;
+			this.anchorX = param.anchorX || 0;
+			this.anchorY = param.anchorY || 0;
 			this._matrix = undefined;
 		}
 	}

--- a/src/domain/entities/E.ts
+++ b/src/domain/entities/E.ts
@@ -338,7 +338,7 @@ export class E extends Object2D implements CommonArea, Destroyable {
 		}
 
 		renderer.save();
-		if (this.angle || this.scaleX !== 1 || this.scaleY !== 1 || this.anchorX != null || this.anchorY != null) {
+		if (this.angle || this.scaleX !== 1 || this.scaleY !== 1 || this.anchorX !== 0 || this.anchorY !== 0) {
 			// Note: this.scaleX/scaleYが0の場合描画した結果何も表示されない事になるが、特殊扱いはしない
 			renderer.transform(this.getMatrix()._matrix);
 		} else {
@@ -521,8 +521,8 @@ export class E extends Object2D implements CommonArea, Destroyable {
 			this.angle ||
 			this.scaleX !== 1 ||
 			this.scaleY !== 1 ||
-			this.anchorX != null ||
-			this.anchorY != null ||
+			this.anchorX !== 0 ||
+			this.anchorY !== 0 ||
 			this.opacity !== 1 ||
 			this.compositeOperation !== undefined ||
 			this.shaderProgram !== undefined


### PR DESCRIPTION
## このpull requestが解決する内容
* #128 にて追加されたアンカーの初期値を `(0, 0)` に変更します。
* それに伴い `g.Matrix#...WithAnchor()` メソッドを削除します。

## sample

```javascript
var tl = require("@akashic-extension/akashic-timeline");
var game = g.game;

function main() {
    var scene = new g.Scene({
        game: game
    });
    var timeline = new tl.Timeline(scene);
    scene.loaded.add(function () {
        var target = new g.FilledRect({
            scene: scene,
            cssColor: "green",
            width: 50,
            height: 50
        });
        scene.append(target);

        timeline.create(target, {modified: target.modified})
            .moveTo(100, 0, 800)
            .moveTo(100, 100, 800)
            .scaleTo(1.5, 1.5, 800)
            .to({angle: 90}, 800)
    });
    game.pushScene(scene);
}
```

## preview

### before
* 座標: 左上
* 拡縮/回転の基点: 中央
![tween_before](https://user-images.githubusercontent.com/16933898/68005993-7e9f5a80-fcba-11e9-8720-45f17e21099f.gif)

### after
* 座標: 左上
* 拡縮/回転の基点: 左上
![tween_after](https://user-images.githubusercontent.com/16933898/68006002-8232e180-fcba-11e9-87de-fc037667b6e7.gif)

## 破壊的な変更を含んでいるか?
- あり

