### PR TITLE
Modify type of Pane#backgroundImage

### DIFF
--- a/src/__tests__/PaneSpec.ts
+++ b/src/__tests__/PaneSpec.ts
@@ -60,7 +60,37 @@ describe("test Pane", () => {
 			padding: { top: 3, left: 1, right: 4, bottom: 2 },
 			backgroundImage: imageAsset
 		});
-		expect(pane.backgroundImage).toEqual(SurfaceUtil.asSurface(imageAsset));
+		expect(pane._backgroundImageSurface).toEqual(SurfaceUtil.asSurface(imageAsset));
+	});
+
+	it("change backgroundImage", () => {
+		const scene = runtime.scene;
+		const imageAsset = runtime.game.resourceFactory.createImageAsset(null, null, 200, 200);
+		const r = new Renderer();
+
+		const pane = new Pane({
+			scene: scene,
+			width: 10,
+			height: 20,
+			padding: 3
+		});
+		scene.append(pane);
+
+		expect(pane.backgroundImage).toBeUndefined();
+		expect(pane._beforeBackgroundImage).toBeUndefined();
+		expect(pane._backgroundImageSurface).toBeUndefined();
+
+		pane.backgroundImage = imageAsset;
+		pane.renderCache(r); // invalidate()
+		expect(pane.backgroundImage).toBe(imageAsset);
+		expect(pane._beforeBackgroundImage).toBe(imageAsset);
+		expect(pane._backgroundImageSurface).toBe(imageAsset.asSurface());
+
+		pane.backgroundImage = undefined;
+		pane.renderCache(r); // invalidate()
+		expect(pane.backgroundImage).toBeUndefined();
+		expect(pane._beforeBackgroundImage).toBeUndefined();
+		expect(pane._backgroundImageSurface).toBeUndefined();
 	});
 
 	it("modified", () => {

--- a/src/domain/entities/Pane.ts
+++ b/src/domain/entities/Pane.ts
@@ -218,6 +218,7 @@ export class Pane extends CacheableE {
 		}
 		this.backgroundImage = undefined;
 		this._backgroundImageSurface = undefined;
+		this._beforeBackgroundImage = undefined;
 		this._bgSurface = undefined;
 		this._childrenSurface = undefined;
 		super.destroy();

--- a/src/domain/entities/Pane.ts
+++ b/src/domain/entities/Pane.ts
@@ -52,10 +52,10 @@ export interface PaneParameterObject extends CacheableEParameterObject {
  */
 export class Pane extends CacheableE {
 	/**
-	 * 背景画像の `Surface` 。
+	 * 背景画像の `ImageAsset` または `Surface` 。
 	 * この値を変更した場合、 `this.invalidate()` を呼び出す必要がある。
 	 */
-	backgroundImage: SurfaceLike; // TODO: (GAMEDEV-2034) Surface|ImageAsset 型になる予定
+	backgroundImage: ImageAssetLike | SurfaceLike | undefined;
 
 	/**
 	 * 背景画像の拡大・縮小に用いられる `SurfaceEffector` 。
@@ -63,6 +63,16 @@ export class Pane extends CacheableE {
 	 * この値を変更した場合、 `this.invalidate()` を呼び出す必要がある。
 	 */
 	backgroundEffector: SurfaceEffector;
+
+	/**
+	 * @private
+	 */
+	_backgroundImageSurface: SurfaceLike | undefined;
+
+	/**
+	 * @private
+	 */
+	_beforeBackgroundImage: ImageAssetLike | SurfaceLike | undefined;
 
 	/**
 	 * @private
@@ -123,7 +133,9 @@ export class Pane extends CacheableE {
 		super(param);
 		this._oldWidth = param.width;
 		this._oldHeight = param.height;
-		this.backgroundImage = SurfaceUtil.asSurface(param.backgroundImage);
+		this.backgroundImage = param.backgroundImage;
+		this._beforeBackgroundImage = param.backgroundImage;
+		this._backgroundImageSurface = SurfaceUtil.asSurface(param.backgroundImage);
 		this.backgroundEffector = param.backgroundEffector;
 		this._shouldRenderChildren = false;
 		this._padding = param.padding;
@@ -175,8 +187,8 @@ export class Pane extends CacheableE {
 
 		if (this._bgSurface) {
 			renderer.drawImage(this._bgSurface, 0, 0, this.width, this.height, 0, 0);
-		} else if (this.backgroundImage) {
-			renderer.drawImage(this.backgroundImage, 0, 0, this.width, this.height, 0, 0);
+		} else if (this._backgroundImageSurface) {
+			renderer.drawImage(this._backgroundImageSurface, 0, 0, this.width, this.height, 0, 0);
 		}
 		if (this._childrenArea.width <= 0 || this._childrenArea.height <= 0) {
 			return;
@@ -195,8 +207,8 @@ export class Pane extends CacheableE {
 	 * @param destroySurface trueを指定した場合、 `backgroundImage` に利用している `Surface` も合わせて破棄する。
 	 */
 	destroy(destroySurface?: boolean): void {
-		if (destroySurface && this.backgroundImage && !this.backgroundImage.destroyed()) {
-			this.backgroundImage.destroy();
+		if (destroySurface && this._backgroundImageSurface && !this._backgroundImageSurface.destroyed()) {
+			this._backgroundImageSurface.destroy();
 		}
 		if (this._bgSurface && !this._bgSurface.destroyed()) {
 			this._bgSurface.destroy();
@@ -205,6 +217,7 @@ export class Pane extends CacheableE {
 			this._childrenSurface.destroy();
 		}
 		this.backgroundImage = undefined;
+		this._backgroundImageSurface = undefined;
 		this._bgSurface = undefined;
 		this._childrenSurface = undefined;
 		super.destroy();
@@ -214,8 +227,12 @@ export class Pane extends CacheableE {
 	 * @private
 	 */
 	_renderBackground(): void {
-		if (this.backgroundImage && this.backgroundEffector) {
-			const bgSurface = this.backgroundEffector.render(this.backgroundImage, this.width, this.height);
+		if (this.backgroundImage !== this._beforeBackgroundImage) {
+			this._backgroundImageSurface = SurfaceUtil.asSurface(this.backgroundImage);
+			this._beforeBackgroundImage = this.backgroundImage;
+		}
+		if (this._backgroundImageSurface && this.backgroundEffector) {
+			const bgSurface = this.backgroundEffector.render(this._backgroundImageSurface, this.width, this.height);
 			if (this._bgSurface !== bgSurface) {
 				if (this._bgSurface && !this._bgSurface.destroyed()) {
 					this._bgSurface.destroy();


### PR DESCRIPTION
## このpull requestが解決する内容
関連PR: #158 
* `PaneParameterObject#backgroundImage` に対応する `Pane#backgroundImage` を新設します。
* `Pane#backgroundImage` を `Pane#_backgroundImageSurface` (private) に変更します。

## 破壊的な変更を含んでいるか?
* **あり**
  * `Pane#backgroundImage` が `Pane#_backgroundImageSurface` (private) に変更されます。