### PR TITLE
Resolved dependencies around Camera2D

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -3,7 +3,6 @@ import { SurfaceAtlasSet } from "./commons/SurfaceAtlasSet";
 import { AssetManager } from "./domain/AssetManager";
 import { AudioSystemManager } from "./domain/AudioSystemManager";
 import { Camera } from "./domain/Camera";
-import { Camera2D, Camera2DParameterObject } from "./domain/Camera2D";
 import { DefaultLoadingScene } from "./domain/DefaultLoadingScene";
 import { E } from "./domain/entities/E";
 import { Event, EventType, JoinEvent, LeaveEvent, PointSource, SeedEvent } from "./domain/Event";
@@ -723,21 +722,6 @@ export abstract class Game implements Registrable<E> {
 	findPointSource(point: CommonOffset, camera?: Camera): PointSource {
 		if (!camera) camera = this.focusingCamera;
 		return this.scene().findPointSourceByPoint(point, false, camera);
-	}
-
-	/**
-	 * 2D世界におけるカメラを生成して返す。
-	 * 例外的に、`Camera2D` のコンストラクタは `width`, `height` のみ無視することに注意。
-	 *
-	 * @param param Camera2D に渡す値
-	 */
-	createCamera2D(param: Camera2DParameterObject): Camera2D {
-		return new Camera2D({
-			...param,
-			id: !!param.local ? undefined : this._cameraIdx++,
-			width: this.width,
-			height: this.height
-		});
 	}
 
 	/**

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -3,6 +3,7 @@ import { SurfaceAtlasSet } from "./commons/SurfaceAtlasSet";
 import { AssetManager } from "./domain/AssetManager";
 import { AudioSystemManager } from "./domain/AudioSystemManager";
 import { Camera } from "./domain/Camera";
+import { Camera2D, Camera2DParameterObject } from "./domain/Camera2D";
 import { DefaultLoadingScene } from "./domain/DefaultLoadingScene";
 import { E } from "./domain/entities/E";
 import { Event, EventType, JoinEvent, LeaveEvent, PointSource, SeedEvent } from "./domain/Event";
@@ -462,8 +463,6 @@ export abstract class Game implements Registrable<E> {
 	 *
 	 * `Game#draw()`, `Game#findPointSource()` のデフォルト値として使用される。
 	 * この値を変更した場合、変更を描画に反映するためには `Game#modified` に真を代入しなければならない。
-	 * (ただしこの値が非 `undefined` の時、`Game#focusingCamera.modified()` を呼び出す場合は
-	 * `Game#modified` の操作は省略できる。)
 	 */
 	// focusingCameraが変更されても古いカメラをtargetCamerasに持つエンティティのEntityStateFlags.Modifiedを取りこぼすことが無いように、変更時にはrenderを呼べるようアクセサを使う
 	get focusingCamera(): Camera {
@@ -724,6 +723,21 @@ export abstract class Game implements Registrable<E> {
 	findPointSource(point: CommonOffset, camera?: Camera): PointSource {
 		if (!camera) camera = this.focusingCamera;
 		return this.scene().findPointSourceByPoint(point, false, camera);
+	}
+
+	/**
+	 * 2D世界におけるカメラを生成して返す。
+	 * 例外的に、`Camera2D` のコンストラクタは `width`, `height` のみ無視することに注意。
+	 *
+	 * @param param Camera2D に渡す値
+	 */
+	createCamera2D(param: Camera2DParameterObject): Camera2D {
+		return new Camera2D({
+			...param,
+			id: !!param.local ? undefined : this._cameraIdx++,
+			width: this.width,
+			height: this.height
+		});
 	}
 
 	/**

--- a/src/__tests__/CacheableESpec.ts
+++ b/src/__tests__/CacheableESpec.ts
@@ -45,8 +45,8 @@ describe("test CacheableE", () => {
 	it("renderSelf calls renderCache", () => {
 		const ce = new CacheableE({ scene: runtime.scene });
 		const renderer = new Renderer();
-		const cam1 = runtime.game.createCamera2D({});
-		const cam2 = runtime.game.createCamera2D({});
+		const cam1 = new Camera2D({});
+		const cam2 = new Camera2D({});
 
 		let called = false;
 		ce.renderCache = (r, c) => {

--- a/src/__tests__/CacheableESpec.ts
+++ b/src/__tests__/CacheableESpec.ts
@@ -45,8 +45,8 @@ describe("test CacheableE", () => {
 	it("renderSelf calls renderCache", () => {
 		const ce = new CacheableE({ scene: runtime.scene });
 		const renderer = new Renderer();
-		const cam1 = new Camera2D({ game: runtime.game });
-		const cam2 = new Camera2D({ game: runtime.game });
+		const cam1 = runtime.game.createCamera2D({});
+		const cam2 = runtime.game.createCamera2D({});
 
 		let called = false;
 		ce.renderCache = (r, c) => {

--- a/src/__tests__/CameraSpec.ts
+++ b/src/__tests__/CameraSpec.ts
@@ -3,19 +3,17 @@ import { Game, Renderer } from "./helpers";
 
 describe("test Camera", () => {
 	it("初期化", () => {
-		const game = new Game({ width: 320, height: 320, main: "" });
-		const cam1 = game.createCamera2D({ width: 100, height: 100 });
-		expect(cam1.id).toBe(0);
+		const cam1 = new Camera2D({ width: 320, height: 240 });
 		expect(cam1.local).toBe(false);
 		expect(cam1.name).toBeUndefined();
 		expect(cam1.x).toBe(0);
 		expect(cam1.y).toBe(0);
 		expect(cam1.angle).toBe(0);
 		expect(cam1.width).toBe(320);
-		expect(cam1.height).toBe(320);
+		expect(cam1.height).toBe(240);
 		expect(cam1._modifiedCount).toBe(0);
 
-		const cam2 = game.createCamera2D({
+		const cam2 = new Camera2D({
 			name: "foo",
 			x: 100,
 			y: 10,
@@ -23,36 +21,33 @@ describe("test Camera", () => {
 			width: 80,
 			height: 70
 		});
-		expect(cam2.id).toBe(1);
 		expect(cam2.local).toBe(false);
 		expect(cam2.name).toBe("foo");
 		expect(cam2.x).toBe(100);
 		expect(cam2.y).toBe(10);
 		expect(cam2.angle).toBe(4);
-		expect(cam2.width).toBe(320); // width, height 指定は無視される
-		expect(cam2.height).toBe(320);
+		expect(cam2.width).toBe(80);
+		expect(cam2.height).toBe(70);
 		expect(cam2._modifiedCount).toBe(0);
 
-		const cam3 = game.createCamera2D({
+		const cam3 = new Camera2D({
 			local: true,
 			name: "bar",
 			x: 100,
 			y: 10
 		});
-		expect(cam3.id).toBeUndefined();
 		expect(cam3.local).toBe(true);
 		expect(cam3.name).toBe("bar");
 		expect(cam3.x).toBe(100);
 		expect(cam3.y).toBe(10);
 		expect(cam3.angle).toBe(0);
-		expect(cam3.width).toBe(320);
-		expect(cam3.height).toBe(320);
+		expect(cam3.width).toBe(0);
+		expect(cam3.height).toBe(0);
 		expect(cam3._modifiedCount).toBe(0);
 	});
 
 	it("modified", () => {
-		const game = new Game({ width: 320, height: 320, main: "" });
-		const cam = game.createCamera2D({});
+		const cam = new Camera2D({});
 
 		expect(cam._modifiedCount).toBe(0);
 		cam.modified();
@@ -66,8 +61,7 @@ describe("test Camera", () => {
 	});
 
 	it("x, y, angle", () => {
-		const game = new Game({ width: 320, height: 240, main: "" });
-		const cam = game.createCamera2D({});
+		const cam = new Camera2D({});
 		const expected = new PlainMatrix();
 		let mat: Matrix;
 
@@ -90,8 +84,7 @@ describe("test Camera", () => {
 	});
 
 	it("anchor", () => {
-		const game = new Game({ width: 320, height: 240, main: "" });
-		const cam = game.createCamera2D({ angle: 10, x: 10, y: 100, anchorX: 0.5, anchorY: 0.5 });
+		const cam = new Camera2D({ width: 320, height: 240, angle: 10, x: 10, y: 100, anchorX: 0.5, anchorY: 0.5 });
 		const expected = new PlainMatrix();
 		const mat = cam.getMatrix();
 		expected.updateByInverse(320, 240, 1, 1, 10, 10, 100, 0.5, 0.5);
@@ -100,7 +93,7 @@ describe("test Camera", () => {
 
 	it("_applyTransformToRenderer", () => {
 		const game = new Game({ width: 320, height: 240, main: "" });
-		const cam = game.createCamera2D({});
+		const cam = new Camera2D({});
 		const surface = game.resourceFactory.createSurface(320, 240);
 		const renderer = surface.renderer() as Renderer;
 
@@ -133,9 +126,7 @@ describe("test Camera", () => {
 	});
 
 	it("serialize", () => {
-		const game = new Game({ width: 320, height: 240, main: "" });
-
-		const cam = game.createCamera2D({
+		const cam = new Camera2D({
 			x: 32,
 			y: 15,
 			angle: 3,
@@ -154,8 +145,6 @@ describe("test Camera", () => {
 		expect(cam2.anchorY).toBe(0);
 		expect(cam2.name).toBe("mycamera1");
 		expect(cam2.local).toBe(false);
-		expect(cam2.id).not.toBe(undefined);
-		expect(cam.id === cam2.id).toBe(true);
 
 		cam2.x = 10;
 		cam2.y = 100;
@@ -174,7 +163,5 @@ describe("test Camera", () => {
 		expect(cam3.opacity).toBe(0.5);
 		expect(cam3.name).toBe("mycamera1");
 		expect(cam3.local).toBe(false);
-		expect(cam3.id).not.toBe(undefined);
-		expect(cam.id === cam3.id).toBe(true);
 	});
 });

--- a/src/__tests__/CameraSpec.ts
+++ b/src/__tests__/CameraSpec.ts
@@ -4,8 +4,7 @@ import { Game, Renderer } from "./helpers";
 describe("test Camera", () => {
 	it("初期化", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const cam1 = new Camera2D({ game: game });
-		expect(cam1.game).toBe(game);
+		const cam1 = game.createCamera2D({ width: 100, height: 100 });
 		expect(cam1.id).toBe(0);
 		expect(cam1.local).toBe(false);
 		expect(cam1.name).toBeUndefined();
@@ -16,8 +15,7 @@ describe("test Camera", () => {
 		expect(cam1.height).toBe(320);
 		expect(cam1._modifiedCount).toBe(0);
 
-		const cam2 = new Camera2D({
-			game: game,
+		const cam2 = game.createCamera2D({
 			name: "foo",
 			x: 100,
 			y: 10,
@@ -25,7 +23,6 @@ describe("test Camera", () => {
 			width: 80,
 			height: 70
 		});
-		expect(cam2.game).toBe(game);
 		expect(cam2.id).toBe(1);
 		expect(cam2.local).toBe(false);
 		expect(cam2.name).toBe("foo");
@@ -36,14 +33,12 @@ describe("test Camera", () => {
 		expect(cam2.height).toBe(320);
 		expect(cam2._modifiedCount).toBe(0);
 
-		const cam3 = new Camera2D({
-			game: game,
+		const cam3 = game.createCamera2D({
 			local: true,
 			name: "bar",
 			x: 100,
 			y: 10
 		});
-		expect(cam3.game).toBe(game);
 		expect(cam3.id).toBeUndefined();
 		expect(cam3.local).toBe(true);
 		expect(cam3.name).toBe("bar");
@@ -57,25 +52,22 @@ describe("test Camera", () => {
 
 	it("modified", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const cam = new Camera2D({ game: game });
+		const cam = game.createCamera2D({});
 
-		game.modified = false; // テストのためリセット
 		expect(cam._modifiedCount).toBe(0);
 		cam.modified();
 		expect(cam._modifiedCount).toBe(1);
-		expect(game.modified).toBe(true);
 		const matrix = cam._matrix;
 		cam.getMatrix();
 		cam.modified();
 		expect(cam._modifiedCount).toBe(2);
-		expect(game.modified).toBe(true);
 		expect(cam._matrix._modified).toBe(true);
 		expect(cam._matrix).not.toEqual(matrix);
 	});
 
 	it("x, y, angle", () => {
 		const game = new Game({ width: 320, height: 240, main: "" });
-		const cam = new Camera2D({ game: game });
+		const cam = game.createCamera2D({});
 		const expected = new PlainMatrix();
 		let mat: Matrix;
 
@@ -99,7 +91,7 @@ describe("test Camera", () => {
 
 	it("anchor", () => {
 		const game = new Game({ width: 320, height: 240, main: "" });
-		const cam = new Camera2D({ game: game, angle: 10, x: 10, y: 100, anchorX: 0.5, anchorY: 0.5 });
+		const cam = game.createCamera2D({ angle: 10, x: 10, y: 100, anchorX: 0.5, anchorY: 0.5 });
 		const expected = new PlainMatrix();
 		const mat = cam.getMatrix();
 		expected.updateByInverse(320, 240, 1, 1, 10, 10, 100, 0.5, 0.5);
@@ -108,7 +100,7 @@ describe("test Camera", () => {
 
 	it("_applyTransformToRenderer", () => {
 		const game = new Game({ width: 320, height: 240, main: "" });
-		const cam = new Camera2D({ game: game });
+		const cam = game.createCamera2D({});
 		const surface = game.resourceFactory.createSurface(320, 240);
 		const renderer = surface.renderer() as Renderer;
 
@@ -143,8 +135,7 @@ describe("test Camera", () => {
 	it("serialize", () => {
 		const game = new Game({ width: 320, height: 240, main: "" });
 
-		const cam = new Camera2D({
-			game: game,
+		const cam = game.createCamera2D({
 			x: 32,
 			y: 15,
 			angle: 3,
@@ -152,14 +143,15 @@ describe("test Camera", () => {
 		});
 		let ser = cam.serialize();
 
-		const cam2 = Camera2D.deserialize(ser, game);
-		expect(cam2.game).toBe(game);
+		const cam2 = Camera2D.deserialize(ser);
 		expect(cam2.x).toBe(32);
 		expect(cam2.y).toBe(15);
 		expect(cam2.angle).toBe(3);
 		expect(cam2.scaleX).toBe(1);
 		expect(cam2.scaleY).toBe(1);
 		expect(cam2.opacity).toBe(1);
+		expect(cam2.anchorX).toBe(0);
+		expect(cam2.anchorY).toBe(0);
 		expect(cam2.name).toBe("mycamera1");
 		expect(cam2.local).toBe(false);
 		expect(cam2.id).not.toBe(undefined);
@@ -168,15 +160,17 @@ describe("test Camera", () => {
 		cam2.x = 10;
 		cam2.y = 100;
 		cam2.opacity = 0.5;
+		cam2.anchor(1.0, 0.5);
 		ser = cam2.serialize();
 
-		const cam3 = Camera2D.deserialize(ser, game);
-		expect(cam3.game).toBe(game);
+		const cam3 = Camera2D.deserialize(ser);
 		expect(cam3.x).toBe(10);
 		expect(cam3.y).toBe(100);
 		expect(cam3.angle).toBe(3);
 		expect(cam3.scaleX).toBe(1);
 		expect(cam3.scaleY).toBe(1);
+		expect(cam3.anchorX).toBe(1.0);
+		expect(cam3.anchorY).toBe(0.5);
 		expect(cam3.opacity).toBe(0.5);
 		expect(cam3.name).toBe("mycamera1");
 		expect(cam3.local).toBe(false);

--- a/src/__tests__/ESpec.ts
+++ b/src/__tests__/ESpec.ts
@@ -480,7 +480,7 @@ describe("test E", () => {
 	});
 
 	it("findPointSource", () => {
-		const cam1 = runtime.game.createCamera2D({});
+		const cam1 = new Camera2D({});
 
 		e.touchable = true;
 		e.x = e.y = 100;
@@ -503,7 +503,7 @@ describe("test E", () => {
 		found = runtime.game.findPointSource({ x: 115, y: 115 }, cam1);
 		expect(found && found.target).toBe(face1);
 
-		const cam2 = runtime.game.createCamera2D({});
+		const cam2 = new Camera2D({});
 		const face2 = new E({ scene: runtime.scene });
 		face2.touchable = true;
 		face2.x = face2.y = 10;
@@ -867,13 +867,13 @@ describe("test E", () => {
 		expect(e.targetCameras).toEqual([]);
 		expect(e._targetCameras).toEqual([]);
 
-		const c = runtime.game.createCamera2D({});
+		const c = new Camera2D({});
 		e.targetCameras = [c];
 
 		expect(e._targetCameras).toEqual([c]);
 		expect(e.targetCameras).toEqual([c]);
 
-		const c2 = runtime.game.createCamera2D({});
+		const c2 = new Camera2D({});
 		e.targetCameras = [c, c2];
 
 		expect(e._targetCameras).toEqual([c, c2]);
@@ -919,9 +919,9 @@ describe("test E", () => {
 	it("render with camera", () => {
 		const e = new E({ scene: runtime.scene });
 		const r = new Renderer();
-		const c = runtime.game.createCamera2D({});
+		const c = new Camera2D({});
 
-		const c2 = runtime.game.createCamera2D({});
+		const c2 = new Camera2D({});
 		e.targetCameras = [c2];
 		e.render(r, c);
 		expect(r.methodCallHistory).toEqual([]);
@@ -991,7 +991,7 @@ describe("test E", () => {
 	it("renderSelf with camera", () => {
 		const e = new E({ scene: runtime.scene });
 		const r = new Renderer();
-		const c = runtime.game.createCamera2D({});
+		const c = new Camera2D({});
 
 		expect(e.renderSelf(r, c)).toBe(true);
 		expect(r.methodCallHistory).toEqual([]);
@@ -1161,7 +1161,7 @@ describe("test E", () => {
 		scene.append(e2);
 		e.append(e2);
 
-		const camera = runtime.game.createCamera2D({});
+		const camera = new Camera2D({});
 		e.targetCameras.push(camera);
 
 		const result = e.calculateBoundingRect(camera);

--- a/src/__tests__/ESpec.ts
+++ b/src/__tests__/ESpec.ts
@@ -480,7 +480,7 @@ describe("test E", () => {
 	});
 
 	it("findPointSource", () => {
-		const cam1 = new Camera2D({ game: runtime.game });
+		const cam1 = runtime.game.createCamera2D({});
 
 		e.touchable = true;
 		e.x = e.y = 100;
@@ -503,7 +503,7 @@ describe("test E", () => {
 		found = runtime.game.findPointSource({ x: 115, y: 115 }, cam1);
 		expect(found && found.target).toBe(face1);
 
-		const cam2 = new Camera2D({ game: runtime.game });
+		const cam2 = runtime.game.createCamera2D({});
 		const face2 = new E({ scene: runtime.scene });
 		face2.touchable = true;
 		face2.x = face2.y = 10;
@@ -867,13 +867,13 @@ describe("test E", () => {
 		expect(e.targetCameras).toEqual([]);
 		expect(e._targetCameras).toEqual([]);
 
-		const c = new Camera2D({ game: runtime.game });
+		const c = runtime.game.createCamera2D({});
 		e.targetCameras = [c];
 
 		expect(e._targetCameras).toEqual([c]);
 		expect(e.targetCameras).toEqual([c]);
 
-		const c2 = new Camera2D({ game: runtime.game });
+		const c2 = runtime.game.createCamera2D({});
 		e.targetCameras = [c, c2];
 
 		expect(e._targetCameras).toEqual([c, c2]);
@@ -919,9 +919,9 @@ describe("test E", () => {
 	it("render with camera", () => {
 		const e = new E({ scene: runtime.scene });
 		const r = new Renderer();
-		const c = new Camera2D({ game: runtime.game });
+		const c = runtime.game.createCamera2D({});
 
-		const c2 = new Camera2D({ game: runtime.game });
+		const c2 = runtime.game.createCamera2D({});
 		e.targetCameras = [c2];
 		e.render(r, c);
 		expect(r.methodCallHistory).toEqual([]);
@@ -991,7 +991,7 @@ describe("test E", () => {
 	it("renderSelf with camera", () => {
 		const e = new E({ scene: runtime.scene });
 		const r = new Renderer();
-		const c = new Camera2D({ game: runtime.game });
+		const c = runtime.game.createCamera2D({});
 
 		expect(e.renderSelf(r, c)).toBe(true);
 		expect(r.methodCallHistory).toEqual([]);
@@ -1161,7 +1161,7 @@ describe("test E", () => {
 		scene.append(e2);
 		e.append(e2);
 
-		const camera = new Camera2D({ game: runtime.game });
+		const camera = runtime.game.createCamera2D({});
 		e.targetCameras.push(camera);
 
 		const result = e.calculateBoundingRect(camera);

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -917,7 +917,7 @@ describe("test Game", () => {
 		expect(e.state).toBe(0);
 		expect(game.modified).toBe(true);
 
-		const camera = game.createCamera2D({});
+		const camera = new Camera2D({});
 		game.focusingCamera = camera;
 		expect(game.focusingCamera).toEqual(camera);
 		expect(e.state).toBe(EntityStateFlags.None);
@@ -931,7 +931,7 @@ describe("test Game", () => {
 		expect(game.modified).toBe(true);
 
 		e.modified();
-		const camera2 = game.createCamera2D({});
+		const camera2 = new Camera2D({});
 		game.focusingCamera = camera2;
 		expect(game.focusingCamera).toEqual(camera2);
 		expect(e.state).toBe(EntityStateFlags.ContextLess);

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -3,8 +3,8 @@ import {
 	Camera2D,
 	E,
 	EventType,
-	ImageAsset,
 	GameConfiguration,
+	ImageAsset,
 	LoadingScene,
 	LoadingSceneParameterObject,
 	LocalTickMode,
@@ -917,7 +917,7 @@ describe("test Game", () => {
 		expect(e.state).toBe(0);
 		expect(game.modified).toBe(true);
 
-		const camera = new Camera2D({ game: game });
+		const camera = game.createCamera2D({});
 		game.focusingCamera = camera;
 		expect(game.focusingCamera).toEqual(camera);
 		expect(e.state).toBe(EntityStateFlags.None);
@@ -931,7 +931,7 @@ describe("test Game", () => {
 		expect(game.modified).toBe(true);
 
 		e.modified();
-		const camera2 = new Camera2D({ game: game });
+		const camera2 = game.createCamera2D({});
 		game.focusingCamera = camera2;
 		expect(game.focusingCamera).toEqual(camera2);
 		expect(e.state).toBe(EntityStateFlags.ContextLess);

--- a/src/domain/Camera.ts
+++ b/src/domain/Camera.ts
@@ -5,13 +5,6 @@ import { RendererLike } from "../interfaces/RendererLike";
  */
 export interface Camera {
 	/**
-	 * このカメラのID。
-	 * カメラ生成時に暗黙に設定される値。
-	 * `local` が真である場合、この値は `undefined` である。
-	 */
-	id: number;
-
-	/**
 	 * このカメラがローカルであるか否か。
 	 */
 	local: boolean;

--- a/src/domain/Camera2D.ts
+++ b/src/domain/Camera2D.ts
@@ -3,7 +3,6 @@ import { Camera } from "./Camera";
 import { Object2D, Object2DParameterObject } from "./Object2D";
 
 export interface Camera2DSerialization {
-	id: number | undefined;
 	param: Camera2DParameterObject;
 }
 
@@ -14,12 +13,6 @@ export interface Camera2DSerialization {
  * 例外的に、`Camera2D` のコンストラクタは `width`, `height` のみ無視することに注意。
  */
 export interface Camera2DParameterObject extends Object2DParameterObject {
-	/**
-	 * このカメラのID。
-	 * @default undefined
-	 */
-	id?: number;
-
 	/**
 	 * このカメラがローカルであるか否か。
 	 * @default false
@@ -35,22 +28,8 @@ export interface Camera2DParameterObject extends Object2DParameterObject {
 
 /**
  * 2D世界におけるカメラ。
- *
- * ゲーム開発者がこのクラスを直接利用する必要はない。
- * `Game#createCamera2D()` を用いるべきである。
  */
 export class Camera2D extends Object2D implements Camera {
-	/**
-	 * このカメラのID。
-	 *
-	 * カメラ生成時に暗黙に設定される値。
-	 * `local` が真である場合、この値は `undefined` である。
-	 *
-	 * ひとつの実行環境中、ある `Game` に対して、ある `undefined` ではない `id` を持つカメラは、最大でもひとつしか存在しない。
-	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を直接変更してはならない。
-	 */
-	id: number | undefined;
-
 	/**
 	 * このカメラがローカルであるか否か。
 	 *
@@ -78,7 +57,6 @@ export class Camera2D extends Object2D implements Camera {
 	static deserialize(ser: any): Camera2D {
 		const s: Camera2DSerialization = ser;
 		const ret = new Camera2D(s.param);
-		ret.id = s.id;
 		return ret;
 	}
 
@@ -89,7 +67,6 @@ export class Camera2D extends Object2D implements Camera {
 	constructor(param: Camera2DParameterObject) {
 		super(param);
 		this.local = !!param.local;
-		this.id = this.local ? undefined : param.id;
 		this.name = param.name;
 		this._modifiedCount = 0;
 	}
@@ -115,7 +92,6 @@ export class Camera2D extends Object2D implements Camera {
 	 */
 	serialize(): any {
 		const ser: Camera2DSerialization = {
-			id: this.id,
 			param: {
 				local: this.local,
 				name: this.name,

--- a/src/domain/Camera2D.ts
+++ b/src/domain/Camera2D.ts
@@ -9,8 +9,6 @@ export interface Camera2DSerialization {
 /**
  * `Camera2D` のコンストラクタに渡すことができるパラメータ。
  * 各メンバの詳細は `Camera2D` の同名メンバの説明を参照すること。
- *
- * 例外的に、`Camera2D` のコンストラクタは `width`, `height` のみ無視することに注意。
  */
 export interface Camera2DParameterObject extends Object2DParameterObject {
 	/**


### PR DESCRIPTION
## このpull requestが解決する内容
`Camera2D` の生成周りの依存関係を整理します。

## 破壊的な変更を含んでいるか?
- あり
  - `Camera#id` が削除されます
  - `Camera2D#width, height` が `game.width, height` と等価では無くなります

## before
![camera2d_before](https://user-images.githubusercontent.com/16933898/68284968-c6aaec80-00c1-11ea-94da-5d4180344fa0.png)

## after
![camera2d_after](https://user-images.githubusercontent.com/16933898/68284988-ca3e7380-00c1-11ea-8837-010ef37ad69f.png)