### PR TITLE
Support Sprite#src

### DIFF
--- a/src/__tests__/DestroySpec.ts
+++ b/src/__tests__/DestroySpec.ts
@@ -80,9 +80,9 @@ describe("test Destroy", () => {
 
 		// 参照保持処理
 		// Sprite
-		(entities[1] as any).__surface = (entities[1] as any).surface;
+		(entities[1] as any).__surface = (entities[1] as any)._surface;
 		// FrameSprite
-		(entities[2] as any).__surface = (entities[2] as any).surface;
+		(entities[2] as any).__surface = (entities[2] as any)._surface;
 		// Label
 		(entities[3] as any).__cache = (entities[3] as any)._cache;
 		// Pane
@@ -95,12 +95,12 @@ describe("test Destroy", () => {
 			expect(e.destroyed()).toBe(true);
 		});
 		// Sprite
-		expect((entities[1] as any).surface).toBeUndefined();
+		expect((entities[1] as any)._surface).toBeUndefined();
 		expect((entities[1] as any).__surface.destroyed()).toBe(false);
 		(entities[1] as any).__surface.destroy();
 		expect((entities[1] as any).__surface.destroyed()).toBe(true);
 		// FrameSprite
-		expect((entities[2] as any).surface).toBeUndefined();
+		expect((entities[2] as any)._surface).toBeUndefined();
 		expect((entities[2] as any).__surface.destroyed()).toBe(false);
 		(entities[2] as any).__surface.destroy();
 		expect((entities[2] as any).__surface.destroyed()).toBe(true);
@@ -142,8 +142,8 @@ describe("test Destroy", () => {
 			expect(e[propName]).toBeUndefined();
 			expect(tmp.destroyed()).toBe(true);
 		}
-		destroyAndCheckProp(entities[1], "surface"); // Sprite
-		destroyAndCheckProp(entities[2], "surface"); // FrameSprite
+		destroyAndCheckProp(entities[1], "_surface"); // Sprite
+		destroyAndCheckProp(entities[2], "_surface"); // FrameSprite
 	});
 
 	it("Sprite1つの破棄で複数Spriteが破壊される", () => {
@@ -189,9 +189,9 @@ describe("test Destroy", () => {
 			expect(e.destroyed()).toBe(e === entities[0]);
 			// surfaceのみ破壊されている。（本来あってはいけない状態）
 			if (e === entities[0]) {
-				expect(e.surface).toBeUndefined();
+				expect(e._surface).toBeUndefined();
 			} else {
-				expect(e.surface.destroyed()).toBe(true);
+				expect(e._surface.destroyed()).toBe(true);
 			}
 		});
 	});
@@ -235,7 +235,7 @@ describe("test Destroy", () => {
 		scene.destroy();
 		entities.forEach(e => {
 			expect(e.destroyed()).toBe(true);
-			expect(e.surface).toBeUndefined();
+			expect(e._surface).toBeUndefined();
 		});
 		expect(surface.destroyed()).toBe(false);
 		surface.destroy();

--- a/src/__tests__/SpriteSpec.ts
+++ b/src/__tests__/SpriteSpec.ts
@@ -24,37 +24,41 @@ describe("test Sprite", () => {
 			width: 32,
 			height: 48
 		});
-		expect(sprite.width).toEqual(32);
-		expect(sprite.height).toEqual(48);
-		expect(sprite.srcWidth).toEqual(32);
-		expect(sprite.srcHeight).toEqual(48);
-		expect(sprite.srcX).toEqual(0);
-		expect(sprite.srcY).toEqual(0);
-		expect(sprite.surface).toEqual(surface);
-		expect(sprite._beforeSurface).toEqual(sprite.surface);
+		expect(sprite.width).toBe(32);
+		expect(sprite.height).toBe(48);
+		expect(sprite.srcWidth).toBe(32);
+		expect(sprite.srcHeight).toBe(48);
+		expect(sprite.srcX).toBe(0);
+		expect(sprite.srcY).toBe(0);
+		expect(sprite.src).toBeUndefined();
+		expect(sprite._beforeSrc).toBeUndefined();
+		expect(sprite.surface).toBe(surface);
+		expect(sprite._beforeSurface).toBe(sprite.surface);
 
 		sprite.invalidate();
-		expect(sprite.width).toEqual(32);
-		expect(sprite.height).toEqual(48);
+		expect(sprite.width).toBe(32);
+		expect(sprite.height).toBe(48);
 		sprite.srcWidth = 10;
 		sprite.srcHeight = 10;
 		sprite.invalidate();
-		expect(sprite.srcWidth).toEqual(10);
-		expect(sprite.srcHeight).toEqual(10);
+		expect(sprite.srcWidth).toBe(10);
+		expect(sprite.srcHeight).toBe(10);
 
 		const surface2 = new Surface(16, 32);
 		const sprite2 = new MonitorSprite({
 			scene: runtime.scene,
 			src: surface2
 		});
-		expect(sprite2.width).toEqual(16);
-		expect(sprite2.height).toEqual(32);
-		expect(sprite2.srcWidth).toEqual(16);
-		expect(sprite2.srcHeight).toEqual(32);
-		expect(sprite2.srcX).toEqual(0);
-		expect(sprite2.srcY).toEqual(0);
+		expect(sprite2.width).toBe(16);
+		expect(sprite2.height).toBe(32);
+		expect(sprite2.srcWidth).toBe(16);
+		expect(sprite2.srcHeight).toBe(32);
+		expect(sprite2.srcX).toBe(0);
+		expect(sprite2.srcY).toBe(0);
+		expect(sprite2.src).toBeUndefined();
+		expect(sprite._beforeSrc).toBeUndefined();
 		expect(sprite2.surface).toBe(surface2);
-		expect(sprite2._beforeSurface).toEqual(sprite2.surface);
+		expect(sprite2._beforeSurface).toBe(sprite2.surface);
 	});
 
 	it("初期化 - 動画サーフェス", () => {
@@ -284,7 +288,6 @@ describe("test Sprite", () => {
 		surface2.animatingStarted.fire();
 		sprite.update.fire();
 		expect(updated).toBe(true);
-
 	});
 
 	it("再生中の動画サーフェスへの切り替え", () => {
@@ -307,5 +310,34 @@ describe("test Sprite", () => {
 
 		sprite.update.fire();
 		expect(updated).toBe(true);
+	});
+
+	it("srcの変更", () => {
+		const runtime = skeletonRuntime();
+		const imageAsset = runtime.game.resourceFactory.createImageAsset(null, null, 200, 200);
+		const sprite = new MonitorSprite({
+			scene: runtime.scene,
+			src: imageAsset
+		});
+		expect(sprite.src).toBe(imageAsset);
+		expect(sprite._beforeSrc).toBe(imageAsset);
+		expect(sprite.surface).toBe(imageAsset.asSurface());
+		expect(sprite._beforeSurface).toBe(imageAsset.asSurface());
+
+		const otherImageAsset = runtime.game.resourceFactory.createImageAsset(null, null, 100, 100);
+		sprite.src = otherImageAsset;
+		sprite.invalidate();
+		expect(sprite.src).toBe(otherImageAsset);
+		expect(sprite._beforeSrc).toBe(otherImageAsset);
+		expect(sprite.surface).toBe(otherImageAsset.asSurface());
+		expect(sprite._beforeSurface).toBe(otherImageAsset.asSurface());
+
+		const surface = new Surface(16, 32);
+		sprite.surface = surface;
+		sprite.invalidate();
+		expect(sprite.src).toBe(otherImageAsset);
+		expect(sprite._beforeSrc).toBe(otherImageAsset);
+		expect(sprite.surface).toBe(surface);
+		expect(sprite._beforeSurface).toBe(surface);
 	});
 });

--- a/src/__tests__/SpriteSpec.ts
+++ b/src/__tests__/SpriteSpec.ts
@@ -30,10 +30,10 @@ describe("test Sprite", () => {
 		expect(sprite.srcHeight).toBe(48);
 		expect(sprite.srcX).toBe(0);
 		expect(sprite.srcY).toBe(0);
-		expect(sprite.src).toBeUndefined();
-		expect(sprite._beforeSrc).toBeUndefined();
-		expect(sprite.surface).toBe(surface);
-		expect(sprite._beforeSurface).toBe(sprite.surface);
+		expect(sprite.src).toBe(surface);
+		expect(sprite._beforeSrc).toBe(sprite.src);
+		expect(sprite._surface).toBe(surface);
+		expect(sprite._beforeSurface).toBe(sprite._surface);
 
 		sprite.invalidate();
 		expect(sprite.width).toBe(32);
@@ -55,10 +55,10 @@ describe("test Sprite", () => {
 		expect(sprite2.srcHeight).toBe(32);
 		expect(sprite2.srcX).toBe(0);
 		expect(sprite2.srcY).toBe(0);
-		expect(sprite2.src).toBeUndefined();
-		expect(sprite._beforeSrc).toBeUndefined();
-		expect(sprite2.surface).toBe(surface2);
-		expect(sprite2._beforeSurface).toBe(sprite2.surface);
+		expect(sprite2.src).toBe(surface2);
+		expect(sprite2._beforeSrc).toBe(sprite2.src);
+		expect(sprite2._surface).toBe(surface2);
+		expect(sprite2._beforeSurface).toBe(sprite2._surface);
 	});
 
 	it("初期化 - 動画サーフェス", () => {
@@ -76,8 +76,8 @@ describe("test Sprite", () => {
 		expect(sprite.srcHeight).toEqual(32);
 		expect(sprite.srcX).toEqual(0);
 		expect(sprite.srcY).toEqual(0);
-		expect(sprite.surface).toBe(surface);
-		expect(sprite._beforeSurface).toEqual(sprite.surface);
+		expect(sprite._surface).toBe(surface);
+		expect(sprite._beforeSurface).toEqual(sprite._surface);
 
 		sprite.update.fire();
 		expect(updated).toBe(false);
@@ -107,8 +107,8 @@ describe("test Sprite", () => {
 		expect(sprite.srcHeight).toEqual(32);
 		expect(sprite.srcX).toEqual(0);
 		expect(sprite.srcY).toEqual(0);
-		expect(sprite.surface).toBe(surface);
-		expect(sprite._beforeSurface).toEqual(sprite.surface);
+		expect(sprite._surface).toBe(surface);
+		expect(sprite._beforeSurface).toEqual(sprite._surface);
 
 		sprite.update.fire();
 		expect(updated).toBe(true);
@@ -133,7 +133,7 @@ describe("test Sprite", () => {
 		expect(sprite.srcHeight).toEqual(24);
 		expect(sprite.srcX).toEqual(1);
 		expect(sprite.srcY).toEqual(2);
-		expect(sprite.surface).toEqual(surface);
+		expect(sprite._surface).toEqual(surface);
 
 		const surface2 = new Surface(48, 128);
 		const sprite2 = new MonitorSprite({
@@ -146,7 +146,7 @@ describe("test Sprite", () => {
 		expect(sprite2.srcHeight).toEqual(128);
 		expect(sprite2.srcX).toEqual(0);
 		expect(sprite2.srcY).toEqual(0);
-		expect(sprite2.surface).toBe(surface2);
+		expect(sprite2._surface).toBe(surface2);
 	});
 
 	it("初期化 - ParameterObject, 動画サーフェス", () => {
@@ -169,8 +169,8 @@ describe("test Sprite", () => {
 		expect(sprite.srcHeight).toEqual(24);
 		expect(sprite.srcX).toEqual(1);
 		expect(sprite.srcY).toEqual(2);
-		expect(sprite.surface).toEqual(surface);
-		expect(sprite._beforeSurface).toEqual(sprite.surface);
+		expect(sprite._surface).toEqual(surface);
+		expect(sprite._beforeSurface).toEqual(sprite._surface);
 
 		sprite.update.fire();
 		expect(updated).toBe(false);
@@ -203,8 +203,8 @@ describe("test Sprite", () => {
 		expect(sprite.srcHeight).toEqual(24);
 		expect(sprite.srcX).toEqual(1);
 		expect(sprite.srcY).toEqual(2);
-		expect(sprite.surface).toEqual(surface);
-		expect(sprite._beforeSurface).toEqual(sprite.surface);
+		expect(sprite._surface).toEqual(surface);
+		expect(sprite._beforeSurface).toEqual(sprite._surface);
 
 		sprite.update.fire();
 		expect(updated).toBe(true);
@@ -277,7 +277,7 @@ describe("test Sprite", () => {
 		sprite.update.fire();
 		expect(updated).toBe(true);
 
-		sprite.surface = surface2;
+		sprite._surface = surface2;
 		sprite.invalidate();
 		updated = false;
 
@@ -304,7 +304,7 @@ describe("test Sprite", () => {
 		sprite.update.fire();
 		expect(updated).toBe(true);
 
-		sprite.surface = surface2;
+		sprite._surface = surface2;
 		sprite.invalidate();
 		updated = false;
 
@@ -321,7 +321,7 @@ describe("test Sprite", () => {
 		});
 		expect(sprite.src).toBe(imageAsset);
 		expect(sprite._beforeSrc).toBe(imageAsset);
-		expect(sprite.surface).toBe(imageAsset.asSurface());
+		expect(sprite._surface).toBe(imageAsset.asSurface());
 		expect(sprite._beforeSurface).toBe(imageAsset.asSurface());
 
 		const otherImageAsset = runtime.game.resourceFactory.createImageAsset(null, null, 100, 100);
@@ -329,15 +329,15 @@ describe("test Sprite", () => {
 		sprite.invalidate();
 		expect(sprite.src).toBe(otherImageAsset);
 		expect(sprite._beforeSrc).toBe(otherImageAsset);
-		expect(sprite.surface).toBe(otherImageAsset.asSurface());
+		expect(sprite._surface).toBe(otherImageAsset.asSurface());
 		expect(sprite._beforeSurface).toBe(otherImageAsset.asSurface());
 
 		const surface = new Surface(16, 32);
-		sprite.surface = surface;
+		sprite._surface = surface;
 		sprite.invalidate();
 		expect(sprite.src).toBe(otherImageAsset);
 		expect(sprite._beforeSrc).toBe(otherImageAsset);
-		expect(sprite.surface).toBe(surface);
+		expect(sprite._surface).toBe(surface);
 		expect(sprite._beforeSurface).toBe(surface);
 	});
 });

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -231,6 +231,7 @@ class LoadFailureController {
 
 export class ImageAsset extends g.ImageAsset {
 	_failureController: LoadFailureController;
+	_surface: Surface;
 
 	constructor(necessaryRetryCount: number, id: string, assetPath: string, width: number, height: number) {
 		super(id, assetPath, width, height);
@@ -246,7 +247,10 @@ export class ImageAsset extends g.ImageAsset {
 	}
 
 	asSurface(): g.Surface {
-		return new Surface(0, 0);
+		if (this._surface == null) {
+			this._surface = new Surface(this.width, this.height);
+		}
+		return this._surface;
 	}
 }
 

--- a/src/domain/entities/FrameSprite.ts
+++ b/src/domain/entities/FrameSprite.ts
@@ -127,7 +127,7 @@ export class FrameSprite extends Sprite {
 	static createBySprite(sprite: Sprite, width?: number, height?: number): FrameSprite {
 		var frameSprite = new FrameSprite({
 			scene: sprite.scene,
-			src: sprite.surface,
+			src: sprite.src,
 			width: width === undefined ? sprite.width : width,
 			height: height === undefined ? sprite.height : height
 		});
@@ -224,7 +224,7 @@ export class FrameSprite extends Sprite {
 	 */
 	_changeFrame(): void {
 		var frame = this.frames[this.frameNumber];
-		var sep = Math.floor(this.surface.width / this.srcWidth);
+		var sep = Math.floor(this._surface.width / this.srcWidth);
 		this.srcX = (frame % sep) * this.srcWidth;
 		this.srcY = Math.floor(frame / sep) * this.srcHeight;
 		this._lastUsedIndex = frame;


### PR DESCRIPTION
## このpull requestが解決する内容
* `SpriteParameterObject#src` に対応する `Sprite#src` を新設します。
* `Sprite#surface` を `Sprite#_surface` (private) に変更します。

## 破壊的な変更を含んでいるか?

- **あり**
  - `Sprite#surface` が `Sprite#_surface` に変更されます

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

