### PR TITLE
Drop E#targetCameras

### DIFF
--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -830,7 +830,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 		if (camera && camera instanceof Camera2D) m = camera.getMatrix();
 
 		for (var i = children.length - 1; i >= 0; --i) {
-			var ret = children[i].findPointSourceByPoint(point, m, force, camera);
+			const ret = children[i].findPointSourceByPoint(point, m, force);
 			if (ret) {
 				ret.local = ret.target.local || mayConsumeLocalTick;
 				return ret;

--- a/src/__tests__/CacheableESpec.ts
+++ b/src/__tests__/CacheableESpec.ts
@@ -11,7 +11,6 @@ describe("test CacheableE", () => {
 	it("初期化", () => {
 		const ce = new CacheableE({ scene: runtime.scene });
 		expect(ce._shouldRenderChildren).toBe(true);
-		expect(ce._targetCameras).toBeUndefined();
 		expect(ce._cache).toBeUndefined();
 		expect(ce._renderer).toBeUndefined();
 		expect(ce._renderedCamera).toBeUndefined();

--- a/src/domain/SpriteFactory.ts
+++ b/src/domain/SpriteFactory.ts
@@ -19,7 +19,7 @@ export class SpriteFactory {
 		var width = e.width;
 		var height = e.height;
 
-		var boundingRect = e.calculateBoundingRect(camera);
+		const boundingRect = e.calculateBoundingRect();
 		if (!boundingRect) {
 			throw ExceptionFactory.createAssertionError("SpriteFactory.createSpriteFromE: camera must look e");
 		}

--- a/src/domain/entities/Pane.ts
+++ b/src/domain/entities/Pane.ts
@@ -284,13 +284,13 @@ export class Pane extends CacheableE {
 	 * Eを継承する他のクラスと異なり、Paneは子要素の位置を包括矩形に含まない。
 	 * @private
 	 */
-	_calculateBoundingRect(m?: Matrix, c?: Camera): CommonRect {
+	_calculateBoundingRect(m?: Matrix): CommonRect {
 		var matrix = this.getMatrix();
 		if (m) {
 			matrix = m.multiplyNew(matrix);
 		}
 
-		if (!this.visible() || (c && (!this._targetCameras || this._targetCameras.indexOf(c) === -1))) {
+		if (!this.visible()) {
 			return undefined;
 		}
 


### PR DESCRIPTION
## このpull requestが解決する内容
`E#targetCameras` を削除します。
この機能の代替として `E#local`, `Game#focusingCamera` などを利用してください。

## 破壊的な変更を含んでいるか?
- **あり**
  - `E#targetCameras` が削除されます。
  - `E#findPointSourceByPoint()` から引数 `camera` が削除されます。
  - `E#calculateBoundingRect()` から引数 `camera` が削除されます。
  - `E#_calculateBoundingRect()` から引数 `camera` が削除されます。
