### PR TITLE
Use import refactor audioasset

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -9,12 +9,15 @@ import { Event, EventType, JoinEvent, LeaveEvent, SeedEvent } from "./domain/Eve
 import { LoadingScene } from "./domain/LoadingScene";
 import { _require } from "./domain/Module";
 import { OperationPluginManager } from "./domain/OperationPluginManager";
+import { PlaingContextManager } from "./domain/PlaingContextManager";
 import { RandomGenerator } from "./domain/RandomGenerator";
 import { RequireCacheable } from "./domain/RequireCacheable";
 import { Storage } from "./domain/Storage";
 import { MusicAudioSystem, SoundAudioSystem } from "./implementations/AudioSystem";
+import { MusicContext, SoundContext } from "./implementations/PlaingContext";
 import { AssetLike } from "./interfaces/AssetLike";
 import { AudioSystemLike } from "./interfaces/AudioSystemLike";
+import { PlaingContextLike } from "./interfaces/PlaingContextLike";
 import { RendererLike } from "./interfaces/RendererLike";
 import { ResourceFactoryLike } from "./interfaces/ResourceFactoryLike";
 import { SurfaceAtlasSetLike } from "./interfaces/SurfaceAtlasSetLike";
@@ -217,7 +220,8 @@ export abstract class Game implements Registrable<E> {
 	 * 本ゲームで利用可能なオーディオシステム群。デフォルトはmusicとsoundが登録されている。
 	 * SE・声・音楽等で分けたい場合、本プロパティにvoice等のAudioSystemを登録することで実現する。
 	 */
-	audio: { [key: string]: AudioSystemLike };
+	// audio: { [key: string]: AudioSystemLike };
+	audio: { [key: string]: PlaingContextLike };
 
 	/**
 	 * デフォルトで利用されるオーディオシステムのID。デフォルト値はsound。
@@ -389,7 +393,8 @@ export abstract class Game implements Registrable<E> {
 	 * Game#audioの管理者。
 	 * @private
 	 */
-	_audioSystemManager: AudioSystemManager;
+	// _audioSystemManager: AudioSystemManager;
+	_audioSystemManager: PlaingContextManager;
 
 	/**
 	 * 操作プラグインの管理者。
@@ -501,16 +506,14 @@ export abstract class Game implements Registrable<E> {
 		this.selfId = selfId || undefined;
 		this.playId = undefined;
 
-		this._audioSystemManager = new AudioSystemManager();
+		this._audioSystemManager = new PlaingContextManager();
 		this.audio = {
-			music: new MusicAudioSystem({
+			music: new MusicContext({
 				id: "music",
-				audioSystemManager: this._audioSystemManager,
 				resourceFactory: this.resourceFactory
 			}),
-			sound: new SoundAudioSystem({
+			sound: new SoundContext({
 				id: "sound",
-				audioSystemManager: this._audioSystemManager,
 				resourceFactory: this.resourceFactory
 			})
 		};
@@ -954,14 +957,14 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_setAudioPlaybackRate(playbackRate: number): void {
-		this._audioSystemManager._setPlaybackRate(playbackRate, this.audio);
+		this._audioSystemManager._setPlaybackRate(playbackRate);
 	}
 
 	/**
 	 * @private
 	 */
 	_setMuted(muted: boolean): void {
-		this._audioSystemManager._setMuted(muted, this.audio);
+		this._audioSystemManager._setMuted(muted);
 	}
 
 	/**
@@ -996,7 +999,7 @@ export abstract class Game implements Registrable<E> {
 			if (param.randGen !== undefined) this.random = param.randGen;
 		}
 
-		this._audioSystemManager._reset(this.audio);
+		this._audioSystemManager._reset();
 		this._loaded.removeAll({ func: this._start, owner: this });
 		this.join.removeAll();
 		this.leave.removeAll();

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -501,10 +501,18 @@ export abstract class Game implements Registrable<E> {
 		this.selfId = selfId || undefined;
 		this.playId = undefined;
 
-		this._audioSystemManager = new AudioSystemManager(this);
+		this._audioSystemManager = new AudioSystemManager();
 		this.audio = {
-			music: new MusicAudioSystem("music", this),
-			sound: new SoundAudioSystem("sound", this)
+			music: new MusicAudioSystem({
+				id: "music",
+				audioSystemManager: this._audioSystemManager,
+				resourceFactory: this.resourceFactory
+			}),
+			sound: new SoundAudioSystem({
+				id: "sound",
+				audioSystemManager: this._audioSystemManager,
+				resourceFactory: this.resourceFactory
+			})
 		};
 		this.defaultAudioSystemId = "sound";
 		this.storage = new Storage();
@@ -946,14 +954,14 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_setAudioPlaybackRate(playbackRate: number): void {
-		this._audioSystemManager._setPlaybackRate(playbackRate);
+		this._audioSystemManager._setPlaybackRate(playbackRate, this.audio);
 	}
 
 	/**
 	 * @private
 	 */
 	_setMuted(muted: boolean): void {
-		this._audioSystemManager._setMuted(muted);
+		this._audioSystemManager._setMuted(muted, this.audio);
 	}
 
 	/**
@@ -988,7 +996,7 @@ export abstract class Game implements Registrable<E> {
 			if (param.randGen !== undefined) this.random = param.randGen;
 		}
 
-		this._audioSystemManager._reset();
+		this._audioSystemManager._reset(this.audio);
 		this._loaded.removeAll({ func: this._start, owner: this });
 		this.join.removeAll();
 		this.leave.removeAll();
@@ -1100,7 +1108,6 @@ export abstract class Game implements Registrable<E> {
 		this._mainParameter = undefined;
 		this._assetManager.destroy();
 		this._assetManager = undefined;
-		this._audioSystemManager._game = undefined;
 		this._audioSystemManager = undefined;
 		this._operationPluginManager = undefined;
 		this._operationPluginOperated.destroy();

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -154,7 +154,7 @@ export class SceneAssetHolder {
 	/**
 	 * @private
 	 */
-	_onAssetError(asset: AssetLike, error: AssetLoadError, assetManager: AssetManager): void {
+	_onAssetError(asset: AssetLike, error: AssetLoadError): void {
 		if (this.destroyed() || this._scene.destroyed()) return;
 		var failureInfo = {
 			asset: asset,

--- a/src/__tests__/AssetManagerSpec.ts
+++ b/src/__tests__/AssetManagerSpec.ts
@@ -369,11 +369,10 @@ describe("test AssetManager", () => {
 					done();
 				}
 			},
-			_onAssetError: (a, err, mgr) => {
-				expect(mgr).toBe(manager);
+			_onAssetError: (a, err, callback) => {
 				if (!failureCounts.hasOwnProperty(a.id)) failureCounts[a.id] = 0;
 				++failureCounts[a.id];
-				manager.retryLoad(a);
+				callback(a);
 			}
 		};
 
@@ -394,19 +393,18 @@ describe("test AssetManager", () => {
 				fail("should not succeed to load");
 				done();
 			},
-			_onAssetError: (a, err, mgr) => {
-				expect(mgr).toBe(manager);
+			_onAssetError: (a, err, callback) => {
 				if (!failureCounts.hasOwnProperty(a.id)) failureCounts[a.id] = 0;
 				++failureCounts[a.id];
 
 				if (!err.retriable) {
 					expect(failureCounts[a.id]).toBe(AssetManager.MAX_ERROR_COUNT + 1);
 					expect(() => {
-						manager.retryLoad(a);
+						callback(a);
 					}).toThrowError("AssertionError");
 					++gaveUpCount;
 				} else {
-					manager.retryLoad(a);
+					callback(a);
 				}
 
 				if (gaveUpCount === 2) {
@@ -435,19 +433,18 @@ describe("test AssetManager", () => {
 				fail("should not succeed to load");
 				done();
 			},
-			_onAssetError: (a, err, mgr) => {
-				expect(mgr).toBe(manager);
+			_onAssetError: (a, err, callback) => {
 				if (!failureCounts.hasOwnProperty(a.id)) failureCounts[a.id] = 0;
 				++failureCounts[a.id];
 
 				if (!err.retriable) {
 					expect(failureCounts[a.id]).toBe(1);
 					expect(() => {
-						manager.retryLoad(a);
+						callback(a);
 					}).toThrowError("AssertionError");
 					++gaveUpCount;
 				} else {
-					manager.retryLoad(a);
+					callback(a);
 				}
 
 				if (gaveUpCount === 2) {

--- a/src/__tests__/AssetSpec.ts
+++ b/src/__tests__/AssetSpec.ts
@@ -7,7 +7,11 @@ describe("test Asset", () => {
 		const path = "path";
 		const duration = 1984;
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new MusicAudioSystem("music", game);
+		const system = new MusicAudioSystem({
+			id: "music",
+			audioSystemManager: game._audioSystemManager,
+			resourceFactory: game.resourceFactory
+		});
 		const hint = { streaming: true };
 		const asset = new AudioAsset(0, id, path, duration, system, true, hint);
 		expect(asset.id).toBe(id);

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -4,7 +4,6 @@ import { AudioPlayer, Game } from "./helpers";
 describe("test AudioPlayer", () => {
 	it("初期化-music", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		// const system = new MusicAudioSystem("music", game);
 		const system = new MusicAudioSystem({
 			id: "music",
 			audioSystemManager: game._audioSystemManager,

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -4,7 +4,12 @@ import { AudioPlayer, Game } from "./helpers";
 describe("test AudioPlayer", () => {
 	it("初期化-music", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new MusicAudioSystem("music", game);
+		// const system = new MusicAudioSystem("music", game);
+		const system = new MusicAudioSystem({
+			id: "music",
+			audioSystemManager: game._audioSystemManager,
+			resourceFactory: game.resourceFactory
+		});
 		const player = new AudioPlayer(system);
 		expect(player.volume).toBe(system.volume);
 		expect(player.played.constructor).toBe(Trigger);
@@ -14,7 +19,11 @@ describe("test AudioPlayer", () => {
 
 	it("初期化-sound", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new SoundAudioSystem("voice", game);
+		const system = new SoundAudioSystem({
+			id: "voice",
+			audioSystemManager: game._audioSystemManager,
+			resourceFactory: game.resourceFactory
+		});
 		system.volume = 0.5;
 		const player = new AudioPlayer(system);
 		expect(player.volume).toBe(system.volume);

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -6,7 +6,11 @@ expect.extend(customMatchers);
 describe("test AudioPlayer", () => {
 	it("AudioSystem#volumeの入力値チェック", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new MusicAudioSystem("music", game);
+		const system = new MusicAudioSystem({
+			id: "music",
+			audioSystemManager: game._audioSystemManager,
+			resourceFactory: game.resourceFactory
+		});
 		expect(() => {
 			system.volume = NaN!;
 		}).toThrowError();
@@ -35,7 +39,11 @@ describe("test AudioPlayer", () => {
 
 	it("AudioSystem#_destroyRequestedAssets", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new MusicAudioSystem("music", game);
+		const system = new MusicAudioSystem({
+			id: "music",
+			audioSystemManager: game._audioSystemManager,
+			resourceFactory: game.resourceFactory
+		});
 		const audio = new ResourceFactory().createAudioAsset("testId", "testAssetPath", 0, null, false, null);
 		system.requestDestroy(audio);
 		expect(system._destroyRequestedAssets[audio.id]).toEqual(audio);

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -891,7 +891,11 @@ describe("test Game", () => {
 		expect(game.audio.music._muted).toBe(true);
 
 		// 後から追加された AudioSystem でも GameDriver の値を反映する。
-		const myAudioSys = new SoundAudioSystem("voice_chara1", game);
+		const myAudioSys = new SoundAudioSystem({
+			id: "voice_chara1",
+			audioSystemManager: game._audioSystemManager,
+			resourceFactory: game.resourceFactory
+		});
 		game.audio.chara1 = myAudioSys;
 		expect(game.audio.chara1._playbackRate).toBe(1.7);
 		expect(game.audio.chara1._muted).toBe(true);

--- a/src/domain/AssetManager.ts
+++ b/src/domain/AssetManager.ts
@@ -384,7 +384,7 @@ export class AssetManager implements AssetLoadHandler {
 			path = asset.path;
 			if (asset.inUse()) {
 				if (asset.type === "audio") {
-					asset._system.requestDestroy(asset);
+					// asset._contextMgr.requestDestroy(asset);
 				} else if (asset.type === "video") {
 					// NOTE: 一旦再生完了を待たずに破棄することにする
 					// TODO: 再生中の動画を破棄するタイミングをどのように扱うか検討し実装

--- a/src/domain/AssetManager.ts
+++ b/src/domain/AssetManager.ts
@@ -431,7 +431,7 @@ export class AssetManager implements AssetLoadHandler {
 			error = ExceptionFactory.createAssetLoadError("Retry limit exceeded", false, AssetLoadErrorType.RetryLimitExceeded, error);
 		}
 		if (!error.retriable) delete this._loadings[asset.id];
-		for (var i = 0; i < hs.length; ++i) hs[i]._onAssetError(asset, error, this);
+		for (var i = 0; i < hs.length; ++i) hs[i]._onAssetError(asset, error, (_asset: AssetLike) => this.retryLoad(_asset));
 	}
 
 	/**

--- a/src/domain/AssetManagerLoadHandler.ts
+++ b/src/domain/AssetManagerLoadHandler.ts
@@ -1,6 +1,5 @@
 import { AssetLike } from "../interfaces/AssetLike";
 import { AssetLoadError } from "../types/errors";
-import { AssetManager } from "./AssetManager";
 
 /**
  * `AssetManager` から `Asset` の読み込みまたは読み込み失敗を受け取るハンドラのインターフェース定義。
@@ -11,9 +10,9 @@ export interface AssetManagerLoadHandler {
 	 * 読み込失敗の通知を受ける関数。
 	 * @param asset 読み込みに失敗したアセット
 	 * @param error 失敗の内容を表すエラー
-	 * @param manager アセットの読み込みを試みた`AssetManager`. この値の `retryLoad()` を呼び出すことで読み込みを再試行できる
+	 * @param callback `読み込みの再試行を行うコールバック関数
 	 */
-	_onAssetError(asset: AssetLike, error: AssetLoadError, manager: AssetManager): void;
+	_onAssetError(asset: AssetLike, error: AssetLoadError, callback?: (asset: AssetLike) => void): void;
 
 	/**
 	 * 読み込み完了の通知を受ける関数。

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -1,4 +1,4 @@
-import { Game } from "../Game";
+import { AudioSystemLike } from "../interfaces/AudioSystemLike";
 
 /**
  * `Game#audio` の管理クラス。
@@ -10,11 +10,6 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_game: Game;
-
-	/**
-	 * @private
-	 */
 	_muted: boolean;
 
 	/**
@@ -22,8 +17,7 @@ export class AudioSystemManager {
 	 */
 	_playbackRate: number;
 
-	constructor(game: Game) {
-		this._game = game;
+	constructor() {
 		this._muted = false;
 		this._playbackRate = 1.0;
 	}
@@ -31,10 +25,9 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_reset(): void {
+	_reset(systems: { [key: string]: AudioSystemLike }): void {
 		this._muted = false;
 		this._playbackRate = 1.0;
-		var systems = this._game.audio;
 		for (var id in systems) {
 			if (!systems.hasOwnProperty(id)) continue;
 			systems[id]._reset();
@@ -44,11 +37,10 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_setMuted(muted: boolean): void {
+	_setMuted(muted: boolean, systems: { [key: string]: AudioSystemLike }): void {
 		if (this._muted === muted) return;
 
 		this._muted = muted;
-		var systems = this._game.audio;
 		for (var id in systems) {
 			if (!systems.hasOwnProperty(id)) continue;
 			systems[id]._setMuted(muted);
@@ -58,11 +50,10 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_setPlaybackRate(rate: number): void {
+	_setPlaybackRate(rate: number, systems: { [key: string]: AudioSystemLike }): void {
 		if (this._playbackRate === rate) return;
 
 		this._playbackRate = rate;
-		var systems = this._game.audio;
 		for (var id in systems) {
 			if (!systems.hasOwnProperty(id)) continue;
 			systems[id]._setPlaybackRate(rate);

--- a/src/domain/PlaingContextManager.ts
+++ b/src/domain/PlaingContextManager.ts
@@ -1,0 +1,87 @@
+import { PlaingContextLike } from "../interfaces/PlaingContextLike";
+import { PlaingContextManagerLike } from "../interfaces/PlaingContextManagerLike";
+import { PlayableDataLike } from "../interfaces/PlayableDataLike";
+
+export class PlaingContextManager implements PlaingContextManagerLike {
+	_soundContexts: PlaingContextLike[];
+	_musicContexts: PlaingContextLike;
+	_muted: boolean;
+	_playbackRate: number;
+	hoge: number[];
+
+	constructor() {
+		// nop
+		this._muted = false;
+		this._playbackRate = 1.0;
+		this._musicContexts = undefined;
+		this._soundContexts = [];
+		this.hoge = [];
+	}
+
+	addContext(ctx: PlaingContextLike): void {
+		if (ctx.id === "music") {
+			this._musicContexts = ctx;
+		} else {
+			this._soundContexts.push(ctx);
+		}
+	}
+	removeContext(ctx: PlaingContextLike): void {
+		if (ctx.id === "music") {
+			this._musicContexts.stop();
+			this._musicContexts = undefined;
+		} else {
+			this._soundContexts = this._soundContexts.filter(target => target !== ctx);
+		}
+	}
+
+	requestDestroy(asset: PlayableDataLike): void {
+		throw new Error("Method not implemented.");
+	}
+
+	findMusicContext(asset: PlayableDataLike): PlaingContextLike[] {
+		// if (this.player.currentAudio && this.player.currentAudio.id === asset.id) return [this.player];
+		return [this._musicContexts];
+		// return [];
+	}
+	findSoundContext(asset: PlayableDataLike): PlaingContextLike[] {
+		var ret: PlaingContextLike[] = [];
+		for (let i = 0; i < this._soundContexts.length; ++i) {
+			if (this._soundContexts[i].currentAudioData && this._soundContexts[i].currentAudioData.id === asset.id)
+				ret.push(this._soundContexts[i]);
+		}
+		return ret;
+	}
+
+	findContext(asset: PlayableDataLike): PlaingContextLike[] {
+		if (asset.id === "music") return this.findMusicContext(asset);
+		else return this.findSoundContext(asset);
+	}
+	stopAll(): void {
+		if (this._musicContexts) this._musicContexts.stop();
+
+		const ctxs = this._soundContexts;
+		for (let i = 0; i < ctxs.length; ++i) {
+			ctxs[i].stop();
+		}
+	}
+	_reset(): void {
+		this._muted = false;
+		this._playbackRate = 1.0;
+		for (let i = 0; i < this._soundContexts.length; ++i) {
+			this._soundContexts[i]._reset();
+		}
+
+		this._musicContexts._reset();
+	}
+	_setMuted(muted: boolean): void {
+		if (this._muted === muted) return;
+
+		this._muted = muted;
+		for (let i = 0; i < this._soundContexts.length; ++i) {
+			this._soundContexts[i]._setMuted(muted);
+		}
+	}
+	_setPlaybackRate(value: number): void {
+		throw new Error("Method not implemented.");
+	}
+}

--- a/src/implementations/PlaingContext.ts
+++ b/src/implementations/PlaingContext.ts
@@ -1,0 +1,292 @@
+import { ExceptionFactory } from "../commons/ExceptionFactory";
+// import { AudioSystemManager } from "../domain/AudioSystemManager";
+import { AudioContextEvent, PlaingContextLike } from "../interfaces/PlaingContextLike";
+// import { PlaingContextManagerLike } from "../interfaces/PlaingContextManagerLike";
+import { PlayableDataLike } from "../interfaces/PlayableDataLike";
+import { ResourceFactoryLike } from "../interfaces/ResourceFactoryLike";
+import { Trigger } from "../Trigger";
+
+export interface PlaingContextParameterObject {
+	id: string;
+
+	// plaingContextManager: PlaingContextManagerLike;
+
+	resourceFactory: ResourceFactoryLike;
+}
+
+export abstract class PlaingContext implements PlaingContextLike {
+	id: string;
+	_volume: number;
+	_muted: boolean;
+	_destroyRequestedAssets: { [key: string]: PlayableDataLike };
+	_playbackRate: number;
+	currentAudioData: PlayableDataLike;
+	played: Trigger<AudioContextEvent>;
+	stopped: Trigger<AudioContextEvent>;
+	_resourceFactory: ResourceFactoryLike;
+	// _contextManager: any;
+
+	// volumeの変更時には通知が必要なのでアクセサを使う。
+	// 呼び出し頻度が少ないため許容。
+	get volume(): number {
+		return this._volume;
+	}
+
+	set volume(value: number) {
+		if (value < 0 || value > 1 || isNaN(value) || typeof value !== "number")
+			throw ExceptionFactory.createAssertionError("AudioSystem#volume: expected: 0.0-1.0, actual: " + value);
+
+		this._volume = value;
+		this._onVolumeChanged();
+	}
+
+	constructor(param: PlaingContextParameterObject) {
+		this.id = param.id;
+		this._volume = 1;
+		this._resourceFactory = param.resourceFactory;
+	}
+
+	play(playData: PlayableDataLike): void {
+		this.currentAudioData = playData;
+		this.played.fire({
+			context: this,
+			audioData: playData
+		});
+	}
+	stop(): void {
+		if (!this.currentAudioData) return;
+		this.currentAudioData = undefined;
+		this.stopped.fire({
+			context: this,
+			audioData: this.currentAudioData
+		});
+	}
+
+	requestDestroy(playData: PlayableDataLike): void {
+		this._destroyRequestedAssets[playData.id] = playData;
+	}
+
+	/**
+	 * 音声の終了を検知できるか否か。
+	 * 通常、ゲーム開発者がこのメソッドを利用する必要はない。
+	 */
+	canHandleStopped(): boolean {
+		return true;
+	}
+	changeVolume(volume: number): void {
+		this.volume = volume;
+	}
+
+	abstract _onMutedChanged(): void;
+	abstract _onPlaybackRateChanged(): void;
+	abstract stopAll(): void;
+
+	_reset(): void {
+		this.stopAll();
+		this._volume = 1;
+		this._destroyRequestedAssets = {};
+		this._muted = this._muted;
+		this._playbackRate = this._playbackRate;
+	}
+
+	_changeMuted(muted: boolean): void {
+		this._muted = muted;
+	}
+	_changePlaybackRate(rate: number): void {
+		this._playbackRate = rate;
+	}
+	_supportsPlaybackRate(): boolean {
+		return false;
+	}
+	_onVolumeChanged(): void {
+		this.changeVolume(this._volume);
+	}
+
+	_setMuted(value: boolean): void {
+		var before = this._muted;
+		this._muted = !!value;
+		if (this._muted !== before) {
+			this._onMutedChanged();
+		}
+	}
+	_setPlaybackRate(value: number): void {
+		if (value < 0 || isNaN(value) || typeof value !== "number")
+			throw ExceptionFactory.createAssertionError("AudioSystem#playbackRate: expected: greater or equal to 0.0, actual: " + value);
+
+		var before = this._playbackRate;
+		this._playbackRate = value;
+		if (this._playbackRate !== before) {
+			this._onPlaybackRateChanged();
+		}
+	}
+}
+
+export class MusicContext extends PlaingContext {
+	get context(): PlaingContextLike {
+		if (!this._context) {
+			this._context = this._resourceFactory.createAudioContext(this);
+			this._context.played.add(this._onPlayerPlayed, this);
+			this._context.stopped.add(this._onPlayerStopped, this);
+		}
+		return this._context;
+	}
+	set context(ctx: PlaingContextLike) {
+		this._context = ctx;
+	}
+	_context: PlaingContextLike;
+	_suppressingAudio: PlayableDataLike;
+
+	constructor(param: PlaingContextParameterObject) {
+		super(param);
+		this._context = undefined;
+		this._suppressingAudio = undefined;
+	}
+
+	stopAll(): void {
+		if (!this._context) return;
+		this._context.stop();
+	}
+
+	_onMutedChanged(): void {
+		this.context.changeVolume(this._volume);
+	}
+
+	_onPlaybackRateChanged(): void {
+		this.context._changePlaybackRate(this._playbackRate);
+		if (!this.context._supportsPlaybackRate()) {
+			this._onUnsupportedPlaybackRateChanged();
+		}
+	}
+	_onUnsupportedPlaybackRateChanged(): void {
+		// 再生速度非対応の場合のフォールバック: 鳴らそうとしてミュートしていた音があれば鳴らし直す
+		if (this._playbackRate === 1.0) {
+			if (this._suppressingAudio) {
+				const audio = this._suppressingAudio;
+				this._suppressingAudio = undefined;
+				if (!audio.isDestroy()) {
+					this.context._changeMuted(false);
+				}
+			}
+		}
+	}
+
+	_reset(): void {
+		super._reset();
+		if (this._context) {
+			this._context.played.remove({ owner: this, func: this._onPlayerPlayed });
+			this._context.stopped.remove({ owner: this, func: this._onPlayerStopped });
+		}
+		this._context = undefined;
+		this._suppressingAudio = undefined;
+	}
+
+	_onPlayerPlayed(e: AudioContextEvent): void {
+		if (e.context !== this._context)
+			throw ExceptionFactory.createAssertionError("MusicAudioSystem#_onPlayerPlayed: unexpected audio player");
+
+		if (e.context._supportsPlaybackRate()) return;
+
+		// 再生速度非対応の場合のフォールバック: 鳴らさず即ミュートにする
+		if (this._playbackRate !== 1.0) {
+			e.context._changeMuted(true);
+			this._suppressingAudio = e.audioData;
+		}
+	}
+	_onPlayerStopped(e: AudioContextEvent): void {
+		if (this._suppressingAudio) {
+			this._suppressingAudio = undefined;
+			this.context._changeMuted(false);
+		}
+		if (this._destroyRequestedAssets[e.context.id]) {
+			delete this._destroyRequestedAssets[e.context.id];
+			e.audioData.destroy();
+		}
+	}
+
+	_onVolumeChanged(): void {
+		this.context.changeVolume(this._volume);
+	}
+}
+
+export class SoundContext extends PlaingContext {
+	contexts: PlaingContextLike[];
+
+	constructor(param: PlaingContextParameterObject) {
+		super(param);
+		this.contexts = [];
+	}
+
+	/**
+	 * @private
+	 */
+	_onMutedChanged(): void {
+		var ctxs = this.contexts;
+		for (var i = 0; i < ctxs.length; ++i) {
+			ctxs[i]._changeMuted(this._muted);
+		}
+	}
+	/**
+	 * @private
+	 */
+	_onPlaybackRateChanged(): void {
+		var ctxs = this.contexts;
+		for (var i = 0; i < ctxs.length; ++i) {
+			ctxs[i]._changePlaybackRate(this._playbackRate);
+
+			// 再生速度非対応の場合のフォールバック: 即止める
+			if (!ctxs[i]._supportsPlaybackRate() && this._playbackRate !== 1.0) {
+				ctxs[i].stop();
+			}
+		}
+	}
+	/**
+	 * @private
+	 */
+	_onPlayerPlayed(e: AudioContextEvent): void {
+		if (e.context._supportsPlaybackRate()) return;
+
+		// 再生速度非対応の場合のフォールバック: 鳴らさず即止める
+		if (this._playbackRate !== 1.0) {
+			e.context.stop();
+		}
+	}
+	/**
+	 * @private
+	 */
+	_onPlayerStopped(e: AudioContextEvent): void {
+		var index = this.contexts.indexOf(e.context);
+		if (index < 0) return;
+
+		e.context.stopped.remove({ owner: this, func: this._onPlayerStopped });
+		this.contexts.splice(index, 1);
+		if (this._destroyRequestedAssets[e.audioData.id]) {
+			delete this._destroyRequestedAssets[e.audioData.id];
+			e.audioData.destroy();
+		}
+	}
+
+	/**
+	 * @private
+	 */
+	_onVolumeChanged(): void {
+		for (var i = 0; i < this.contexts.length; ++i) {
+			this.contexts[i].changeVolume(this._volume);
+		}
+	}
+
+	_reset(): void {
+		super._reset();
+		for (var i = 0; i < this.contexts.length; ++i) {
+			const ctx = this.contexts[i];
+			ctx.played.remove({ owner: this, func: this._onPlayerPlayed });
+			ctx.stopped.remove({ owner: this, func: this._onPlayerStopped });
+		}
+		this.contexts = [];
+	}
+
+	stopAll(): void {
+		for (var i = 0; i < this.contexts.length; ++i) {
+			this.contexts[i].stop(); // auto remove
+		}
+	}
+}

--- a/src/implementations/PlaingContextFactory.ts
+++ b/src/implementations/PlaingContextFactory.ts
@@ -1,0 +1,12 @@
+import { PlaingContextLike } from "../interfaces/PlaingContextLike";
+import { MusicContext, PlaingContextParameterObject, SoundContext } from "./PlaingContext";
+
+export class ContextFactory {
+	static create(type: string, param: PlaingContextParameterObject): PlaingContextLike {
+		if (type === "music") {
+			return new MusicContext(param);
+		} else {
+			return new SoundContext(param);
+		}
+	}
+}

--- a/src/implementations/PlayableData.ts
+++ b/src/implementations/PlayableData.ts
@@ -1,0 +1,54 @@
+import { PlaingContextLike } from "../interfaces/PlaingContextLike";
+import { PlayableDataLike } from "../interfaces/PlayableDataLike";
+import { Trigger } from "../Trigger";
+import { AudioAssetHint } from "../types/AssetConfiguration";
+
+interface PlayableDataParameter {
+	id: string;
+	duration: number;
+	loop: boolean;
+	hint: AudioAssetHint;
+	volume: number;
+	_muted?: boolean;
+	_playbackRate?: number;
+}
+
+export class PlayableData implements PlayableDataLike {
+	id: string;
+	duration: number;
+	loop: boolean;
+	hint: AudioAssetHint;
+	volume: number;
+	_muted: boolean;
+	_playbackRate: number;
+	destroyed: Trigger<void>;
+	playStart: Trigger<PlaingContextLike>;
+	playStop: Trigger<void>;
+
+	constructor(params: PlayableDataParameter) {
+		this.id = params.id;
+		this.duration = params.duration;
+		this.loop = params.loop;
+		this.hint = params.hint;
+		this._muted = params._muted;
+		this._playbackRate = params._playbackRate;
+		this.destroyed = new Trigger<void>();
+		this.playStart = new Trigger<PlaingContextLike>();
+		this.playStop = new Trigger<void>();
+	}
+
+	play(): void {
+		this.playStart.fire();
+	}
+	stop(): void {
+		this.playStop.fire();
+	}
+
+	destroy(): void {
+		this.destroyed.fire();
+		this.id = undefined;
+	}
+	isDestroy(): boolean {
+		return this.id === undefined;
+	}
+}

--- a/src/implementations/ResourceFactory.ts
+++ b/src/implementations/ResourceFactory.ts
@@ -1,4 +1,5 @@
 import { SurfaceAtlas } from "../commons/SurfaceAtlas";
+import { PlaingContext } from "../index.runtime";
 import { AudioAssetLike } from "../interfaces/AudioAssetLike";
 import { AudioPlayerLike } from "../interfaces/AudioPlayerLike";
 import { AudioSystemLike } from "../interfaces/AudioSystemLike";
@@ -49,6 +50,8 @@ export abstract class ResourceFactory implements ResourceFactoryLike {
 	abstract createAudioPlayer(system: AudioSystemLike): AudioPlayerLike;
 
 	abstract createScriptAsset(id: string, assetPath: string): ScriptAssetLike;
+
+	abstract createAudioContext(id: string): PlaingContext;
 
 	/**
 	 * Surface を作成する。

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,14 @@ export * from "./implementations/TextAsset";
 export * from "./implementations/VideoAsset";
 export * from "./implementations/VideoPlayer";
 
+export * from "./domain/PlaingContextManager";
+export * from "./implementations/PlaingContext";
+export * from "./implementations/PlaingContextFactory";
+export * from "./implementations/PlayableDAta";
+export * from "./interfaces/PlayableDataLike";
+export * from "./interfaces/PlaingContextLike";
+export * from "./interfaces/PlaingContextManagerLike";
+
 export * from "./interfaces/AssetLike";
 export * from "./interfaces/AssetLoadFailureInfo";
 export * from "./interfaces/AudioAssetLike";

--- a/src/interfaces/AudioAssetLike.ts
+++ b/src/interfaces/AudioAssetLike.ts
@@ -1,7 +1,7 @@
-import { AudioAssetHint } from "../types/AssetConfiguration";
 import { AssetLike } from "./AssetLike";
-import { AudioPlayerLike } from "./AudioPlayerLike";
-import { AudioSystemLike } from "./AudioSystemLike";
+import { PlaingContextLike } from "./PlaingContextLike";
+import { PlaingContextManagerLike } from "./PlaingContextManagerLike";
+import { PlayableDataLike } from "./PlayableDataLike";
 
 /**
  * 音リソースを表すインターフェース。
@@ -13,15 +13,14 @@ import { AudioSystemLike } from "./AudioSystemLike";
  */
 export interface AudioAssetLike extends AssetLike {
 	type: "audio";
-	data: any;
-	duration: number;
-	loop: boolean;
-	hint: AudioAssetHint;
-	_system: AudioSystemLike;
 
-	play(): AudioPlayerLike;
+	playableData: PlayableDataLike;
+
+	_contextMgr: PlaingContextManagerLike;
+
+	play(): PlaingContextLike;
 
 	stop(): void;
 
-	inUse(): boolean;
+	createPlaingContext(): PlaingContextLike;
 }

--- a/src/interfaces/PlaingContextLike.ts
+++ b/src/interfaces/PlaingContextLike.ts
@@ -1,0 +1,149 @@
+import { Trigger } from "../Trigger";
+import { PlayableDataLike } from "./PlayableDataLike";
+
+export interface AudioContextEvent {
+	context: PlaingContextLike;
+	audioData: PlayableDataLike;
+}
+
+export interface PlaingContextLike {
+	id: string;
+
+	/**
+	 * @private
+	 */
+	_volume: number;
+
+	/**
+	 * @private
+	 */
+	_muted: boolean;
+
+	/**
+	 * @private
+	 */
+	// _destroyRequestedAssets: { [key: string]: PlayableDataLike };
+
+	/**
+	 * @private
+	 */
+	_playbackRate: number;
+
+	/**
+	 * 再生中のオーディオアセット。
+	 * 再生中のものがない場合、 `undefined` 。
+	 */
+	currentAudioData: PlayableDataLike;
+
+	/**
+	 * `play()` が呼び出された時に通知される `Trigger` 。
+	 */
+	played: Trigger<AudioContextEvent>;
+
+	/**
+	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 */
+	stopped: Trigger<AudioContextEvent>;
+
+	/**
+	 * `AudioAsset` を再生する。
+	 *
+	 * 再生後、 `this.played` がfireされる。
+	 * @param audio 再生するオーディオアセット
+	 */
+	play(audio: PlayableDataLike): void;
+
+	/**
+	 * 再生を停止する。
+	 *
+	 * 停止後、 `this.stopped` がfireされる。
+	 * 再生中でない場合、何もしない(`stopped` もfireされない)。
+	 */
+	stop(): void;
+
+	/**
+	 * 音声の終了を検知できるか否か。
+	 * 通常、ゲーム開発者がこのメソッドを利用する必要はない。
+	 */
+	canHandleStopped(): boolean;
+
+	/**
+	 * 音量を変更する。
+	 *
+	 * @param volume 音量。0以上1.0以下でなければならない
+	 */
+	// エンジンユーザが `AudioPlayer` の派生クラスを実装する場合は、
+	// `_changeMuted()` などと同様、このメソッドをオーバーライドして実際に音量を変更する処理を行うこと。
+	// オーバーライド先のメソッドはこのメソッドを呼びださなければならない。
+	changeVolume(volume: number): void;
+
+	/**
+	 * ミュート状態を変更する。
+	 *
+	 * エンジンユーザが `AudioPlayer` の派生クラスを実装する場合は、
+	 * このメソッドをオーバーライドして実際にミュート状態を変更する処理を行うこと。
+	 * オーバーライド先のメソッドはこのメソッドを呼びださなければならない。
+	 *
+	 * @param muted ミュート状態にするか否か
+	 * @private
+	 */
+	_changeMuted(muted: boolean): void;
+
+	/**
+	 * 再生速度を変更する。
+	 *
+	 * エンジンユーザが `AudioPlayer` の派生クラスを実装し、
+	 * かつ `this._supportsPlaybackRate()` をオーバライドして真を返すようにするならば、
+	 * このメソッドもオーバーライドして実際に再生速度を変更する処理を行うこと。
+	 * オーバーライド先のメソッドはこのメソッドを呼びださなければならない。
+	 *
+	 * @param rate 再生速度の倍率。0以上でなければならない。1.0で等倍である。
+	 * @private
+	 */
+	_changePlaybackRate(rate: number): void;
+
+	/**
+	 * 再生速度の変更に対応するか否か。
+	 *
+	 * エンジンユーザが `AudioPlayer` の派生クラスを実装し、
+	 * 再生速度の変更に対応する場合、このメソッドをオーバーライドして真を返さねばならない。
+	 * その場合 `_changePlaybackRate()` もオーバーライドし、実際の再生速度変更処理を実装しなければならない。
+	 *
+	 * なおここで「再生速度の変更に対応する」は、任意の速度で実際に再生できることを意味しない。
+	 * 実装は等倍速 (再生速度1.0) で実際に再生できなければならない。
+	 * しかしそれ以外の再生速度が指定された場合、実装はまるで音量がゼロであるかのように振舞ってもよい。
+	 *
+	 * このメソッドが偽を返す場合、エンジンは音声の非等倍速度再生に対するデフォルトの処理を実行する。
+	 * @private
+	 */
+	_supportsPlaybackRate(): boolean;
+
+	/**
+	 * 音量の変更を通知する。
+	 * @deprecated このメソッドは実験的に導入されたが、利用されていない。将来的に削除される。
+	 */
+	_onVolumeChanged(): void;
+
+	_onPlaybackRateChanged(): void;
+
+	_onMutedChanged(): void;
+
+	_reset(): void;
+
+	_setMuted(value: boolean): void;
+
+	_setPlaybackRate(value: number): void;
+
+	stopAll(): void;
+}
+
+export interface MusicContextLike extends PlaingContextLike {
+	type: "music";
+	// _suppressingAudio: AudioAssetLike2;
+}
+
+export interface SoundContextLike extends PlaingContextLike {
+	type: "sound";
+	_onPlayerPlayed(e: AudioContextEvent): void;
+	_onPlayerStopped(e: AudioContextEvent): void;
+}

--- a/src/interfaces/PlaingContextManagerLike.ts
+++ b/src/interfaces/PlaingContextManagerLike.ts
@@ -1,0 +1,37 @@
+import { PlaingContextLike } from "./PlaingContextLike";
+import { PlayableDataLike } from "./PlayableDataLike";
+
+export interface PlaingContextManagerLike {
+	_soundContexts: PlaingContextLike[];
+	_musicContexts: PlaingContextLike;
+
+	addContext(ctx: PlaingContextLike): void;
+
+	removeContext(ctx: PlaingContextLike): void;
+
+	stopAll(): void;
+
+	findContext(asset: PlayableDataLike): PlaingContextLike[];
+
+	findMusicContext(asset: PlayableDataLike): PlaingContextLike[];
+
+	findSoundContext(asset: PlayableDataLike): PlaingContextLike[];
+
+	requestDestroy(asset: PlayableDataLike): void;
+
+	/**
+	 * @private
+	 */
+	_reset(): void;
+
+	/**
+	 * @private
+	 */
+	// _setMuted(value: boolean): void;
+	_setMuted(muted: boolean, systems: { [key: string]: PlaingContextLike }): void;
+
+	/**
+	 * @private
+	 */
+	_setPlaybackRate(value: number): void;
+}

--- a/src/interfaces/PlayableDataLike.ts
+++ b/src/interfaces/PlayableDataLike.ts
@@ -1,0 +1,30 @@
+import { AudioAssetHint } from "../types/AssetConfiguration";
+
+export interface PlayableDataLike {
+	id: string;
+	duration: number;
+	loop: boolean;
+	hint: AudioAssetHint;
+
+	volume: number;
+
+	/**
+	 * ミュート中か否か。
+	 * @private
+	 */
+	_muted?: boolean;
+
+	/**
+	 * 再生速度の倍率。
+	 * @private
+	 */
+	_playbackRate?: number;
+
+	play(): void;
+
+	stop(): void;
+
+	destroy(): void;
+
+	isDestroy(): boolean;
+}

--- a/src/interfaces/ResourceFactoryLike.ts
+++ b/src/interfaces/ResourceFactoryLike.ts
@@ -6,6 +6,7 @@ import { AudioPlayerLike } from "./AudioPlayerLike";
 import { AudioSystemLike } from "./AudioSystemLike";
 import { GlyphFactoryLike } from "./GlyphFactoryLike";
 import { ImageAssetLike } from "./ImageAssetLike";
+import { PlaingContextLike } from "./PlaingContextLike";
 import { ScriptAssetLike } from "./ScriptAssetLike";
 import { SurfaceAtlasLike } from "./SurfaceAtlasLike";
 import { SurfaceLike } from "./SurfaceLike";
@@ -37,7 +38,7 @@ export interface ResourceFactoryLike {
 		id: string,
 		assetPath: string,
 		duration: number,
-		system: AudioSystemLike,
+		system: AudioSystemLike | PlaingContextLike,
 		loop: boolean,
 		hint: AudioAssetHint
 	): AudioAssetLike;
@@ -47,6 +48,8 @@ export interface ResourceFactoryLike {
 	createAudioPlayer(system: AudioSystemLike): AudioPlayerLike;
 
 	createScriptAsset(id: string, assetPath: string): ScriptAssetLike;
+
+	createAudioContext(system: any): any;
 
 	/**
 	 * Surface を作成する。


### PR DESCRIPTION
## このpull requestが解決する内容

**このPRは解決していないためCLOSEとする**

`AudioAsset`, `AudioPlayer`, `AudioSystem` の循環参照を解決するため、classを下記4つにし循環参照を解決できる事がわかった。

-`AudioAsset` : asset
-`PlayableData`: playに関するdata
-`PlaingContext`: AudioPlayerとAudioSystemの性質を持つ
-`PlaingContextFactory`: contextのFactory

しかし、上記のようなclassで修正すると大きく下記2点の問題が出てくる。
- pdi層の問題:  
  - AudioAssset,AudioPlayerが変わるため、ロジックの追従が必要となる。
  - サーバサイドの追従が完了するまで、pdi層へ送るplayableDataをAudioAssetへ変換するadapterの用意が必要となる
- 開発者への問題
  - AudioAssetが変更となるため、今まで `asset as AudioAsset` のように使用していたロジックが全て使えなくなる。


