### PR TITLE
remove circular dependencies

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -501,10 +501,18 @@ export abstract class Game implements Registrable<E> {
 		this.selfId = selfId || undefined;
 		this.playId = undefined;
 
-		this._audioSystemManager = new AudioSystemManager(this);
+		this._audioSystemManager = new AudioSystemManager();
 		this.audio = {
-			music: new MusicAudioSystem("music", this),
-			sound: new SoundAudioSystem("sound", this)
+			music: new MusicAudioSystem({
+				id: "music",
+				audioSystemManager: this._audioSystemManager,
+				resourceFactory: this.resourceFactory
+			}),
+			sound: new SoundAudioSystem({
+				id: "sound",
+				audioSystemManager: this._audioSystemManager,
+				resourceFactory: this.resourceFactory
+			})
 		};
 		this.defaultAudioSystemId = "sound";
 		this.storage = new Storage();
@@ -946,14 +954,14 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_setAudioPlaybackRate(playbackRate: number): void {
-		this._audioSystemManager._setPlaybackRate(playbackRate);
+		this._audioSystemManager._setPlaybackRate(playbackRate, this.audio);
 	}
 
 	/**
 	 * @private
 	 */
 	_setMuted(muted: boolean): void {
-		this._audioSystemManager._setMuted(muted);
+		this._audioSystemManager._setMuted(muted, this.audio);
 	}
 
 	/**
@@ -988,7 +996,7 @@ export abstract class Game implements Registrable<E> {
 			if (param.randGen !== undefined) this.random = param.randGen;
 		}
 
-		this._audioSystemManager._reset();
+		this._audioSystemManager._reset(this.audio);
 		this._loaded.removeAll({ func: this._start, owner: this });
 		this.join.removeAll();
 		this.leave.removeAll();
@@ -1100,7 +1108,6 @@ export abstract class Game implements Registrable<E> {
 		this._mainParameter = undefined;
 		this._assetManager.destroy();
 		this._assetManager = undefined;
-		this._audioSystemManager._game = undefined;
 		this._audioSystemManager = undefined;
 		this._operationPluginManager = undefined;
 		this._operationPluginOperated.destroy();

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -514,6 +514,8 @@ export abstract class Game implements Registrable<E> {
 				resourceFactory: this.resourceFactory
 			})
 		};
+		this._audioSystemManager.systems = this.audio;
+
 		this.defaultAudioSystemId = "sound";
 		this.storage = new Storage();
 		this.assets = {};
@@ -954,14 +956,14 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_setAudioPlaybackRate(playbackRate: number): void {
-		this._audioSystemManager._setPlaybackRate(playbackRate, this.audio);
+		this._audioSystemManager._setPlaybackRate(playbackRate);
 	}
 
 	/**
 	 * @private
 	 */
 	_setMuted(muted: boolean): void {
-		this._audioSystemManager._setMuted(muted, this.audio);
+		this._audioSystemManager._setMuted(muted);
 	}
 
 	/**
@@ -996,7 +998,7 @@ export abstract class Game implements Registrable<E> {
 			if (param.randGen !== undefined) this.random = param.randGen;
 		}
 
-		this._audioSystemManager._reset(this.audio);
+		this._audioSystemManager._reset();
 		this._loaded.removeAll({ func: this._start, owner: this });
 		this.join.removeAll();
 		this.leave.removeAll();

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -516,6 +516,7 @@ export abstract class Game implements Registrable<E> {
 				resourceFactory: this.resourceFactory
 			})
 		};
+		// TODO: AudioSystemManager, AudioSystem関連のリファクタリングが行われるまでの一時的な対応とする
 		this._audioSystemManager.systems = this.audio;
 
 		this.defaultAudioSystemId = "sound";

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -516,6 +516,7 @@ export abstract class Game implements Registrable<E> {
 				resourceFactory: this.resourceFactory
 			})
 		};
+		this._audioSystemManager.systems = this.audio;
 
 		this.defaultAudioSystemId = "sound";
 		this.storage = new Storage();
@@ -957,14 +958,14 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_setAudioPlaybackRate(playbackRate: number): void {
-		this._audioSystemManager._setPlaybackRate(playbackRate, this.audio);
+		this._audioSystemManager._setPlaybackRate(playbackRate);
 	}
 
 	/**
 	 * @private
 	 */
 	_setMuted(muted: boolean): void {
-		this._audioSystemManager._setMuted(muted, this.audio);
+		this._audioSystemManager._setMuted(muted);
 	}
 
 	/**
@@ -999,7 +1000,7 @@ export abstract class Game implements Registrable<E> {
 			if (param.randGen !== undefined) this.random = param.randGen;
 		}
 
-		this._audioSystemManager._reset(this.audio);
+		this._audioSystemManager._reset();
 		this._loaded.removeAll({ func: this._start, owner: this });
 		this.join.removeAll();
 		this.leave.removeAll();

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -154,7 +154,7 @@ export class SceneAssetHolder {
 	/**
 	 * @private
 	 */
-	_onAssetError(asset: AssetLike, error: AssetLoadError, assetManager: AssetManager): void {
+	_onAssetError(asset: AssetLike, error: AssetLoadError): void {
 		if (this.destroyed() || this._scene.destroyed()) return;
 		var failureInfo = {
 			asset: asset,

--- a/src/__tests__/AssetManagerSpec.ts
+++ b/src/__tests__/AssetManagerSpec.ts
@@ -369,11 +369,10 @@ describe("test AssetManager", () => {
 					done();
 				}
 			},
-			_onAssetError: (a, err, mgr) => {
-				expect(mgr).toBe(manager);
+			_onAssetError: (a, err, callback) => {
 				if (!failureCounts.hasOwnProperty(a.id)) failureCounts[a.id] = 0;
 				++failureCounts[a.id];
-				manager.retryLoad(a);
+				callback(a);
 			}
 		};
 
@@ -394,19 +393,18 @@ describe("test AssetManager", () => {
 				fail("should not succeed to load");
 				done();
 			},
-			_onAssetError: (a, err, mgr) => {
-				expect(mgr).toBe(manager);
+			_onAssetError: (a, err, callback) => {
 				if (!failureCounts.hasOwnProperty(a.id)) failureCounts[a.id] = 0;
 				++failureCounts[a.id];
 
 				if (!err.retriable) {
 					expect(failureCounts[a.id]).toBe(AssetManager.MAX_ERROR_COUNT + 1);
 					expect(() => {
-						manager.retryLoad(a);
+						callback(a);
 					}).toThrowError("AssertionError");
 					++gaveUpCount;
 				} else {
-					manager.retryLoad(a);
+					callback(a);
 				}
 
 				if (gaveUpCount === 2) {
@@ -435,19 +433,18 @@ describe("test AssetManager", () => {
 				fail("should not succeed to load");
 				done();
 			},
-			_onAssetError: (a, err, mgr) => {
-				expect(mgr).toBe(manager);
+			_onAssetError: (a, err, callback) => {
 				if (!failureCounts.hasOwnProperty(a.id)) failureCounts[a.id] = 0;
 				++failureCounts[a.id];
 
 				if (!err.retriable) {
 					expect(failureCounts[a.id]).toBe(1);
 					expect(() => {
-						manager.retryLoad(a);
+						callback(a);
 					}).toThrowError("AssertionError");
 					++gaveUpCount;
 				} else {
-					manager.retryLoad(a);
+					callback(a);
 				}
 
 				if (gaveUpCount === 2) {

--- a/src/__tests__/AssetSpec.ts
+++ b/src/__tests__/AssetSpec.ts
@@ -9,7 +9,8 @@ describe("test Asset", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 		const system = new MusicAudioSystem({
 			id: "music",
-			audioSystemManager: game._audioSystemManager,
+			muted: game._audioSystemManager._muted,
+			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		const hint = { streaming: true };

--- a/src/__tests__/AssetSpec.ts
+++ b/src/__tests__/AssetSpec.ts
@@ -7,7 +7,11 @@ describe("test Asset", () => {
 		const path = "path";
 		const duration = 1984;
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new MusicAudioSystem("music", game);
+		const system = new MusicAudioSystem({
+			id: "music",
+			audioSystemManager: game._audioSystemManager,
+			resourceFactory: game.resourceFactory
+		});
 		const hint = { streaming: true };
 		const asset = new AudioAsset(0, id, path, duration, system, true, hint);
 		expect(asset.id).toBe(id);

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -6,7 +6,8 @@ describe("test AudioPlayer", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 		const system = new MusicAudioSystem({
 			id: "music",
-			audioSystemManager: game._audioSystemManager,
+			muted: game._audioSystemManager._muted,
+			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		const player = new AudioPlayer(system);
@@ -20,7 +21,8 @@ describe("test AudioPlayer", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 		const system = new SoundAudioSystem({
 			id: "voice",
-			audioSystemManager: game._audioSystemManager,
+			muted: game._audioSystemManager._muted,
+			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		system.volume = 0.5;

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -4,7 +4,6 @@ import { AudioPlayer, Game } from "./helpers";
 describe("test AudioPlayer", () => {
 	it("初期化-music", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		// const system = new MusicAudioSystem("music", game);
 		const system = new MusicAudioSystem({
 			id: "music",
 			audioSystemManager: game._audioSystemManager,

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -4,7 +4,12 @@ import { AudioPlayer, Game } from "./helpers";
 describe("test AudioPlayer", () => {
 	it("初期化-music", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new MusicAudioSystem("music", game);
+		// const system = new MusicAudioSystem("music", game);
+		const system = new MusicAudioSystem({
+			id: "music",
+			audioSystemManager: game._audioSystemManager,
+			resourceFactory: game.resourceFactory
+		});
 		const player = new AudioPlayer(system);
 		expect(player.volume).toBe(system.volume);
 		expect(player.played.constructor).toBe(Trigger);
@@ -14,7 +19,11 @@ describe("test AudioPlayer", () => {
 
 	it("初期化-sound", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new SoundAudioSystem("voice", game);
+		const system = new SoundAudioSystem({
+			id: "voice",
+			audioSystemManager: game._audioSystemManager,
+			resourceFactory: game.resourceFactory
+		});
 		system.volume = 0.5;
 		const player = new AudioPlayer(system);
 		expect(player.volume).toBe(system.volume);

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -8,6 +8,8 @@ describe("test AudioPlayer", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 		const system = new MusicAudioSystem({
 			id: "music",
+			muted: game._audioSystemManager._muted,
+			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		expect(() => {
@@ -40,6 +42,8 @@ describe("test AudioPlayer", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 		const system = new MusicAudioSystem({
 			id: "music",
+			muted: game._audioSystemManager._muted,
+			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		const audio = new ResourceFactory().createAudioAsset("testId", "testAssetPath", 0, null, false, null);
@@ -49,7 +53,7 @@ describe("test AudioPlayer", () => {
 
 	it("AudioSystem#_setPlaybackRate", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game._audioSystemManager._systems.sound;
+		const system = game.audio.sound;
 		const player1 = system.createPlayer();
 		const player2 = system.createPlayer();
 
@@ -63,7 +67,7 @@ describe("test AudioPlayer", () => {
 
 	it("AudioSystem#_changeMuted", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game._audioSystemManager._systems.sound;
+		const system = game.audio.sound;
 		const player1 = system.createPlayer();
 		const asset = game.resourceFactory.createAudioAsset("a1", "./dummypath", 2000, system, false, null);
 
@@ -81,7 +85,7 @@ describe("test AudioPlayer", () => {
 
 	it("SoundAudioSystem#_reset", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game._audioSystemManager._systems.sound;
+		const system = game.audio.sound;
 		const asset = game.resourceFactory.createAudioAsset("dummy", "audio/dummy", 0, system, true, {});
 		const player = system.createPlayer();
 
@@ -98,7 +102,7 @@ describe("test AudioPlayer", () => {
 
 	it("MusicAudioSystem#_reset", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game._audioSystemManager._systems.music;
+		const system = game.audio.music;
 		const asset = game.resourceFactory.createAudioAsset("dummy", "audio/dummy", 0, system, true, {});
 		const player = system.createPlayer();
 
@@ -115,7 +119,7 @@ describe("test AudioPlayer", () => {
 
 	it("MusicAudioSystem#_setPlaybackRate", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game._audioSystemManager._systems.music;
+		const system = game.audio.music;
 		const player1 = system.createPlayer() as AudioPlayer;
 		const asset = game.resourceFactory.createAudioAsset("a1", "./dummypath", 2000, system, false, null);
 
@@ -189,7 +193,7 @@ describe("test AudioPlayer", () => {
 
 	it("SoundAudioSystem#_setPlaybackRate", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game._audioSystemManager._systems.sound;
+		const system = game.audio.sound;
 		const player1 = system.createPlayer() as AudioPlayer;
 		const asset = game.resourceFactory.createAudioAsset("a1", "./dummypath", 2000, system, false, null);
 

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -6,7 +6,11 @@ expect.extend(customMatchers);
 describe("test AudioPlayer", () => {
 	it("AudioSystem#volumeの入力値チェック", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new MusicAudioSystem("music", game);
+		const system = new MusicAudioSystem({
+			id: "music",
+			audioSystemManager: game._audioSystemManager,
+			resourceFactory: game.resourceFactory
+		});
 		expect(() => {
 			system.volume = NaN!;
 		}).toThrowError();
@@ -35,7 +39,11 @@ describe("test AudioPlayer", () => {
 
 	it("AudioSystem#_destroyRequestedAssets", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new MusicAudioSystem("music", game);
+		const system = new MusicAudioSystem({
+			id: "music",
+			audioSystemManager: game._audioSystemManager,
+			resourceFactory: game.resourceFactory
+		});
 		const audio = new ResourceFactory().createAudioAsset("testId", "testAssetPath", 0, null, false, null);
 		system.requestDestroy(audio);
 		expect(system._destroyRequestedAssets[audio.id]).toEqual(audio);

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -8,7 +8,6 @@ describe("test AudioPlayer", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 		const system = new MusicAudioSystem({
 			id: "music",
-			audioSystemManager: game._audioSystemManager,
 			resourceFactory: game.resourceFactory
 		});
 		expect(() => {
@@ -41,7 +40,6 @@ describe("test AudioPlayer", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 		const system = new MusicAudioSystem({
 			id: "music",
-			audioSystemManager: game._audioSystemManager,
 			resourceFactory: game.resourceFactory
 		});
 		const audio = new ResourceFactory().createAudioAsset("testId", "testAssetPath", 0, null, false, null);
@@ -51,7 +49,7 @@ describe("test AudioPlayer", () => {
 
 	it("AudioSystem#_setPlaybackRate", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game.audio.sound;
+		const system = game._audioSystemManager._systems.sound;
 		const player1 = system.createPlayer();
 		const player2 = system.createPlayer();
 
@@ -65,7 +63,7 @@ describe("test AudioPlayer", () => {
 
 	it("AudioSystem#_changeMuted", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game.audio.sound;
+		const system = game._audioSystemManager._systems.sound;
 		const player1 = system.createPlayer();
 		const asset = game.resourceFactory.createAudioAsset("a1", "./dummypath", 2000, system, false, null);
 
@@ -83,7 +81,7 @@ describe("test AudioPlayer", () => {
 
 	it("SoundAudioSystem#_reset", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game.audio.sound;
+		const system = game._audioSystemManager._systems.sound;
 		const asset = game.resourceFactory.createAudioAsset("dummy", "audio/dummy", 0, system, true, {});
 		const player = system.createPlayer();
 
@@ -100,7 +98,7 @@ describe("test AudioPlayer", () => {
 
 	it("MusicAudioSystem#_reset", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game.audio.music;
+		const system = game._audioSystemManager._systems.music;
 		const asset = game.resourceFactory.createAudioAsset("dummy", "audio/dummy", 0, system, true, {});
 		const player = system.createPlayer();
 
@@ -117,7 +115,7 @@ describe("test AudioPlayer", () => {
 
 	it("MusicAudioSystem#_setPlaybackRate", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game.audio.music;
+		const system = game._audioSystemManager._systems.music;
 		const player1 = system.createPlayer() as AudioPlayer;
 		const asset = game.resourceFactory.createAudioAsset("a1", "./dummypath", 2000, system, false, null);
 
@@ -191,7 +189,7 @@ describe("test AudioPlayer", () => {
 
 	it("SoundAudioSystem#_setPlaybackRate", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game.audio.sound;
+		const system = game._audioSystemManager._systems.sound;
 		const player1 = system.createPlayer() as AudioPlayer;
 		const asset = game.resourceFactory.createAudioAsset("a1", "./dummypath", 2000, system, false, null);
 

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -869,44 +869,45 @@ describe("test Game", () => {
 			game._setAudioPlaybackRate(-0.5);
 		}).toThrowError("AssertionError");
 
-		expect(game.audio.sound._playbackRate).toBe(1.0);
-		expect(game.audio.music._playbackRate).toBe(1.0);
-		expect(game.audio.sound._muted).toBe(false);
-		expect(game.audio.music._muted).toBe(false);
+		const audio = game._audioSystemManager._systems;
+		expect(audio.sound._playbackRate).toBe(1.0);
+		expect(audio.music._playbackRate).toBe(1.0);
+		expect(audio.sound._muted).toBe(false);
+		expect(audio.music._muted).toBe(false);
 
 		game._setMuted(true);
 		game._setMuted(true); // 同じ値を設定するパスのカバレッジ稼ぎ
 		expect(game._audioSystemManager._muted).toBe(true);
-		expect(game.audio.sound._playbackRate).toBe(1.0);
-		expect(game.audio.music._playbackRate).toBe(1.0);
-		expect(game.audio.sound._muted).toBe(true);
-		expect(game.audio.music._muted).toBe(true);
+		expect(audio.sound._playbackRate).toBe(1.0);
+		expect(audio.music._playbackRate).toBe(1.0);
+		expect(audio.sound._muted).toBe(true);
+		expect(audio.music._muted).toBe(true);
 
 		game._setAudioPlaybackRate(1.7);
 		game._setAudioPlaybackRate(1.7); // 同じ値を設定するパスのカバレッジ稼ぎ
 		expect(game._audioSystemManager._playbackRate).toBe(1.7);
-		expect(game.audio.sound._playbackRate).toBe(1.7);
-		expect(game.audio.music._playbackRate).toBe(1.7);
-		expect(game.audio.sound._muted).toBe(true);
-		expect(game.audio.music._muted).toBe(true);
+		expect(audio.sound._playbackRate).toBe(1.7);
+		expect(audio.music._playbackRate).toBe(1.7);
+		expect(audio.sound._muted).toBe(true);
+		expect(audio.music._muted).toBe(true);
 
 		// 後から追加された AudioSystem でも GameDriver の値を反映する。
 		const myAudioSys = new SoundAudioSystem({
 			id: "voice_chara1",
-			audioSystemManager: game._audioSystemManager,
 			resourceFactory: game.resourceFactory
 		});
-		game.audio.chara1 = myAudioSys;
-		expect(game.audio.chara1._playbackRate).toBe(1.7);
-		expect(game.audio.chara1._muted).toBe(true);
+
+		game._audioSystemManager.addSystem("chara1", myAudioSys);
+		expect(audio.chara1._playbackRate).toBe(1.7);
+		expect(audio.chara1._muted).toBe(true);
 		game._setMuted(false);
 		expect(game._audioSystemManager._muted).toBe(false);
-		expect(game.audio.chara1._playbackRate).toBe(1.7);
-		expect(game.audio.sound._playbackRate).toBe(1.7);
-		expect(game.audio.music._playbackRate).toBe(1.7);
-		expect(game.audio.chara1._muted).toBe(false);
-		expect(game.audio.sound._muted).toBe(false);
-		expect(game.audio.music._muted).toBe(false);
+		expect(audio.chara1._playbackRate).toBe(1.7);
+		expect(audio.sound._playbackRate).toBe(1.7);
+		expect(audio.music._playbackRate).toBe(1.7);
+		expect(audio.chara1._muted).toBe(false);
+		expect(audio.sound._muted).toBe(false);
+		expect(audio.music._muted).toBe(false);
 	});
 
 	it("focusingCamera", () => {

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -869,45 +869,45 @@ describe("test Game", () => {
 			game._setAudioPlaybackRate(-0.5);
 		}).toThrowError("AssertionError");
 
-		const audio = game._audioSystemManager._systems;
-		expect(audio.sound._playbackRate).toBe(1.0);
-		expect(audio.music._playbackRate).toBe(1.0);
-		expect(audio.sound._muted).toBe(false);
-		expect(audio.music._muted).toBe(false);
+		expect(game.audio.sound._playbackRate).toBe(1.0);
+		expect(game.audio.music._playbackRate).toBe(1.0);
+		expect(game.audio.sound._muted).toBe(false);
+		expect(game.audio.music._muted).toBe(false);
 
 		game._setMuted(true);
 		game._setMuted(true); // 同じ値を設定するパスのカバレッジ稼ぎ
 		expect(game._audioSystemManager._muted).toBe(true);
-		expect(audio.sound._playbackRate).toBe(1.0);
-		expect(audio.music._playbackRate).toBe(1.0);
-		expect(audio.sound._muted).toBe(true);
-		expect(audio.music._muted).toBe(true);
+		expect(game.audio.sound._playbackRate).toBe(1.0);
+		expect(game.audio.music._playbackRate).toBe(1.0);
+		expect(game.audio.sound._muted).toBe(true);
+		expect(game.audio.music._muted).toBe(true);
 
 		game._setAudioPlaybackRate(1.7);
 		game._setAudioPlaybackRate(1.7); // 同じ値を設定するパスのカバレッジ稼ぎ
 		expect(game._audioSystemManager._playbackRate).toBe(1.7);
-		expect(audio.sound._playbackRate).toBe(1.7);
-		expect(audio.music._playbackRate).toBe(1.7);
-		expect(audio.sound._muted).toBe(true);
-		expect(audio.music._muted).toBe(true);
+		expect(game.audio.sound._playbackRate).toBe(1.7);
+		expect(game.audio.music._playbackRate).toBe(1.7);
+		expect(game.audio.sound._muted).toBe(true);
+		expect(game.audio.music._muted).toBe(true);
 
 		// 後から追加された AudioSystem でも GameDriver の値を反映する。
 		const myAudioSys = new SoundAudioSystem({
 			id: "voice_chara1",
+			muted: game._audioSystemManager._muted,
+			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
-
-		game._audioSystemManager.addSystem("chara1", myAudioSys);
-		expect(audio.chara1._playbackRate).toBe(1.7);
-		expect(audio.chara1._muted).toBe(true);
+		game.audio.chara1 = myAudioSys;
+		expect(game.audio.chara1._playbackRate).toBe(1.7);
+		expect(game.audio.chara1._muted).toBe(true);
 		game._setMuted(false);
 		expect(game._audioSystemManager._muted).toBe(false);
-		expect(audio.chara1._playbackRate).toBe(1.7);
-		expect(audio.sound._playbackRate).toBe(1.7);
-		expect(audio.music._playbackRate).toBe(1.7);
-		expect(audio.chara1._muted).toBe(false);
-		expect(audio.sound._muted).toBe(false);
-		expect(audio.music._muted).toBe(false);
+		expect(game.audio.chara1._playbackRate).toBe(1.7);
+		expect(game.audio.sound._playbackRate).toBe(1.7);
+		expect(game.audio.music._playbackRate).toBe(1.7);
+		expect(game.audio.chara1._muted).toBe(false);
+		expect(game.audio.sound._muted).toBe(false);
+		expect(game.audio.music._muted).toBe(false);
 	});
 
 	it("focusingCamera", () => {

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -891,7 +891,11 @@ describe("test Game", () => {
 		expect(game.audio.music._muted).toBe(true);
 
 		// 後から追加された AudioSystem でも GameDriver の値を反映する。
-		const myAudioSys = new SoundAudioSystem("voice_chara1", game);
+		const myAudioSys = new SoundAudioSystem({
+			id: "voice_chara1",
+			audioSystemManager: game._audioSystemManager,
+			resourceFactory: game.resourceFactory
+		});
 		game.audio.chara1 = myAudioSys;
 		expect(game.audio.chara1._playbackRate).toBe(1.7);
 		expect(game.audio.chara1._muted).toBe(true);

--- a/src/domain/AssetManager.ts
+++ b/src/domain/AssetManager.ts
@@ -360,9 +360,7 @@ export class AssetManager implements AssetLoadHandler {
 				asset.initialize(<ImageAssetHint>conf.hint);
 				return asset;
 			case "audio":
-				var system = conf.systemId
-					? this.game._audioSystemManager._systems[conf.systemId]
-					: this.game._audioSystemManager._systems[this.game.defaultAudioSystemId];
+				var system = conf.systemId ? this.game.audio[conf.systemId] : this.game.audio[this.game.defaultAudioSystemId];
 				return resourceFactory.createAudioAsset(id, uri, conf.duration, system, conf.loop, <AudioAssetHint>conf.hint);
 			case "text":
 				return resourceFactory.createTextAsset(id, uri);

--- a/src/domain/AssetManager.ts
+++ b/src/domain/AssetManager.ts
@@ -431,7 +431,7 @@ export class AssetManager implements AssetLoadHandler {
 			error = ExceptionFactory.createAssetLoadError("Retry limit exceeded", false, AssetLoadErrorType.RetryLimitExceeded, error);
 		}
 		if (!error.retriable) delete this._loadings[asset.id];
-		for (var i = 0; i < hs.length; ++i) hs[i]._onAssetError(asset, error, (a: AssetLike) => this.retryLoad(a));
+		for (var i = 0; i < hs.length; ++i) hs[i]._onAssetError(asset, error, a => this.retryLoad(a));
 	}
 
 	/**

--- a/src/domain/AssetManager.ts
+++ b/src/domain/AssetManager.ts
@@ -360,7 +360,9 @@ export class AssetManager implements AssetLoadHandler {
 				asset.initialize(<ImageAssetHint>conf.hint);
 				return asset;
 			case "audio":
-				var system = conf.systemId ? this.game.audio[conf.systemId] : this.game.audio[this.game.defaultAudioSystemId];
+				var system = conf.systemId
+					? this.game._audioSystemManager._systems[conf.systemId]
+					: this.game._audioSystemManager._systems[this.game.defaultAudioSystemId];
 				return resourceFactory.createAudioAsset(id, uri, conf.duration, system, conf.loop, <AudioAssetHint>conf.hint);
 			case "text":
 				return resourceFactory.createTextAsset(id, uri);

--- a/src/domain/AssetManager.ts
+++ b/src/domain/AssetManager.ts
@@ -431,7 +431,7 @@ export class AssetManager implements AssetLoadHandler {
 			error = ExceptionFactory.createAssetLoadError("Retry limit exceeded", false, AssetLoadErrorType.RetryLimitExceeded, error);
 		}
 		if (!error.retriable) delete this._loadings[asset.id];
-		for (var i = 0; i < hs.length; ++i) hs[i]._onAssetError(asset, error, a => this.retryLoad(a));
+		for (var i = 0; i < hs.length; ++i) hs[i]._onAssetError(asset, error, this.retryLoad.bind(this));
 	}
 
 	/**

--- a/src/domain/AssetManager.ts
+++ b/src/domain/AssetManager.ts
@@ -431,7 +431,7 @@ export class AssetManager implements AssetLoadHandler {
 			error = ExceptionFactory.createAssetLoadError("Retry limit exceeded", false, AssetLoadErrorType.RetryLimitExceeded, error);
 		}
 		if (!error.retriable) delete this._loadings[asset.id];
-		for (var i = 0; i < hs.length; ++i) hs[i]._onAssetError(asset, error, (_asset: AssetLike) => this.retryLoad(_asset));
+		for (var i = 0; i < hs.length; ++i) hs[i]._onAssetError(asset, error, (a: AssetLike) => this.retryLoad(a));
 	}
 
 	/**

--- a/src/domain/AssetManager.ts
+++ b/src/domain/AssetManager.ts
@@ -431,7 +431,7 @@ export class AssetManager implements AssetLoadHandler {
 			error = ExceptionFactory.createAssetLoadError("Retry limit exceeded", false, AssetLoadErrorType.RetryLimitExceeded, error);
 		}
 		if (!error.retriable) delete this._loadings[asset.id];
-		for (var i = 0; i < hs.length; ++i) hs[i]._onAssetError(asset, error, this);
+		for (var i = 0; i < hs.length; ++i) hs[i]._onAssetError(asset, error, (_asset: AssetLike) => this.retryLoad(_asset));
 	}
 
 	/**

--- a/src/domain/AssetManagerLoadHandler.ts
+++ b/src/domain/AssetManagerLoadHandler.ts
@@ -10,7 +10,7 @@ export interface AssetManagerLoadHandler {
 	 * 読み込失敗の通知を受ける関数。
 	 * @param asset 読み込みに失敗したアセット
 	 * @param error 失敗の内容を表すエラー
-	 * @param retryCallback `読み込みの再試行を行うコールバック関数。`AssetManager#retryLoad()` が設定される。
+	 * @param retryCallback 読み込みの再試行を行うコールバック関数。`AssetManager#retryLoad()` が設定される。
 	 */
 	_onAssetError(asset: AssetLike, error: AssetLoadError, retryCallback: (asset: AssetLike) => void): void;
 

--- a/src/domain/AssetManagerLoadHandler.ts
+++ b/src/domain/AssetManagerLoadHandler.ts
@@ -10,9 +10,9 @@ export interface AssetManagerLoadHandler {
 	 * 読み込失敗の通知を受ける関数。
 	 * @param asset 読み込みに失敗したアセット
 	 * @param error 失敗の内容を表すエラー
-	 * @param callback `読み込みの再試行を行うコールバック関数
+	 * @param retryCallback `読み込みの再試行を行うコールバック関数。`AssetManager#retryLoad()` が設定される。
 	 */
-	_onAssetError(asset: AssetLike, error: AssetLoadError, callback?: (asset: AssetLike) => void): void;
+	_onAssetError(asset: AssetLike, error: AssetLoadError, retryCallback: (asset: AssetLike) => void): void;
 
 	/**
 	 * 読み込み完了の通知を受ける関数。

--- a/src/domain/AssetManagerLoadHandler.ts
+++ b/src/domain/AssetManagerLoadHandler.ts
@@ -1,6 +1,5 @@
 import { AssetLike } from "../interfaces/AssetLike";
 import { AssetLoadError } from "../types/errors";
-import { AssetManager } from "./AssetManager";
 
 /**
  * `AssetManager` から `Asset` の読み込みまたは読み込み失敗を受け取るハンドラのインターフェース定義。
@@ -11,9 +10,9 @@ export interface AssetManagerLoadHandler {
 	 * 読み込失敗の通知を受ける関数。
 	 * @param asset 読み込みに失敗したアセット
 	 * @param error 失敗の内容を表すエラー
-	 * @param manager アセットの読み込みを試みた`AssetManager`. この値の `retryLoad()` を呼び出すことで読み込みを再試行できる
+	 * @param callback `読み込みの再試行を行うコールバック関数
 	 */
-	_onAssetError(asset: AssetLike, error: AssetLoadError, manager: AssetManager): void;
+	_onAssetError(asset: AssetLike, error: AssetLoadError, callback?: (asset: AssetLike) => void): void;
 
 	/**
 	 * 読み込み完了の通知を受ける関数。

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -22,13 +22,13 @@ export class AudioSystemManager {
 	 */
 	_systems: { [key: string]: AudioSystemLike };
 
+	set systems(systems: { [key: string]: AudioSystemLike }) {
+		this._systems = systems;
+	}
+
 	constructor() {
 		this._muted = false;
 		this._playbackRate = 1.0;
-	}
-
-	set systems(systems: { [key: string]: AudioSystemLike }) {
-		this._systems = systems;
 	}
 
 	/**

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -1,6 +1,4 @@
-import { MusicAudioSystem, SoundAudioSystem } from "../implementations/AudioSystem";
 import { AudioSystemLike } from "../interfaces/AudioSystemLike";
-import { ResourceFactoryLike } from "../interfaces/ResourceFactoryLike";
 
 /**
  * `Game#audio` の管理クラス。
@@ -19,81 +17,46 @@ export class AudioSystemManager {
 	 */
 	_playbackRate: number;
 
-	/**
-	 * ゲームで利用可能なオーディオシステム群。デフォルトでmusicとsoundを登録する。
-	 * SE・声・音楽等で分けたい場合、本プロパティにvoice等のAudioSystemを登録することで実現する。
-	 * @private
-	 */
-	_systems: { [key: string]: AudioSystemLike };
-
-	constructor(resourceFactory?: ResourceFactoryLike) {
+	constructor() {
 		this._muted = false;
 		this._playbackRate = 1.0;
-
-		this._systems = {
-			music: new MusicAudioSystem({
-				id: "music",
-				resourceFactory: resourceFactory
-			}),
-			sound: new SoundAudioSystem({
-				id: "sound",
-				resourceFactory: resourceFactory
-			})
-		};
-	}
-
-	/**
-	 * AudioSystemを追加する。
-	 * @param key オーディオシステムのID
-	 * @param system 追加するオーディオシステム
-	 */
-	addSystem(key: string, system: AudioSystemLike): void {
-		system.muted = this._muted;
-		system.playbackRate = this._playbackRate;
-		this._systems[key] = system;
-	}
-
-	/**
-	 * 全ての オーディオを停止する。
-	 */
-	stopAll(): void {
-		const audioSystemIds = Object.keys(this._systems);
-		for (var i = 0; i < audioSystemIds.length; ++i) this._systems[audioSystemIds[i]].stopAll();
 	}
 
 	/**
 	 * @private
 	 */
-	_reset(): void {
-		for (var id in this._systems) {
-			if (!this._systems.hasOwnProperty(id)) continue;
-			this._systems[id]._reset();
+	_reset(systems: { [key: string]: AudioSystemLike }): void {
+		this._muted = false;
+		this._playbackRate = 1.0;
+		for (var id in systems) {
+			if (!systems.hasOwnProperty(id)) continue;
+			systems[id]._reset();
 		}
 	}
 
 	/**
 	 * @private
 	 */
-	_setMuted(muted: boolean): void {
+	_setMuted(muted: boolean, systems: { [key: string]: AudioSystemLike }): void {
 		if (this._muted === muted) return;
 
 		this._muted = muted;
-		for (var id in this._systems) {
-			if (!this._systems.hasOwnProperty(id)) continue;
-			this._systems[id]._setMuted(muted);
+		for (var id in systems) {
+			if (!systems.hasOwnProperty(id)) continue;
+			systems[id]._setMuted(muted);
 		}
 	}
 
 	/**
 	 * @private
 	 */
-	_setPlaybackRate(rate: number): void {
+	_setPlaybackRate(rate: number, systems: { [key: string]: AudioSystemLike }): void {
 		if (this._playbackRate === rate) return;
 
 		this._playbackRate = rate;
-		for (var id in this._systems) {
-			if (!this._systems.hasOwnProperty(id)) continue;
-			this._systems[id]._setPlaybackRate(rate);
+		for (var id in systems) {
+			if (!systems.hasOwnProperty(id)) continue;
+			systems[id]._setPlaybackRate(rate);
 		}
 	}
 }

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -17,11 +17,7 @@ export class AudioSystemManager {
 	 */
 	_playbackRate: number;
 
-	_systems: { [key: string]: AudioSystemLike };
-
-	set systems(system: { [key: string]: AudioSystemLike }) {
-		this._systems = system;
-	}
+	systems: { [key: string]: AudioSystemLike };
 
 	constructor() {
 		this._muted = false;
@@ -34,9 +30,9 @@ export class AudioSystemManager {
 	_reset(): void {
 		this._muted = false;
 		this._playbackRate = 1.0;
-		for (var id in this._systems) {
-			if (!this._systems.hasOwnProperty(id)) continue;
-			this._systems[id]._reset();
+		for (var id in this.systems) {
+			if (!this.systems.hasOwnProperty(id)) continue;
+			this.systems[id]._reset();
 		}
 	}
 
@@ -47,9 +43,9 @@ export class AudioSystemManager {
 		if (this._muted === muted) return;
 
 		this._muted = muted;
-		for (var id in this._systems) {
-			if (!this._systems.hasOwnProperty(id)) continue;
-			this._systems[id]._setMuted(muted);
+		for (var id in this.systems) {
+			if (!this.systems.hasOwnProperty(id)) continue;
+			this.systems[id]._setMuted(muted);
 		}
 	}
 
@@ -60,9 +56,9 @@ export class AudioSystemManager {
 		if (this._playbackRate === rate) return;
 
 		this._playbackRate = rate;
-		for (var id in this._systems) {
-			if (!this._systems.hasOwnProperty(id)) continue;
-			this._systems[id]._setPlaybackRate(rate);
+		for (var id in this.systems) {
+			if (!this.systems.hasOwnProperty(id)) continue;
+			this.systems[id]._setPlaybackRate(rate);
 		}
 	}
 }

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -17,6 +17,12 @@ export class AudioSystemManager {
 	 */
 	_playbackRate: number;
 
+	_systems: { [key: string]: AudioSystemLike };
+
+	set systems(system: { [key: string]: AudioSystemLike }) {
+		this._systems = system;
+	}
+
 	constructor() {
 		this._muted = false;
 		this._playbackRate = 1.0;
@@ -25,38 +31,38 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_reset(systems: { [key: string]: AudioSystemLike }): void {
+	_reset(): void {
 		this._muted = false;
 		this._playbackRate = 1.0;
-		for (var id in systems) {
-			if (!systems.hasOwnProperty(id)) continue;
-			systems[id]._reset();
+		for (var id in this.systems) {
+			if (!this.systems.hasOwnProperty(id)) continue;
+			this.systems[id]._reset();
 		}
 	}
 
 	/**
 	 * @private
 	 */
-	_setMuted(muted: boolean, systems: { [key: string]: AudioSystemLike }): void {
+	_setMuted(muted: boolean): void {
 		if (this._muted === muted) return;
 
 		this._muted = muted;
-		for (var id in systems) {
-			if (!systems.hasOwnProperty(id)) continue;
-			systems[id]._setMuted(muted);
+		for (var id in this.systems) {
+			if (!this.systems.hasOwnProperty(id)) continue;
+			this.systems[id]._setMuted(muted);
 		}
 	}
 
 	/**
 	 * @private
 	 */
-	_setPlaybackRate(rate: number, systems: { [key: string]: AudioSystemLike }): void {
+	_setPlaybackRate(rate: number): void {
 		if (this._playbackRate === rate) return;
 
 		this._playbackRate = rate;
-		for (var id in systems) {
-			if (!systems.hasOwnProperty(id)) continue;
-			systems[id]._setPlaybackRate(rate);
+		for (var id in this.systems) {
+			if (!this.systems.hasOwnProperty(id)) continue;
+			this.systems[id]._setPlaybackRate(rate);
 		}
 	}
 }

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -17,46 +17,55 @@ export class AudioSystemManager {
 	 */
 	_playbackRate: number;
 
+	/**
+	 * @private
+	 */
+	_systems: { [key: string]: AudioSystemLike };
+
 	constructor() {
 		this._muted = false;
 		this._playbackRate = 1.0;
 	}
 
+	set systems(systems: { [key: string]: AudioSystemLike }) {
+		this._systems = systems;
+	}
+
 	/**
 	 * @private
 	 */
-	_reset(systems: { [key: string]: AudioSystemLike }): void {
+	_reset(): void {
 		this._muted = false;
 		this._playbackRate = 1.0;
-		for (var id in systems) {
-			if (!systems.hasOwnProperty(id)) continue;
-			systems[id]._reset();
+		for (var id in this._systems) {
+			if (!this._systems.hasOwnProperty(id)) continue;
+			this._systems[id]._reset();
 		}
 	}
 
 	/**
 	 * @private
 	 */
-	_setMuted(muted: boolean, systems: { [key: string]: AudioSystemLike }): void {
+	_setMuted(muted: boolean): void {
 		if (this._muted === muted) return;
 
 		this._muted = muted;
-		for (var id in systems) {
-			if (!systems.hasOwnProperty(id)) continue;
-			systems[id]._setMuted(muted);
+		for (var id in this._systems) {
+			if (!this._systems.hasOwnProperty(id)) continue;
+			this._systems[id]._setMuted(muted);
 		}
 	}
 
 	/**
 	 * @private
 	 */
-	_setPlaybackRate(rate: number, systems: { [key: string]: AudioSystemLike }): void {
+	_setPlaybackRate(rate: number): void {
 		if (this._playbackRate === rate) return;
 
 		this._playbackRate = rate;
-		for (var id in systems) {
-			if (!systems.hasOwnProperty(id)) continue;
-			systems[id]._setPlaybackRate(rate);
+		for (var id in this._systems) {
+			if (!this._systems.hasOwnProperty(id)) continue;
+			this._systems[id]._setPlaybackRate(rate);
 		}
 	}
 }

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -1,4 +1,6 @@
+import { MusicAudioSystem, SoundAudioSystem } from "../implementations/AudioSystem";
 import { AudioSystemLike } from "../interfaces/AudioSystemLike";
+import { ResourceFactoryLike } from "../interfaces/ResourceFactoryLike";
 
 /**
  * `Game#audio` の管理クラス。
@@ -18,25 +20,51 @@ export class AudioSystemManager {
 	_playbackRate: number;
 
 	/**
+	 * ゲームで利用可能なオーディオシステム群。デフォルトでmusicとsoundを登録する。
+	 * SE・声・音楽等で分けたい場合、本プロパティにvoice等のAudioSystemを登録することで実現する。
 	 * @private
 	 */
 	_systems: { [key: string]: AudioSystemLike };
 
-	set systems(systems: { [key: string]: AudioSystemLike }) {
-		this._systems = systems;
-	}
-
-	constructor() {
+	constructor(resourceFactory?: ResourceFactoryLike) {
 		this._muted = false;
 		this._playbackRate = 1.0;
+
+		this._systems = {
+			music: new MusicAudioSystem({
+				id: "music",
+				resourceFactory: resourceFactory
+			}),
+			sound: new SoundAudioSystem({
+				id: "sound",
+				resourceFactory: resourceFactory
+			})
+		};
+	}
+
+	/**
+	 * AudioSystemを追加する。
+	 * @param key オーディオシステムのID
+	 * @param system 追加するオーディオシステム
+	 */
+	addSystem(key: string, system: AudioSystemLike): void {
+		system.muted = this._muted;
+		system.playbackRate = this._playbackRate;
+		this._systems[key] = system;
+	}
+
+	/**
+	 * 全ての オーディオを停止する。
+	 */
+	stopAll(): void {
+		const audioSystemIds = Object.keys(this._systems);
+		for (var i = 0; i < audioSystemIds.length; ++i) this._systems[audioSystemIds[i]].stopAll();
 	}
 
 	/**
 	 * @private
 	 */
 	_reset(): void {
-		this._muted = false;
-		this._playbackRate = 1.0;
 		for (var id in this._systems) {
 			if (!this._systems.hasOwnProperty(id)) continue;
 			this._systems[id]._reset();

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -1,4 +1,4 @@
-import { Game } from "../Game";
+import { AudioSystemLike } from "../interfaces/AudioSystemLike";
 
 /**
  * `Game#audio` の管理クラス。
@@ -10,11 +10,6 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_game: Game;
-
-	/**
-	 * @private
-	 */
 	_muted: boolean;
 
 	/**
@@ -22,8 +17,7 @@ export class AudioSystemManager {
 	 */
 	_playbackRate: number;
 
-	constructor(game: Game) {
-		this._game = game;
+	constructor() {
 		this._muted = false;
 		this._playbackRate = 1.0;
 	}
@@ -31,10 +25,9 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_reset(): void {
+	_reset(systems: { [key: string]: AudioSystemLike }): void {
 		this._muted = false;
 		this._playbackRate = 1.0;
-		var systems = this._game.audio;
 		for (var id in systems) {
 			if (!systems.hasOwnProperty(id)) continue;
 			systems[id]._reset();
@@ -44,11 +37,10 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_setMuted(muted: boolean): void {
+	_setMuted(muted: boolean, systems: { [key: string]: AudioSystemLike }): void {
 		if (this._muted === muted) return;
 
 		this._muted = muted;
-		var systems = this._game.audio;
 		for (var id in systems) {
 			if (!systems.hasOwnProperty(id)) continue;
 			systems[id]._setMuted(muted);
@@ -58,11 +50,10 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_setPlaybackRate(rate: number): void {
+	_setPlaybackRate(rate: number, systems: { [key: string]: AudioSystemLike }): void {
 		if (this._playbackRate === rate) return;
 
 		this._playbackRate = rate;
-		var systems = this._game.audio;
 		for (var id in systems) {
 			if (!systems.hasOwnProperty(id)) continue;
 			systems[id]._setPlaybackRate(rate);

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -34,9 +34,9 @@ export class AudioSystemManager {
 	_reset(): void {
 		this._muted = false;
 		this._playbackRate = 1.0;
-		for (var id in this.systems) {
-			if (!this.systems.hasOwnProperty(id)) continue;
-			this.systems[id]._reset();
+		for (var id in this._systems) {
+			if (!this._systems.hasOwnProperty(id)) continue;
+			this._systems[id]._reset();
 		}
 	}
 
@@ -47,9 +47,9 @@ export class AudioSystemManager {
 		if (this._muted === muted) return;
 
 		this._muted = muted;
-		for (var id in this.systems) {
-			if (!this.systems.hasOwnProperty(id)) continue;
-			this.systems[id]._setMuted(muted);
+		for (var id in this._systems) {
+			if (!this._systems.hasOwnProperty(id)) continue;
+			this._systems[id]._setMuted(muted);
 		}
 	}
 
@@ -60,9 +60,9 @@ export class AudioSystemManager {
 		if (this._playbackRate === rate) return;
 
 		this._playbackRate = rate;
-		for (var id in this.systems) {
-			if (!this.systems.hasOwnProperty(id)) continue;
-			this.systems[id]._setPlaybackRate(rate);
+		for (var id in this._systems) {
+			if (!this._systems.hasOwnProperty(id)) continue;
+			this._systems[id]._setPlaybackRate(rate);
 		}
 	}
 }

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -1,5 +1,4 @@
 import { ExceptionFactory } from "../commons/ExceptionFactory";
-import { AudioSystemManager } from "../domain/AudioSystemManager";
 import { AudioAssetLike } from "../interfaces/AudioAssetLike";
 import { AudioPlayerEvent, AudioPlayerLike } from "../interfaces/AudioPlayerLike";
 import { AudioSystemLike } from "../interfaces/AudioSystemLike";
@@ -10,11 +9,6 @@ export interface AudioSystemParameterObject {
 	 * オーディオシステムのID
 	 */
 	id: string;
-
-	/**
-	 * audioの管理者
-	 */
-	audioSystemManager: AudioSystemManager;
 
 	/**
 	 * 各種リソースのファクトリ
@@ -48,11 +42,6 @@ export abstract class AudioSystem implements AudioSystemLike {
 	/**
 	 * @private
 	 */
-	_audioSystemManager: AudioSystemManager;
-
-	/**
-	 * @private
-	 */
 	_resourceFactory: ResourceFactoryLike;
 
 	// volumeの変更時には通知が必要なのでアクセサを使う。
@@ -69,13 +58,20 @@ export abstract class AudioSystem implements AudioSystemLike {
 		this._onVolumeChanged();
 	}
 
+	set muted(mute: boolean) {
+		this._muted = mute;
+	}
+
+	set playbackRate(rate: number) {
+		this._playbackRate = rate;
+	}
+
 	constructor(param: AudioSystemParameterObject) {
 		this.id = param.id;
 		this._volume = 1;
 		this._destroyRequestedAssets = {};
-		this._audioSystemManager = param.audioSystemManager;
-		this._muted = this._audioSystemManager._muted;
-		this._playbackRate = this._audioSystemManager._playbackRate;
+		this._muted = false;
+		this._playbackRate = 1.0;
 		this._resourceFactory = param.resourceFactory;
 	}
 
@@ -96,8 +92,8 @@ export abstract class AudioSystem implements AudioSystemLike {
 		this.stopAll();
 		this._volume = 1;
 		this._destroyRequestedAssets = {};
-		this._muted = this._audioSystemManager._muted;
-		this._playbackRate = this._audioSystemManager._playbackRate;
+		this._muted = false;
+		this._playbackRate = 1.0;
 	}
 
 	/**

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -11,6 +11,16 @@ export interface AudioSystemParameterObject {
 	id: string;
 
 	/**
+	 * ミュート中か否か。
+	 */
+	muted: boolean;
+
+	/**
+	 * 再生速度の倍率。
+	 */
+	playbackRate: number;
+
+	/**
 	 * 各種リソースのファクトリ
 	 */
 	resourceFactory: ResourceFactoryLike;
@@ -58,20 +68,12 @@ export abstract class AudioSystem implements AudioSystemLike {
 		this._onVolumeChanged();
 	}
 
-	set muted(mute: boolean) {
-		this._muted = mute;
-	}
-
-	set playbackRate(rate: number) {
-		this._playbackRate = rate;
-	}
-
 	constructor(param: AudioSystemParameterObject) {
 		this.id = param.id;
 		this._volume = 1;
 		this._destroyRequestedAssets = {};
-		this._muted = false;
-		this._playbackRate = 1.0;
+		this._muted = param.muted;
+		this._playbackRate = param.playbackRate;
 		this._resourceFactory = param.resourceFactory;
 	}
 

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -11,8 +11,14 @@ export interface AudioSystemParameterObject {
 	 */
 	id: string;
 
+	/**
+	 * audioの管理者
+	 */
 	audioSystemManager: AudioSystemManager;
 
+	/**
+	 * 各種リソースのファクトリ
+	 */
 	resourceFactory: ResourceFactoryLike;
 }
 

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -11,14 +11,19 @@ export interface AudioSystemParameterObject {
 	id: string;
 
 	/**
+	 * オーディオのボリューム
+	 */
+	volume?: number;
+
+	/**
 	 * ミュート中か否か。
 	 */
-	muted: boolean;
+	muted?: boolean;
 
 	/**
 	 * 再生速度の倍率。
 	 */
-	playbackRate: number;
+	playbackRate?: number;
 
 	/**
 	 * 各種リソースのファクトリ
@@ -70,10 +75,10 @@ export abstract class AudioSystem implements AudioSystemLike {
 
 	constructor(param: AudioSystemParameterObject) {
 		this.id = param.id;
-		this._volume = 1;
+		this._volume = param.volume || 1;
 		this._destroyRequestedAssets = {};
-		this._muted = param.muted;
-		this._playbackRate = param.playbackRate;
+		this._muted = param.muted || false;
+		this._playbackRate = param.playbackRate || 1.0;
 		this._resourceFactory = param.resourceFactory;
 	}
 

--- a/src/interfaces/AudioSystemLike.ts
+++ b/src/interfaces/AudioSystemLike.ts
@@ -4,8 +4,6 @@ import { AudioPlayerEvent, AudioPlayerLike } from "./AudioPlayerLike";
 export interface AudioSystemLike {
 	id: string;
 	volume: number;
-	muted: boolean;
-	playbackRate: number;
 
 	/**
 	 * @private

--- a/src/interfaces/AudioSystemLike.ts
+++ b/src/interfaces/AudioSystemLike.ts
@@ -4,6 +4,8 @@ import { AudioPlayerEvent, AudioPlayerLike } from "./AudioPlayerLike";
 export interface AudioSystemLike {
 	id: string;
 	volume: number;
+	muted: boolean;
+	playbackRate: number;
 
 	/**
 	 * @private


### PR DESCRIPTION
## このpull requestが解決する内容

循環参照の解決
- `Game -> AudioSystemManager`,  `Game -> AudioSystem` の解決
  - インスタンス生成時に渡している `Game` やめ必要なパラメータを渡す

- `AssetManager` -> `AssetManagerLoadHandler` の解決
  - `AssetManagerLoadHandler#_onAssetError()` の引数 `AssetManager` をやめCallback関数へ修正。

## 破壊的な変更を含んでいるか?
なし
