### PR TITLE
Game#popSceneでpopする回数を指定できるようにした

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   * g.Util.findAssetByPathDirectory => g._findAssetByPathDirectory (Module.tsに配置)
   * g.Util.createMatrixは削除
 
+機能追加
+ * `g.Game#popScene`で popする回数をオプションで指定できるようにした
+
 ## 2.5.4
 機能追加
  * `g.Object2D#anchorX` と `g.Object2D#anchorY` を追加

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -627,21 +627,22 @@ export abstract class Game implements Registrable<E> {
 	}
 
 	/**
-	 * 一つ前のシーンに戻ることを要求する。
+	 * シーンスタックから現在のシーンを取り除くことを要求する
 	 *
 	 * このメソッドは要求を行うだけである。呼び出し直後にはシーン遷移は行われていないことに注意。
 	 * 実際のシーン遷移は次のフレームまでに(次のupdateのfireまでに)行われる。
-	 * 引数 `preserveCurrent` が偽の場合、このメソッドの呼び出しにより現在のシーンは破棄される。
+	 * 引数 `preserve` が偽の場合、このメソッドの呼び出しにより取り除かれたシーンは全て破棄される。
 	 * またその時 `stateChanged` が引数 `SceneState.Destroyed` でfireされる。
 	 * その後一つ前のシーンの `stateChanged` が引数 `SceneState.Active` でfireされる。
+	 * また、step数がスタックされているシーンの数以上の場合、例外が投げられる。
 	 *
-	 * @param preserveCurrent 真の場合、現在のシーンを破棄しない(ゲーム開発者が明示的に破棄せねばならない)。省略された場合、偽
+	 * @param preserve 真の場合、シーンを破棄しない(ゲーム開発者が明示的に破棄せねばならない)。省略された場合、偽
+	 * @param step 取り除くシーンの数。省略された場合、1
 	 */
-	popScene(preserveCurrent?: boolean): void {
-		this._sceneChangeRequests.push({
-			type: SceneChangeType.Pop,
-			preserveCurrent: preserveCurrent
-		});
+	popScene(preserve?: boolean, step: number = 1): void {
+		for (let i = 0; i < step; i++) {
+			this._sceneChangeRequests.push({ type: SceneChangeType.Pop, preserveCurrent: preserve });
+		}
 	}
 
 	/**

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -243,6 +243,40 @@ describe("test Game", () => {
 		game._startLoadingGlobalAssets();
 	});
 
+	it("popScene - specified step", done => {
+		const game = new Game({ width: 320, height: 320, main: "" });
+
+		game._loaded.add(() => { // game.scenes テストのため _loaded を待つ必要がある
+			// popSceneで指定したシーンまで戻る際に経過したシーンは全て削除
+			const scene = new Scene({ game: game, name: "SCENE1" });
+			const scene2 = new Scene({ game: game, name: "SCENE2" });
+			const scene3 = new Scene({ game: game, name: "SCENE3" });
+			game.pushScene(scene);
+			game.pushScene(scene2);
+			game.pushScene(scene3);
+			game.popScene(false, 2);
+			game._flushSceneChangeRequests();
+			expect(game.scenes).toEqual([game._initialScene, scene]);
+			expect(scene.destroyed()).toBe(false);
+			expect(scene2.destroyed()).toBe(true);
+			expect(scene3.destroyed()).toBe(true);
+
+			// popSceneで指定したシーンまで戻る際に経過したシーンは全て残す
+			const scene2Alpha = new Scene({ game: game, name: "SCENE2_Alpha" });
+			const scene3Beta = new Scene({ game: game, name: "SCENE3_Beta" });
+			game.pushScene(scene2Alpha);
+			game.pushScene(scene3Beta);
+			game.popScene(true, 3);
+			game._flushSceneChangeRequests();
+			expect(game.scenes).toEqual([game._initialScene]);
+			expect(scene.destroyed()).toBe(false);
+			expect(scene2Alpha.destroyed()).toBe(false);
+			expect(scene3Beta.destroyed()).toBe(false);
+			done();
+		});
+		game._startLoadingGlobalAssets();
+	});
+
 	it("replaceScene", done => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 


### PR DESCRIPTION
## このpull requestが解決する内容
* 今までGame#popSceneで現在のシーンしかpopできなかったが、オプションでpopする回数を指定することによって指定のシーンまでpopできるようになった

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->