### PR TITLE
Update game.modified to function

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -157,10 +157,6 @@ export abstract class Game implements Registrable<E> {
 	 */
 	seed: Trigger<SeedEvent>;
 	/**
-	 * 画面更新が必要かのフラグ。
-	 */
-	modified: boolean;
-	/**
 	 * このコンテンツの累計経過時間。
 	 * 通常は `this.scene().local` が偽である状態で `tick()` の呼ばれた回数だが、シーン切り替え時等 `tick()` が呼ばれた時以外で加算される事もある。
 	 */
@@ -459,6 +455,12 @@ export abstract class Game implements Registrable<E> {
 	_runtimeValueBase: ScriptAssetRuntimeValueBase;
 
 	/**
+	 * 画面更新が必要か否かのフラグ。
+	 * @private
+	 */
+	_modified: boolean;
+
+	/**
 	 * 実行待ちのシーン遷移要求。
 	 */
 	private _sceneChangeRequests: SceneChangeRequest[];
@@ -467,7 +469,7 @@ export abstract class Game implements Registrable<E> {
 	 * 使用中のカメラ。
 	 *
 	 * `Game#draw()`, `Game#findPointSource()` のデフォルト値として使用される。
-	 * この値を変更した場合、変更を描画に反映するためには `Game#modified` に真を代入しなければならない。
+	 * この値を変更した場合、変更を描画に反映するためには `Game#modified(true)` を呼び出す必要がある。
 	 */
 	// focusingCameraが変更されても古いカメラをtargetCamerasに持つエンティティのEntityStateFlags.Modifiedを取りこぼすことが無いように、変更時にはrenderを呼べるようアクセサを使う
 	get focusingCamera(): Camera {
@@ -475,7 +477,7 @@ export abstract class Game implements Registrable<E> {
 	}
 	set focusingCamera(c: Camera) {
 		if (c === this._focusingCamera) return;
-		if (this.modified) this.render(this._focusingCamera);
+		if (this._modified) this.render(this._focusingCamera);
 		this._focusingCamera = c;
 	}
 
@@ -729,7 +731,7 @@ export abstract class Game implements Registrable<E> {
 			renderer.restore();
 			renderer.end();
 		}
-		this.modified = false;
+		this._modified = false;
 	}
 
 	/**
@@ -824,6 +826,15 @@ export abstract class Game implements Registrable<E> {
 		this._leaveGame();
 		this._isTerminated = true;
 		this._terminateGame();
+	}
+
+	/**
+	 * 画面更新が必要か否かのフラグを設定する。
+	 *
+	 * @param isModified 画面更新が必要な場合は真、でなければ偽。
+	 */
+	modified(isModified: boolean): void {
+		this._modified = isModified;
 	}
 
 	/**
@@ -1028,7 +1039,7 @@ export abstract class Game implements Registrable<E> {
 		this.db = {};
 		this._localDb = {};
 		this.events = [];
-		this.modified = true;
+		this._modified = true;
 		this.loadingScene = undefined;
 		this._focusingCamera = undefined;
 		this.snapshotRequest.removeAll();
@@ -1087,7 +1098,7 @@ export abstract class Game implements Registrable<E> {
 		this.leave = undefined;
 		this.seed.destroy();
 		this.seed = undefined;
-		this.modified = false;
+		this._modified = false;
 		this.age = 0;
 		this.assets = undefined; // this._initialScene.assets のエイリアスなので、特に破棄処理はしない。
 		this.isLoaded = false;
@@ -1174,7 +1185,7 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_updateEventTriggers(scene: Scene): void {
-		this.modified = true;
+		this._modified = true;
 		if (!scene) {
 			this._eventTriggerMap[EventType.Message] = undefined;
 			this._eventTriggerMap[EventType.PointDown] = undefined;
@@ -1300,6 +1311,6 @@ export abstract class Game implements Registrable<E> {
 				this._fireSceneLoaded(scene);
 			}
 		}
-		this.modified = true;
+		this._modified = true;
 	}
 }

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -579,7 +579,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 * @param isBubbling この関数をこのシーンの子の `modified()` から呼び出す場合、真を渡さなくてはならない。省略された場合、偽。
 	 */
 	modified(isBubbling?: boolean): void {
-		this.game.modified = true;
+		this.game.modified(true);
 	}
 
 	/**

--- a/src/__tests__/ESpec.ts
+++ b/src/__tests__/ESpec.ts
@@ -7,7 +7,7 @@ describe("test E", () => {
 	let runtime: Runtime, e: E;
 
 	function resetUpdated(runtime: Runtime): void {
-		runtime.game.modified = false;
+		runtime.game.modified(false);
 		e.state &= ~EntityStateFlags.Modified;
 	}
 
@@ -350,32 +350,32 @@ describe("test E", () => {
 
 	it("modified", () => {
 		resetUpdated(runtime);
-		expect(runtime.game.modified).toBe(false);
+		expect(runtime.game._modified).toBe(false);
 
 		e.modified();
-		expect(runtime.game.modified).toBe(true);
+		expect(runtime.game._modified).toBe(true);
 
 		resetUpdated(runtime);
 
 		const e2 = new E({ scene: runtime.scene });
 		e.append(e2);
-		expect(runtime.game.modified).toBe(true);
+		expect(runtime.game._modified).toBe(true);
 
 		resetUpdated(runtime);
 		const e3 = new E({ scene: runtime.scene });
 		e.append(e3);
-		expect(runtime.game.modified).toBe(true);
+		expect(runtime.game._modified).toBe(true);
 	});
 
 	it("modified with hide/show", () => {
 		resetUpdated(runtime);
-		expect(runtime.game.modified).toBe(false);
+		expect(runtime.game._modified).toBe(false);
 		e.hide();
-		expect(runtime.game.modified).toBe(true);
+		expect(runtime.game._modified).toBe(true);
 		runtime.game.render();
-		expect(runtime.game.modified).toBe(false);
+		expect(runtime.game._modified).toBe(false);
 		e.show();
-		expect(runtime.game.modified).toBe(true);
+		expect(runtime.game._modified).toBe(true);
 	});
 
 	it("update", () => {

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -28,7 +28,7 @@ describe("test Game", () => {
 		expect(game.scenes.length).toBe(0);
 		expect(game.random).toBe(null);
 		expect(game.events.length).toBe(0);
-		expect(game.modified).toBe(true);
+		expect(game._modified).toBe(true);
 		expect(game.external).toEqual({});
 		expect(game.age).toBe(0);
 		expect(game.fps).toBe(30);
@@ -49,7 +49,7 @@ describe("test Game", () => {
 		expect(game.scenes).toBe(undefined);
 		expect(game.random).toBe(undefined);
 		expect(game.events).toBe(undefined);
-		expect(game.modified).toBe(false);
+		expect(game._modified).toBe(false);
 		expect(game.external).toEqual({}); // external は触らない
 		expect(game.vars).toEqual({}); // vars も触らない
 		expect(game.playId).toBe(undefined);
@@ -920,29 +920,29 @@ describe("test Game", () => {
 		const e = new E({ scene: scene });
 		scene.append(e);
 		expect(e.state).toBe(0);
-		expect(game.modified).toBe(true);
+		expect(game._modified).toBe(true);
 
 		const camera = new Camera2D({});
 		game.focusingCamera = camera;
 		expect(game.focusingCamera).toEqual(camera);
 		expect(e.state).toBe(EntityStateFlags.None);
-		expect(game.modified).toBe(false);
+		expect(game._modified).toBe(false);
 
 		e.modified();
 		expect(e.state).toBe(EntityStateFlags.Modified | EntityStateFlags.ContextLess);
-		expect(game.modified).toBe(true);
+		expect(game._modified).toBe(true);
 		game.focusingCamera = camera;
 		expect(e.state).toBe(EntityStateFlags.Modified | EntityStateFlags.ContextLess);
-		expect(game.modified).toBe(true);
+		expect(game._modified).toBe(true);
 
 		e.modified();
 		const camera2 = new Camera2D({});
 		game.focusingCamera = camera2;
 		expect(game.focusingCamera).toEqual(camera2);
 		expect(e.state).toBe(EntityStateFlags.ContextLess);
-		expect(game.modified).toBe(false);
+		expect(game._modified).toBe(false);
 
-		game.modified = false;
+		game.modified(false);
 		game.focusingCamera = camera;
 		expect(game.focusingCamera).toEqual(camera);
 	});

--- a/src/__tests__/SceneSpec.ts
+++ b/src/__tests__/SceneSpec.ts
@@ -876,7 +876,7 @@ describe("test Scene", () => {
 	it("modified", () => {
 		const scene = new Scene({ game: game });
 		scene.modified();
-		expect(scene.game.modified).toEqual(true);
+		expect(scene.game._modified).toEqual(true);
 	});
 
 	it("state", done => {


### PR DESCRIPTION
## このpull requestが解決する内容

`Game#modified` をfunction化。

`Game#modified = true`  -> `Game#modified(true)`  へ変更。

## 破壊的な変更を含んでいるか?

- あり
  - 代入の更新ではなく、`Game#modified(true)` ように function で呼び出す必要があります。
