### PR TITLE
Don't bundle index.runtime.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Akashic Engineの詳細な利用方法については、 [公式ページ](https
 
 ### TypeScript での型定義の利用
 
-TypeScriptでゲームを開発する場合には、型定義ファイルとしてこのリポジトリの `dist/main.runtime.d.ts` を使うことができます。
+TypeScriptでゲームを開発する場合には、型定義ファイルとしてこのリポジトリの `index.runtime.d.ts` を使うことができます。
 `npm install -D @akashic/akashic-engine` でインストールの上、
-tsconfig.json で `node_modules/@akashic/akashic-engine/dist/main.runtime.d.ts` を参照するなどの方法で、 `tsc` に与えてください。
+tsconfig.json で `node_modules/@akashic/akashic-engine/index.runtime.d.ts` を参照するなどの方法で、 `tsc` に与えてください。
 
 ## ビルド方法
 

--- a/index.runtime.d.ts
+++ b/index.runtime.d.ts
@@ -1,23 +1,25 @@
-import { Game } from "./Game";
-
 // このファイルにある変数をエンジン開発者及びエンジンユーザは利用してはならない。
 // これらはゲーム開発者がスクリプトアセット内で `g.game` 等を利用する場合の型解決のために利用される。
+import { Game } from "./lib/Game";
+
 /**
  * スクリプトアセット内で参照可能な値。
  * スクリプトアセットを実行した `Game` を表す。
  */
-export var game: Game;
+export const game: Game;
 
 /**
  * スクリプトアセット内で参照可能な値。
  * スクリプトアセットのファイルパスのうち、ディレクトリ部分を表す。
  */
-export var dirname: string;
+export const dirname: string;
 
 /**
  * スクリプトアセット内で参照可能な値。
  * スクリプトアセットのファイルパス。
  */
-export var filename: string;
+export const filename: string;
 
-export * from ".";
+export * from "./lib";
+
+export as namespace g;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1731,16 +1731,6 @@
       "integrity": "sha1-Yxhv6NNEEydtNiH2qg7F954ifvk=",
       "dev": true
     },
-    "dts-bundle-generator": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-3.3.1.tgz",
-      "integrity": "sha512-ePli14sf9223BwvaeuKpZYrlgAVJFf/OtZXLKtvs3khASEV62yXXN5QHpP2vRNCW7gNgxgTNPuM5G2d/N94oyw==",
-      "dev": true,
-      "requires": {
-        "typescript": ">=2.6.1",
-        "yargs": "~13.3.0"
-      }
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",
-    "dts-bundle-generator": "^3.3.1",
     "jest": "^24.9.0",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.0",
@@ -32,9 +31,7 @@
     "prepublish": "npm run build && npm run doc",
     "prepare": "npm run prepublish",
     "build": "npm run clean && tsc -p ./ && npm run bundle",
-    "bundle": "npm run bundle:js && npm run bundle:runtime:dts",
-    "bundle:js": "rollup -c rollup.config.js",
-    "bundle:runtime:dts": "dts-bundle-generator -o dist/main.runtime.d.ts --umd-module-name g src/index.runtime.ts",
+    "bundle": "rollup -c rollup.config.js",
     "clean": "rimraf dist && rimraf lib",
     "test": "npm run test:jest && npm run lint && npm run textlint",
     "test:jest": "jest --config jest.config.js",
@@ -45,7 +42,8 @@
   "files": [
     "lib",
     "dist",
-    "index.js"
+    "index.js",
+    "index.runtime.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## このpull requestが解決する内容
ゲーム開発者が参照する型定義ファイルを bundle しないで保持するようにします。

## 破壊的な変更を含んでいるか?
- **あり**
  - #122 にて対応した型定義のエントリポイントが `./dist/main.runtime.d.ts` から `index.runtime.d.ts` に変更されます。