### PR TITLE
Modify mute timing of AudioPlayer

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -512,13 +512,13 @@ export abstract class Game implements Registrable<E> {
 			music: new MusicAudioSystem({
 				id: "music",
 				muted: this._audioSystemManager._muted,
-				isSuppressed: this._audioSystemManager._isSuppressed,
+				playbackRate: this._audioSystemManager._playbackRate,
 				resourceFactory: this.resourceFactory
 			}),
 			sound: new SoundAudioSystem({
 				id: "sound",
 				muted: this._audioSystemManager._muted,
-				isSuppressed: this._audioSystemManager._isSuppressed,
+				playbackRate: this._audioSystemManager._playbackRate,
 				resourceFactory: this.resourceFactory
 			})
 		};
@@ -973,11 +973,7 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_setAudioPlaybackRate(playbackRate: number): void {
-		if (playbackRate < 0 || isNaN(playbackRate) || typeof playbackRate !== "number")
-			throw ExceptionFactory.createAssertionError(
-				"Game#_setAudioPlaybackRate: expected: greater or equal to 0.0, actual: " + playbackRate
-			);
-		this._audioSystemManager._changePlaybackRate(playbackRate);
+		this._audioSystemManager._setPlaybackRate(playbackRate);
 	}
 
 	/**

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -512,13 +512,13 @@ export abstract class Game implements Registrable<E> {
 			music: new MusicAudioSystem({
 				id: "music",
 				muted: this._audioSystemManager._muted,
-				playbackRate: this._audioSystemManager._playbackRate,
+				isSuppressed: this._audioSystemManager._isSuppressed,
 				resourceFactory: this.resourceFactory
 			}),
 			sound: new SoundAudioSystem({
 				id: "sound",
 				muted: this._audioSystemManager._muted,
-				playbackRate: this._audioSystemManager._playbackRate,
+				isSuppressed: this._audioSystemManager._isSuppressed,
 				resourceFactory: this.resourceFactory
 			})
 		};
@@ -973,7 +973,11 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_setAudioPlaybackRate(playbackRate: number): void {
-		this._audioSystemManager._setPlaybackRate(playbackRate);
+		if (playbackRate < 0 || isNaN(playbackRate) || typeof playbackRate !== "number")
+			throw ExceptionFactory.createAssertionError(
+				"Game#_setAudioPlaybackRate: expected: greater or equal to 0.0, actual: " + playbackRate
+			);
+		this._audioSystemManager._changePlaybackRate(playbackRate);
 	}
 
 	/**

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -512,13 +512,13 @@ export abstract class Game implements Registrable<E> {
 			music: new MusicAudioSystem({
 				id: "music",
 				muted: this._audioSystemManager._muted,
-				playbackRate: this._audioSystemManager._playbackRate,
+				// playbackRate: this._audioSystemManager._playbackRate,
 				resourceFactory: this.resourceFactory
 			}),
 			sound: new SoundAudioSystem({
 				id: "sound",
 				muted: this._audioSystemManager._muted,
-				playbackRate: this._audioSystemManager._playbackRate,
+				// playbackRate: this._audioSystemManager._playbackRate,
 				resourceFactory: this.resourceFactory
 			})
 		};

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -512,13 +512,11 @@ export abstract class Game implements Registrable<E> {
 			music: new MusicAudioSystem({
 				id: "music",
 				muted: this._audioSystemManager._muted,
-				// playbackRate: this._audioSystemManager._playbackRate,
 				resourceFactory: this.resourceFactory
 			}),
 			sound: new SoundAudioSystem({
 				id: "sound",
 				muted: this._audioSystemManager._muted,
-				// playbackRate: this._audioSystemManager._playbackRate,
 				resourceFactory: this.resourceFactory
 			})
 		};

--- a/src/__tests__/AssetSpec.ts
+++ b/src/__tests__/AssetSpec.ts
@@ -10,7 +10,7 @@ describe("test Asset", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			playbackRate: game._audioSystemManager._playbackRate,
+			isSuppressed: game._audioSystemManager._isSuppressed,
 			resourceFactory: game.resourceFactory
 		});
 		const hint = { streaming: true };

--- a/src/__tests__/AssetSpec.ts
+++ b/src/__tests__/AssetSpec.ts
@@ -10,7 +10,6 @@ describe("test Asset", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			// playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		const hint = { streaming: true };

--- a/src/__tests__/AssetSpec.ts
+++ b/src/__tests__/AssetSpec.ts
@@ -10,7 +10,7 @@ describe("test Asset", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			playbackRate: game._audioSystemManager._playbackRate,
+			// playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		const hint = { streaming: true };

--- a/src/__tests__/AssetSpec.ts
+++ b/src/__tests__/AssetSpec.ts
@@ -10,7 +10,7 @@ describe("test Asset", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			isSuppressed: game._audioSystemManager._isSuppressed,
+			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		const hint = { streaming: true };

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -8,7 +8,6 @@ describe("test AudioPlayer", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			// playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		const player = new AudioPlayer({ volume: system.volume, muted: system._isSuppressed || system._muted });
@@ -23,7 +22,6 @@ describe("test AudioPlayer", () => {
 		const system = new SoundAudioSystem({
 			id: "voice",
 			muted: game._audioSystemManager._muted,
-			// playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		system.volume = 0.5;

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -8,7 +8,7 @@ describe("test AudioPlayer", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			playbackRate: game._audioSystemManager._playbackRate,
+			// playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		const player = new AudioPlayer({ volume: system.volume, muted: system._isSuppressed || system._muted });
@@ -23,7 +23,7 @@ describe("test AudioPlayer", () => {
 		const system = new SoundAudioSystem({
 			id: "voice",
 			muted: game._audioSystemManager._muted,
-			playbackRate: game._audioSystemManager._playbackRate,
+			// playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		system.volume = 0.5;

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -11,7 +11,7 @@ describe("test AudioPlayer", () => {
 			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
-		const player = new AudioPlayer(system);
+		const player = new AudioPlayer({ volume: system.volume, muted: system._playbackRate !== 1.0 });
 		expect(player.volume).toBe(system.volume);
 		expect(player.played.constructor).toBe(Trigger);
 		expect(player.stopped.constructor).toBe(Trigger);
@@ -27,7 +27,7 @@ describe("test AudioPlayer", () => {
 			resourceFactory: game.resourceFactory
 		});
 		system.volume = 0.5;
-		const player = new AudioPlayer(system);
+		const player = new AudioPlayer({ volume: system.volume, muted: system._playbackRate !== 1.0 });
 		expect(player.volume).toBe(system.volume);
 		expect(player.played.constructor).toBe(Trigger);
 		expect(player.stopped.constructor).toBe(Trigger);

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -8,7 +8,7 @@ describe("test AudioPlayer", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			isSuppressed: game._audioSystemManager._isSuppressed,
+			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		const player = new AudioPlayer({ volume: system.volume, muted: system._isSuppressed || system._muted });
@@ -23,7 +23,7 @@ describe("test AudioPlayer", () => {
 		const system = new SoundAudioSystem({
 			id: "voice",
 			muted: game._audioSystemManager._muted,
-			isSuppressed: game._audioSystemManager._isSuppressed,
+			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		system.volume = 0.5;

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -10,7 +10,7 @@ describe("test AudioPlayer", () => {
 			muted: game._audioSystemManager._muted,
 			resourceFactory: game.resourceFactory
 		});
-		const player = new AudioPlayer({ volume: system.volume, muted: system._isSuppressed || system._muted });
+		const player = system.createPlayer();
 		expect(player.volume).toBe(system.volume);
 		expect(player.played.constructor).toBe(Trigger);
 		expect(player.stopped.constructor).toBe(Trigger);
@@ -25,7 +25,7 @@ describe("test AudioPlayer", () => {
 			resourceFactory: game.resourceFactory
 		});
 		system.volume = 0.5;
-		const player = new AudioPlayer({ volume: system.volume, muted: system._isSuppressed || system._muted });
+		const player = system.createPlayer();
 		expect(player.volume).toBe(system.volume);
 		expect(player.played.constructor).toBe(Trigger);
 		expect(player.stopped.constructor).toBe(Trigger);

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -8,10 +8,10 @@ describe("test AudioPlayer", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			playbackRate: game._audioSystemManager._playbackRate,
+			isSuppressed: game._audioSystemManager._isSuppressed,
 			resourceFactory: game.resourceFactory
 		});
-		const player = new AudioPlayer({ volume: system.volume, muted: system._playbackRate !== 1.0 });
+		const player = new AudioPlayer({ volume: system.volume, muted: system._isSuppressed || system._muted });
 		expect(player.volume).toBe(system.volume);
 		expect(player.played.constructor).toBe(Trigger);
 		expect(player.stopped.constructor).toBe(Trigger);
@@ -23,11 +23,11 @@ describe("test AudioPlayer", () => {
 		const system = new SoundAudioSystem({
 			id: "voice",
 			muted: game._audioSystemManager._muted,
-			playbackRate: game._audioSystemManager._playbackRate,
+			isSuppressed: game._audioSystemManager._isSuppressed,
 			resourceFactory: game.resourceFactory
 		});
 		system.volume = 0.5;
-		const player = new AudioPlayer({ volume: system.volume, muted: system._playbackRate !== 1.0 });
+		const player = new AudioPlayer({ volume: system.volume, muted: system._isSuppressed || system._muted });
 		expect(player.volume).toBe(system.volume);
 		expect(player.played.constructor).toBe(Trigger);
 		expect(player.stopped.constructor).toBe(Trigger);

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -57,6 +57,10 @@ describe("test AudioPlayer", () => {
 		const player1 = system.createPlayer();
 		const player2 = system.createPlayer();
 
+		expect(system._isSuppressed).toBeFalsy();
+		expect(player1._muted).toBeFalsy();
+		expect(player2._muted).toBeFalsy();
+
 		system._setPlaybackRate(0.3);
 		expect(system._isSuppressed).toBeTruthy();
 		expect(player1._muted).toBeTruthy();

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -9,7 +9,7 @@ describe("test AudioPlayer", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			isSuppressed: game._audioSystemManager._isSuppressed,
+			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		expect(() => {
@@ -43,7 +43,7 @@ describe("test AudioPlayer", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			isSuppressed: game._audioSystemManager._isSuppressed,
+			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		const audio = new ResourceFactory().createAudioAsset("testId", "testAssetPath", 0, null, false, null);
@@ -51,14 +51,16 @@ describe("test AudioPlayer", () => {
 		expect(system._destroyRequestedAssets[audio.id]).toEqual(audio);
 	});
 
-	it("AudioSystem#_setSuppressed", () => {
+	it("AudioSystem#_setPlaybackRate", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 		const system = game.audio.sound;
 		const player1 = system.createPlayer();
+		const player2 = system.createPlayer();
 
-		system._setSuppressed(true);
+		system._setPlaybackRate(0.3);
 		expect(system._isSuppressed).toBeTruthy();
 		expect(player1._muted).toBeTruthy();
+		expect(player2._muted).toBeTruthy();
 	});
 
 	it("AudioSystem#_changeMuted", () => {
@@ -85,12 +87,13 @@ describe("test AudioPlayer", () => {
 		const asset = game.resourceFactory.createAudioAsset("dummy", "audio/dummy", 0, system, true, {});
 		const player = system.createPlayer();
 
-		system._setSuppressed(true);
+		system._setPlaybackRate(0.3);
 		system.requestDestroy(asset);
 		expect(system._isSuppressed).toBeTruthy();
 		expect(system._destroyRequestedAssets.dummy).toBe(asset);
 
 		system._reset();
+		expect(player._muted).toBeTruthy();
 		expect(system._isSuppressed).toBeFalsy();
 		expect(system._destroyRequestedAssets).toEqual({});
 	});
@@ -99,9 +102,11 @@ describe("test AudioPlayer", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 		const system = game.audio.music;
 		const asset = game.resourceFactory.createAudioAsset("dummy", "audio/dummy", 0, system, true, {});
+		const player = system.createPlayer();
 
-		system._setSuppressed(true);
+		system._setPlaybackRate(0.3);
 		system.requestDestroy(asset);
+		expect(player._muted).toBeTruthy();
 		expect(system._isSuppressed).toBeTruthy();
 		expect(system._destroyRequestedAssets.dummy).toBe(asset);
 
@@ -110,7 +115,7 @@ describe("test AudioPlayer", () => {
 		expect(system._destroyRequestedAssets).toEqual({});
 	});
 
-	it("MusicAudioSystem#_setSuppressed", () => {
+	it("MusicAudioSystem#_setPlaybackRate", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 		const system = game.audio.music;
 		const player1 = system.createPlayer() as AudioPlayer;
@@ -135,13 +140,13 @@ describe("test AudioPlayer", () => {
 		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 
-		// ゲームの再生が抑制された時、AudioPlayerをミュートにする
-		system._setSuppressed(true);
+		// 非等倍になったらミュートにする
+		system._setPlaybackRate(0.4);
 		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 		expect(player1._muted).toBeTruthy();
 
-		// ゲームの再生が抑制された時、Triggerのplayed は実行されずAudioPlayerはミュートとなる
+		// 非等倍で再生時、Triggerのplayed は実行されずミュートとなる
 		player1.stop();
 		resetCalledCount();
 		player1.play(asset);
@@ -149,15 +154,15 @@ describe("test AudioPlayer", () => {
 		expect(stoppedCalled).toBe(0);
 		expect(player1._muted).toBeTruthy();
 
-		// ゲームの再生が抑制状態から通常に戻った時、AudioPlayerのミュートが解除される
+		// 等倍再生に戻すと、ミュートが解除される
 		player1.play(asset);
-		system._setSuppressed(false);
+		system._setPlaybackRate(1.0);
 		expect(playedCalled).toBe(0);
 		expect(stoppedCalled).toBe(0);
 		expect(player1._muted).toBeFalsy();
 	});
 
-	it("SoundAudioSystem#_setSuppressed", () => {
+	it("SoundAudioSystem#_setPlaybackRate", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 		const system = game.audio.sound;
 		const player1 = system.createPlayer() as AudioPlayer;
@@ -182,14 +187,14 @@ describe("test AudioPlayer", () => {
 		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 
-		// ゲームの再生が抑制された時、AudioPlayerをミュートにする
-		system._setSuppressed(true);
+		// 非等倍になったらミュートにする
+		system._setPlaybackRate(0.6);
 		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 		expect(player1._muted).toBeTruthy();
 		player1.stop();
 
-		// ゲームの再生が抑制された時、Triggerのplayed は実行されずAudioPlayerはミュートとなる
+		// 非等倍で再生時、ミュートになりTriggerのplayed は実行されない
 		const player2 = system.createPlayer() as AudioPlayer;
 		resetCalledCount();
 		player2.played.add(() => {
@@ -200,11 +205,11 @@ describe("test AudioPlayer", () => {
 		expect(stoppedCalled).toBe(0);
 		expect(player2._muted).toBeTruthy();
 
-		// ゲームの再生が抑制状態から通常に戻った時、AudioPlayerのミュートが解除される
+		// 等倍速度に戻してもSoundはミュートのままとなる。
 		const player3 = system.createPlayer() as AudioPlayer;
-		system._setSuppressed(true);
+		system._setPlaybackRate(0.5);
 		expect(player3._muted).toBeTruthy();
-		system._setSuppressed(false);
+		system._setPlaybackRate(1.0);
 		expect(player3._muted).toBeTruthy();
 	});
 });

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -9,7 +9,6 @@ describe("test AudioPlayer", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			// playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		expect(() => {
@@ -43,7 +42,6 @@ describe("test AudioPlayer", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			// playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		const audio = new ResourceFactory().createAudioAsset("testId", "testAssetPath", 0, null, false, null);
@@ -57,12 +55,10 @@ describe("test AudioPlayer", () => {
 		const player1 = system.createPlayer();
 		const player2 = system.createPlayer();
 
-		// expect(system._isSuppressed).toBeFalsy();
 		expect(player1._muted).toBeFalsy();
 		expect(player2._muted).toBeFalsy();
 
 		system._setPlaybackRate(0.3);
-		// expect(system._isSuppressed).toBeTruthy();
 		expect(player1._muted).toBeTruthy();
 		expect(player2._muted).toBeTruthy();
 	});
@@ -93,12 +89,10 @@ describe("test AudioPlayer", () => {
 
 		system._setPlaybackRate(0.3);
 		system.requestDestroy(asset);
-		// expect(system._isSuppressed).toBeTruthy();
 		expect(system._destroyRequestedAssets.dummy).toBe(asset);
 
 		system._reset();
 		expect(player._muted).toBeTruthy();
-		// expect(system._isSuppressed).toBeFalsy();
 		expect(system._destroyRequestedAssets).toEqual({});
 	});
 
@@ -111,7 +105,6 @@ describe("test AudioPlayer", () => {
 		system._setPlaybackRate(0.3);
 		system.requestDestroy(asset);
 		expect(player._muted).toBeTruthy();
-		// expect(system._isSuppressed).toBeTruthy();
 		expect(system._destroyRequestedAssets.dummy).toBe(asset);
 
 		system._reset();
@@ -159,7 +152,6 @@ describe("test AudioPlayer", () => {
 		expect(player1._muted).toBeTruthy();
 
 		// 等倍再生に戻すと、ミュートが解除される
-		player1.play(asset);
 		system._setPlaybackRate(1.0);
 		expect(playedCalled).toBe(0);
 		expect(stoppedCalled).toBe(0);

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -187,21 +187,24 @@ describe("test AudioPlayer", () => {
 		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 		expect(player1._muted).toBeTruthy();
+		player1.stop();
 
 		// 非等倍で再生時、ミュートになりTriggerのplayed は実行されない
-		player1.stop();
-		player1._changeMuted(false);
+		const player2 = system.createPlayer() as AudioPlayer;
 		resetCalledCount();
-		player1.play(asset);
+		player2.played.add(() => {
+			++playedCalled;
+		});
+		player2.play(asset);
 		expect(playedCalled).toBe(0);
 		expect(stoppedCalled).toBe(0);
-		expect(player1._muted).toBeTruthy();
+		expect(player2._muted).toBeTruthy();
 
 		// 等倍速度に戻してもSoundはミュートのままとなる。
-		const player2 = system.createPlayer() as AudioPlayer;
+		const player3 = system.createPlayer() as AudioPlayer;
 		system._setPlaybackRate(0.5);
-		expect(player2._muted).toBeTruthy();
+		expect(player3._muted).toBeTruthy();
 		system._setPlaybackRate(1.0);
-		expect(player2._muted).toBeTruthy();
+		expect(player3._muted).toBeTruthy();
 	});
 });

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -108,7 +108,6 @@ describe("test AudioPlayer", () => {
 		expect(system._destroyRequestedAssets.dummy).toBe(asset);
 
 		system._reset();
-		// expect(system._isSuppressed).toBeFalsy();
 		expect(system._destroyRequestedAssets).toEqual({});
 	});
 
@@ -137,23 +136,23 @@ describe("test AudioPlayer", () => {
 		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 
-		// 非等倍になったらミュートにする
+		// 再生速度が非等倍になったらミュートにする
 		system._setPlaybackRate(0.4);
 		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 		expect(player1._muted).toBeTruthy();
 
-		// 非等倍で再生時、Triggerのplayed は実行されずミュートとなる
+		// 再生速度が非等倍の状態で再生された場合、ミュートとなる
 		player1.stop();
 		resetCalledCount();
 		player1.play(asset);
-		expect(playedCalled).toBe(0);
+		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 		expect(player1._muted).toBeTruthy();
 
-		// 等倍再生に戻すと、ミュートが解除される
+		// 再生速度が等倍再生に戻った場合、ミュートが解除される
 		system._setPlaybackRate(1.0);
-		expect(playedCalled).toBe(0);
+		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 		expect(player1._muted).toBeFalsy();
 	});
@@ -183,25 +182,25 @@ describe("test AudioPlayer", () => {
 		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 
-		// 非等倍になったらミュートにする
+		// 再生速度が非等倍になったらミュートにする
 		system._setPlaybackRate(0.6);
 		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 		expect(player1._muted).toBeTruthy();
 		player1.stop();
 
-		// 非等倍で再生時、ミュートになりTriggerのplayed は実行されない
+		// 再生速度が非等倍の状態で再生された場合、ミュートとなる
 		const player2 = system.createPlayer() as AudioPlayer;
 		resetCalledCount();
 		player2.played.add(() => {
 			++playedCalled;
 		});
 		player2.play(asset);
-		expect(playedCalled).toBe(0);
+		expect(playedCalled).toBe(1);
 		expect(stoppedCalled).toBe(0);
 		expect(player2._muted).toBeTruthy();
 
-		// 等倍速度に戻してもSoundはミュートのままとなる。
+		// 再生速度が等倍速度に戻っても Sound はミュートのままとなる。
 		const player3 = system.createPlayer() as AudioPlayer;
 		system._setPlaybackRate(0.5);
 		expect(player3._muted).toBeTruthy();

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -9,7 +9,7 @@ describe("test AudioPlayer", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			playbackRate: game._audioSystemManager._playbackRate,
+			// playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		expect(() => {
@@ -43,7 +43,7 @@ describe("test AudioPlayer", () => {
 		const system = new MusicAudioSystem({
 			id: "music",
 			muted: game._audioSystemManager._muted,
-			playbackRate: game._audioSystemManager._playbackRate,
+			// playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		const audio = new ResourceFactory().createAudioAsset("testId", "testAssetPath", 0, null, false, null);
@@ -57,12 +57,12 @@ describe("test AudioPlayer", () => {
 		const player1 = system.createPlayer();
 		const player2 = system.createPlayer();
 
-		expect(system._isSuppressed).toBeFalsy();
+		// expect(system._isSuppressed).toBeFalsy();
 		expect(player1._muted).toBeFalsy();
 		expect(player2._muted).toBeFalsy();
 
 		system._setPlaybackRate(0.3);
-		expect(system._isSuppressed).toBeTruthy();
+		// expect(system._isSuppressed).toBeTruthy();
 		expect(player1._muted).toBeTruthy();
 		expect(player2._muted).toBeTruthy();
 	});
@@ -93,12 +93,12 @@ describe("test AudioPlayer", () => {
 
 		system._setPlaybackRate(0.3);
 		system.requestDestroy(asset);
-		expect(system._isSuppressed).toBeTruthy();
+		// expect(system._isSuppressed).toBeTruthy();
 		expect(system._destroyRequestedAssets.dummy).toBe(asset);
 
 		system._reset();
 		expect(player._muted).toBeTruthy();
-		expect(system._isSuppressed).toBeFalsy();
+		// expect(system._isSuppressed).toBeFalsy();
 		expect(system._destroyRequestedAssets).toEqual({});
 	});
 
@@ -111,11 +111,11 @@ describe("test AudioPlayer", () => {
 		system._setPlaybackRate(0.3);
 		system.requestDestroy(asset);
 		expect(player._muted).toBeTruthy();
-		expect(system._isSuppressed).toBeTruthy();
+		// expect(system._isSuppressed).toBeTruthy();
 		expect(system._destroyRequestedAssets.dummy).toBe(asset);
 
 		system._reset();
-		expect(system._isSuppressed).toBeFalsy();
+		// expect(system._isSuppressed).toBeFalsy();
 		expect(system._destroyRequestedAssets).toEqual({});
 	});
 

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -897,7 +897,7 @@ describe("test Game", () => {
 	it("controls audio volume", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 
-		expect(game._audioSystemManager._isSuppressed).toBeFalsy();
+		expect(game._audioSystemManager._playbackRate).toBe(1.0);
 		expect(game._audioSystemManager._muted).toBe(false);
 		expect(() => {
 			game._setAudioPlaybackRate(-0.5);
@@ -916,10 +916,9 @@ describe("test Game", () => {
 		expect(game.audio.sound._muted).toBe(true);
 		expect(game.audio.music._muted).toBe(true);
 
-		game._audioSystemManager._isSuppressed = false;
 		game._setAudioPlaybackRate(1.7);
 		game._setAudioPlaybackRate(1.7); // 同じ値を設定するパスのカバレッジ稼ぎ
-		expect(game._audioSystemManager._isSuppressed).toBeTruthy();
+		expect(game._audioSystemManager._playbackRate).toBe(1.7);
 		expect(game.audio.sound._isSuppressed).toBeTruthy();
 		expect(game.audio.music._isSuppressed).toBeTruthy();
 		expect(game.audio.sound._muted).toBe(true);
@@ -929,7 +928,7 @@ describe("test Game", () => {
 		const myAudioSys = new SoundAudioSystem({
 			id: "voice_chara1",
 			muted: game._audioSystemManager._muted,
-			isSuppressed: game._audioSystemManager._isSuppressed,
+			playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		game.audio.chara1 = myAudioSys;

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -897,30 +897,30 @@ describe("test Game", () => {
 	it("controls audio volume", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 
-		expect(game._audioSystemManager._playbackRate).toBe(1.0);
+		// expect(game._audioSystemManager._playbackRate).toBe(1.0);
 		expect(game._audioSystemManager._muted).toBe(false);
 		expect(() => {
 			game._setAudioPlaybackRate(-0.5);
 		}).toThrowError("AssertionError");
 
-		expect(game.audio.sound._isSuppressed).toBeFalsy();
-		expect(game.audio.music._isSuppressed).toBeFalsy();
+		// expect(game.audio.sound._isSuppressed).toBeFalsy();
+		// expect(game.audio.music._isSuppressed).toBeFalsy();
 		expect(game.audio.sound._muted).toBe(false);
 		expect(game.audio.music._muted).toBe(false);
 
 		game._setMuted(true);
 		game._setMuted(true); // 同じ値を設定するパスのカバレッジ稼ぎ
 		expect(game._audioSystemManager._muted).toBe(true);
-		expect(game.audio.sound._isSuppressed).toBeFalsy();
-		expect(game.audio.music._isSuppressed).toBeFalsy();
+		// expect(game.audio.sound._isSuppressed).toBeFalsy();
+		// expect(game.audio.music._isSuppressed).toBeFalsy();
 		expect(game.audio.sound._muted).toBe(true);
 		expect(game.audio.music._muted).toBe(true);
 
 		game._setAudioPlaybackRate(1.7);
 		game._setAudioPlaybackRate(1.7); // 同じ値を設定するパスのカバレッジ稼ぎ
-		expect(game._audioSystemManager._playbackRate).toBe(1.7);
-		expect(game.audio.sound._isSuppressed).toBeTruthy();
-		expect(game.audio.music._isSuppressed).toBeTruthy();
+		// expect(game._audioSystemManager._playbackRate).toBe(1.7);
+		// expect(game.audio.sound._isSuppressed).toBeTruthy();
+		// expect(game.audio.music._isSuppressed).toBeTruthy();
 		expect(game.audio.sound._muted).toBe(true);
 		expect(game.audio.music._muted).toBe(true);
 
@@ -928,17 +928,17 @@ describe("test Game", () => {
 		const myAudioSys = new SoundAudioSystem({
 			id: "voice_chara1",
 			muted: game._audioSystemManager._muted,
-			playbackRate: game._audioSystemManager._playbackRate,
+			// playbackRate: game._audioSystemManager._playbackRate,
 			resourceFactory: game.resourceFactory
 		});
 		game.audio.chara1 = myAudioSys;
-		expect(game.audio.chara1._isSuppressed).toBeTruthy();
+		// expect(game.audio.chara1._isSuppressed).toBeTruthy();
 		expect(game.audio.chara1._muted).toBe(true);
 		game._setMuted(false);
 		expect(game._audioSystemManager._muted).toBe(false);
-		expect(game.audio.chara1._isSuppressed).toBeTruthy();
-		expect(game.audio.sound._isSuppressed).toBeTruthy();
-		expect(game.audio.music._isSuppressed).toBeTruthy();
+		// expect(game.audio.chara1._isSuppressed).toBeTruthy();
+		// expect(game.audio.sound._isSuppressed).toBeTruthy();
+		// expect(game.audio.music._isSuppressed).toBeTruthy();
 		expect(game.audio.chara1._muted).toBe(false);
 		expect(game.audio.sound._muted).toBe(false);
 		expect(game.audio.music._muted).toBe(false);

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -897,49 +897,27 @@ describe("test Game", () => {
 	it("controls audio volume", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 
-		// expect(game._audioSystemManager._playbackRate).toBe(1.0);
 		expect(game._audioSystemManager._muted).toBe(false);
 		expect(() => {
 			game._setAudioPlaybackRate(-0.5);
 		}).toThrowError("AssertionError");
 
-		// expect(game.audio.sound._isSuppressed).toBeFalsy();
-		// expect(game.audio.music._isSuppressed).toBeFalsy();
 		expect(game.audio.sound._muted).toBe(false);
 		expect(game.audio.music._muted).toBe(false);
 
 		game._setMuted(true);
 		game._setMuted(true); // 同じ値を設定するパスのカバレッジ稼ぎ
 		expect(game._audioSystemManager._muted).toBe(true);
-		// expect(game.audio.sound._isSuppressed).toBeFalsy();
-		// expect(game.audio.music._isSuppressed).toBeFalsy();
 		expect(game.audio.sound._muted).toBe(true);
 		expect(game.audio.music._muted).toBe(true);
 
 		game._setAudioPlaybackRate(1.7);
 		game._setAudioPlaybackRate(1.7); // 同じ値を設定するパスのカバレッジ稼ぎ
-		// expect(game._audioSystemManager._playbackRate).toBe(1.7);
-		// expect(game.audio.sound._isSuppressed).toBeTruthy();
-		// expect(game.audio.music._isSuppressed).toBeTruthy();
 		expect(game.audio.sound._muted).toBe(true);
 		expect(game.audio.music._muted).toBe(true);
 
-		// 後から追加された AudioSystem でも GameDriver の値を反映する。
-		const myAudioSys = new SoundAudioSystem({
-			id: "voice_chara1",
-			muted: game._audioSystemManager._muted,
-			// playbackRate: game._audioSystemManager._playbackRate,
-			resourceFactory: game.resourceFactory
-		});
-		game.audio.chara1 = myAudioSys;
-		// expect(game.audio.chara1._isSuppressed).toBeTruthy();
-		expect(game.audio.chara1._muted).toBe(true);
 		game._setMuted(false);
 		expect(game._audioSystemManager._muted).toBe(false);
-		// expect(game.audio.chara1._isSuppressed).toBeTruthy();
-		// expect(game.audio.sound._isSuppressed).toBeTruthy();
-		// expect(game.audio.music._isSuppressed).toBeTruthy();
-		expect(game.audio.chara1._muted).toBe(false);
 		expect(game.audio.sound._muted).toBe(false);
 		expect(game.audio.music._muted).toBe(false);
 	});

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -897,30 +897,31 @@ describe("test Game", () => {
 	it("controls audio volume", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 
-		expect(game._audioSystemManager._playbackRate).toBe(1.0);
+		expect(game._audioSystemManager._isSuppressed).toBeFalsy();
 		expect(game._audioSystemManager._muted).toBe(false);
 		expect(() => {
 			game._setAudioPlaybackRate(-0.5);
 		}).toThrowError("AssertionError");
 
-		expect(game.audio.sound._playbackRate).toBe(1.0);
-		expect(game.audio.music._playbackRate).toBe(1.0);
+		expect(game.audio.sound._isSuppressed).toBeFalsy();
+		expect(game.audio.music._isSuppressed).toBeFalsy();
 		expect(game.audio.sound._muted).toBe(false);
 		expect(game.audio.music._muted).toBe(false);
 
 		game._setMuted(true);
 		game._setMuted(true); // 同じ値を設定するパスのカバレッジ稼ぎ
 		expect(game._audioSystemManager._muted).toBe(true);
-		expect(game.audio.sound._playbackRate).toBe(1.0);
-		expect(game.audio.music._playbackRate).toBe(1.0);
+		expect(game.audio.sound._isSuppressed).toBeFalsy();
+		expect(game.audio.music._isSuppressed).toBeFalsy();
 		expect(game.audio.sound._muted).toBe(true);
 		expect(game.audio.music._muted).toBe(true);
 
+		game._audioSystemManager._isSuppressed = false;
 		game._setAudioPlaybackRate(1.7);
 		game._setAudioPlaybackRate(1.7); // 同じ値を設定するパスのカバレッジ稼ぎ
-		expect(game._audioSystemManager._playbackRate).toBe(1.7);
-		expect(game.audio.sound._playbackRate).toBe(1.7);
-		expect(game.audio.music._playbackRate).toBe(1.7);
+		expect(game._audioSystemManager._isSuppressed).toBeTruthy();
+		expect(game.audio.sound._isSuppressed).toBeTruthy();
+		expect(game.audio.music._isSuppressed).toBeTruthy();
 		expect(game.audio.sound._muted).toBe(true);
 		expect(game.audio.music._muted).toBe(true);
 
@@ -928,17 +929,17 @@ describe("test Game", () => {
 		const myAudioSys = new SoundAudioSystem({
 			id: "voice_chara1",
 			muted: game._audioSystemManager._muted,
-			playbackRate: game._audioSystemManager._playbackRate,
+			isSuppressed: game._audioSystemManager._isSuppressed,
 			resourceFactory: game.resourceFactory
 		});
 		game.audio.chara1 = myAudioSys;
-		expect(game.audio.chara1._playbackRate).toBe(1.7);
+		expect(game.audio.chara1._isSuppressed).toBeTruthy();
 		expect(game.audio.chara1._muted).toBe(true);
 		game._setMuted(false);
 		expect(game._audioSystemManager._muted).toBe(false);
-		expect(game.audio.chara1._playbackRate).toBe(1.7);
-		expect(game.audio.sound._playbackRate).toBe(1.7);
-		expect(game.audio.music._playbackRate).toBe(1.7);
+		expect(game.audio.chara1._isSuppressed).toBeTruthy();
+		expect(game.audio.sound._isSuppressed).toBeTruthy();
+		expect(game.audio.music._isSuppressed).toBeTruthy();
 		expect(game.audio.chara1._muted).toBe(false);
 		expect(game.audio.sound._muted).toBe(false);
 		expect(game.audio.music._muted).toBe(false);

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -916,6 +916,7 @@ describe("test Game", () => {
 		expect(game.audio.sound._muted).toBe(true);
 		expect(game.audio.music._muted).toBe(true);
 
+		game._setAudioPlaybackRate(1.0);
 		game._setMuted(false);
 		expect(game._audioSystemManager._muted).toBe(false);
 		expect(game.audio.sound._muted).toBe(false);

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -573,6 +573,7 @@ export class Game extends g.Game {
 
 	autoTickForInternalEvents: boolean;
 	resourceFactory: ResourceFactory;
+	audio: { [key: string]: AudioSystemLike };
 
 	constructor(
 		gameConfiguration: g.GameConfiguration,
@@ -686,4 +687,8 @@ export class CacheableE extends g.CacheableE {
 	renderCache(renderer: Renderer, camera: g.Camera2D): void {
 		// do nothing
 	}
+}
+
+export interface AudioSystemLike extends g.AudioSystemLike {
+	_muted: boolean;
 }

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -537,7 +537,7 @@ export class ResourceFactory extends g.ResourceFactory {
 	}
 
 	createAudioPlayer(system: g.AudioSystem): g.AudioPlayer {
-		return new AudioPlayer({ volume: system.volume, muted: system._playbackRate !== 1.0 });
+		return new AudioPlayer({ volume: system.volume, muted: system._isSuppressed || system._muted });
 	}
 
 	createGlyphFactory(

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -423,21 +423,15 @@ export class VideoAsset extends g.VideoAsset {
 }
 
 export class AudioPlayer extends g.AudioPlayer {
-	supportsPlaybackRateValue: boolean;
 	canHandleStoppedValue: boolean;
 
 	constructor(system: g.AudioSystem) {
 		super(system);
-		this.supportsPlaybackRateValue = true;
 		this.canHandleStoppedValue = true;
 	}
 
 	canHandleStopped(): boolean {
 		return this.canHandleStoppedValue;
-	}
-
-	_supportsPlaybackRate(): boolean {
-		return this.supportsPlaybackRateValue;
 	}
 }
 

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -425,8 +425,8 @@ export class VideoAsset extends g.VideoAsset {
 export class AudioPlayer extends g.AudioPlayer {
 	canHandleStoppedValue: boolean;
 
-	constructor(param: g.AudioPlayerParameterObject) {
-		super(param);
+	constructor(system: g.AudioSystem) {
+		super(system);
 		this.canHandleStoppedValue = true;
 	}
 
@@ -537,7 +537,7 @@ export class ResourceFactory extends g.ResourceFactory {
 	}
 
 	createAudioPlayer(system: g.AudioSystem): g.AudioPlayer {
-		return new AudioPlayer({ volume: system.volume, muted: system._isSuppressed || system._muted });
+		return new AudioPlayer(system);
 	}
 
 	createGlyphFactory(

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -691,4 +691,6 @@ export class CacheableE extends g.CacheableE {
 
 export interface AudioSystemLike extends g.AudioSystemLike {
 	_muted: boolean;
+
+	_destroyRequestedAssets: { [key: string]: g.AudioAssetLike };
 }

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -690,7 +690,5 @@ export class CacheableE extends g.CacheableE {
 }
 
 export interface AudioSystemLike extends g.AudioSystemLike {
-	_muted: boolean;
-
 	_destroyRequestedAssets: { [key: string]: g.AudioAssetLike };
 }

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -425,8 +425,8 @@ export class VideoAsset extends g.VideoAsset {
 export class AudioPlayer extends g.AudioPlayer {
 	canHandleStoppedValue: boolean;
 
-	constructor(system: g.AudioSystem) {
-		super(system);
+	constructor(param: g.AudioPlayerParameterObject) {
+		super(param);
 		this.canHandleStoppedValue = true;
 	}
 
@@ -537,7 +537,7 @@ export class ResourceFactory extends g.ResourceFactory {
 	}
 
 	createAudioPlayer(system: g.AudioSystem): g.AudioPlayer {
-		return new AudioPlayer(system);
+		return new AudioPlayer({ volume: system.volume, muted: system._playbackRate !== 1.0 });
 	}
 
 	createGlyphFactory(

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -15,13 +15,13 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_playbackRate: number;
+	_isSuppressed: boolean;
 
 	systems: { [key: string]: AudioSystemLike };
 
 	constructor() {
 		this._muted = false;
-		this._playbackRate = 1.0;
+		this._isSuppressed = false;
 	}
 
 	/**
@@ -29,7 +29,7 @@ export class AudioSystemManager {
 	 */
 	_reset(): void {
 		this._muted = false;
-		this._playbackRate = 1.0;
+		this._isSuppressed = false;
 		for (var id in this.systems) {
 			if (!this.systems.hasOwnProperty(id)) continue;
 			this.systems[id]._reset();
@@ -52,13 +52,13 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_setPlaybackRate(rate: number): void {
-		if (this._playbackRate === rate) return;
+	_changePlaybackRate(rate: number): void {
+		if (this._isSuppressed === (rate !== 1.0)) return;
 
-		this._playbackRate = rate;
+		this._isSuppressed = rate !== 1.0;
 		for (var id in this.systems) {
 			if (!this.systems.hasOwnProperty(id)) continue;
-			this.systems[id]._setPlaybackRate(rate);
+			this.systems[id]._setSuppressed(this._isSuppressed);
 		}
 	}
 }

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -15,13 +15,13 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_isSuppressed: boolean;
+	_playbackRate: number;
 
 	systems: { [key: string]: AudioSystemLike };
 
 	constructor() {
 		this._muted = false;
-		this._isSuppressed = false;
+		this._playbackRate = 1.0;
 	}
 
 	/**
@@ -29,7 +29,7 @@ export class AudioSystemManager {
 	 */
 	_reset(): void {
 		this._muted = false;
-		this._isSuppressed = false;
+		this._playbackRate = 1.0;
 		for (var id in this.systems) {
 			if (!this.systems.hasOwnProperty(id)) continue;
 			this.systems[id]._reset();
@@ -52,13 +52,13 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_changePlaybackRate(rate: number): void {
-		if (this._isSuppressed === (rate !== 1.0)) return;
+	_setPlaybackRate(rate: number): void {
+		if (this._playbackRate === rate) return;
 
-		this._isSuppressed = rate !== 1.0;
+		this._playbackRate = rate;
 		for (var id in this.systems) {
 			if (!this.systems.hasOwnProperty(id)) continue;
-			this.systems[id]._setSuppressed(this._isSuppressed);
+			this.systems[id]._setPlaybackRate(rate);
 		}
 	}
 }

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -12,16 +12,10 @@ export class AudioSystemManager {
 	 */
 	_muted: boolean;
 
-	/**
-	 * @private
-	 */
-	_playbackRate: number;
-
 	systems: { [key: string]: AudioSystemLike };
 
 	constructor() {
 		this._muted = false;
-		this._playbackRate = 1.0;
 	}
 
 	/**
@@ -29,7 +23,6 @@ export class AudioSystemManager {
 	 */
 	_reset(): void {
 		this._muted = false;
-		this._playbackRate = 1.0;
 		for (var id in this.systems) {
 			if (!this.systems.hasOwnProperty(id)) continue;
 			this.systems[id]._reset();
@@ -53,9 +46,6 @@ export class AudioSystemManager {
 	 * @private
 	 */
 	_setPlaybackRate(rate: number): void {
-		if (this._playbackRate === rate) return;
-
-		this._playbackRate = rate;
 		for (var id in this.systems) {
 			if (!this.systems.hasOwnProperty(id)) continue;
 			this.systems[id]._setPlaybackRate(rate);

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -1,7 +1,6 @@
 import { Trigger } from "@akashic/trigger";
 import { AudioAssetLike } from "../interfaces/AudioAssetLike";
 import { AudioPlayerEvent, AudioPlayerLike } from "../interfaces/AudioPlayerLike";
-import { AudioSystemLike } from "../interfaces/AudioSystemLike";
 
 export interface AudioPlayerParameterObject {
 	volume: number;

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -62,8 +62,7 @@ export class AudioPlayer implements AudioPlayerLike {
 	/**
 	 * `AudioAsset` を再生する。
 	 *
-	 * 再生後、 等倍速度の再生であれば `this.played` がfireされる。
-	 * 非等倍速度であればミュートにする。
+	 * 再生後、`AudioSystem#_playbackRate` が等倍速度 (1.0) であれば `this.played` がfireされる。
 	 * @param audio 再生するオーディオアセット
 	 */
 	play(audio: AudioAssetLike): void {

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -3,6 +3,11 @@ import { AudioAssetLike } from "../interfaces/AudioAssetLike";
 import { AudioPlayerEvent, AudioPlayerLike } from "../interfaces/AudioPlayerLike";
 import { AudioSystemLike } from "../interfaces/AudioSystemLike";
 
+export interface AudioPlayerParameterObject {
+	volume: number;
+	muted: boolean;
+}
+
 /**
  * サウンド再生を行うクラス。
  *
@@ -43,34 +48,25 @@ export class AudioPlayer implements AudioPlayerLike {
 	_muted: boolean;
 
 	/**
-	 * @private
-	 */
-	_system: AudioSystemLike;
-
-	/**
 	 * `AudioPlayer` のインスタンスを生成する。
 	 */
-	constructor(system: AudioSystemLike) {
+	constructor(param: AudioPlayerParameterObject) {
 		this.played = new Trigger<AudioPlayerEvent>();
 		this.stopped = new Trigger<AudioPlayerEvent>();
 		this.currentAudio = undefined;
-		this.volume = system.volume;
-		this._muted = system._muted;
-		this._system = system;
+		this.volume = param.volume;
+		this._muted = param.muted;
 	}
 
 	/**
 	 * `AudioAsset` を再生する。
 	 *
-	 * 再生後、`AudioSystem#_playbackRate` が等倍速度 (1.0) であれば `this.played` がfireされる。
+	 * 再生後、ミュート中でなければ `this.played` がfireされる。
 	 * @param audio 再生するオーディオアセット
 	 */
 	play(audio: AudioAssetLike): void {
 		this.currentAudio = audio;
-		if (this._system._playbackRate !== 1.0) {
-			this._changeMuted(true);
-			return;
-		}
+		if (this._muted) return;
 		this.played.fire({
 			player: this,
 			audio: audio

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -127,20 +127,4 @@ export class AudioPlayer implements AudioPlayerLike {
 	_changeMuted(muted: boolean): void {
 		this._muted = muted;
 	}
-
-	/**
-	 * システムによる再生速度の変更通知。
-	 *
-	 * システムの再生速度が等倍速度(1.0)でシステムがミュート状態でない場合、ミュートを解除する。
-	 * 再生速度が非等倍速度の場合、ミュートにする。
-	 *
-	 * @private
-	 */
-	_notifyPlaybackRateChanged(): void {
-		if (this._system._playbackRate === 1.0 && !this._system._muted) {
-			this._changeMuted(false);
-		} else if (this._system._playbackRate !== 1.0) {
-			this._changeMuted(true);
-		}
-	}
 }

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -60,12 +60,11 @@ export class AudioPlayer implements AudioPlayerLike {
 	/**
 	 * `AudioAsset` を再生する。
 	 *
-	 * 再生後、ミュート中でなければ `this.played` がfireされる。
+	 * 再生後、 `this.played` がfireされる。
 	 * @param audio 再生するオーディオアセット
 	 */
 	play(audio: AudioAssetLike): void {
 		this.currentAudio = audio;
-		if (this._muted) return;
 		this.played.fire({
 			player: this,
 			audio: audio

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -1,11 +1,7 @@
 import { Trigger } from "@akashic/trigger";
 import { AudioAssetLike } from "../interfaces/AudioAssetLike";
 import { AudioPlayerEvent, AudioPlayerLike } from "../interfaces/AudioPlayerLike";
-
-export interface AudioPlayerParameterObject {
-	volume: number;
-	muted: boolean;
-}
+import { AudioSystemLike } from "../interfaces/AudioSystemLike";
 
 /**
  * サウンド再生を行うクラス。
@@ -47,14 +43,20 @@ export class AudioPlayer implements AudioPlayerLike {
 	_muted: boolean;
 
 	/**
+	 * @private
+	 */
+	_system: AudioSystemLike;
+
+	/**
 	 * `AudioPlayer` のインスタンスを生成する。
 	 */
-	constructor(param: AudioPlayerParameterObject) {
+	constructor(system: AudioSystemLike) {
 		this.played = new Trigger<AudioPlayerEvent>();
 		this.stopped = new Trigger<AudioPlayerEvent>();
 		this.currentAudio = undefined;
-		this.volume = param.volume;
-		this._muted = param.muted;
+		this.volume = system.volume;
+		this._muted = system._muted;
+		this._system = system;
 	}
 
 	/**

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -23,6 +23,7 @@ export interface AudioSystemParameterObject {
 	/**
 	 * 再生速度の倍率。
 	 */
+	// TODO: v3ではゲーム開発者が任意に AudioSystem を追加できるのか仕様確認。
 	playbackRate?: number;
 
 	/**
@@ -121,12 +122,6 @@ export abstract class AudioSystem implements AudioSystemLike {
 	_setPlaybackRate(value: number): void {
 		if (value < 0 || isNaN(value) || typeof value !== "number")
 			throw ExceptionFactory.createAssertionError("AudioSystem#playbackRate: expected: greater or equal to 0.0, actual: " + value);
-
-		const suppressed = value !== 1.0;
-		if (this._isSuppressed !== suppressed) {
-			this._isSuppressed = suppressed;
-			this._onSuppressedChanged();
-		}
 	}
 
 	/**
@@ -142,7 +137,7 @@ export abstract class AudioSystem implements AudioSystemLike {
 	/**
 	 * @private
 	 */
-	abstract _onSuppressedChanged(): void;
+	// abstract _onSuppressedChanged(): void;
 
 	/**
 	 * @private
@@ -225,12 +220,10 @@ export class MusicAudioSystem extends AudioSystem implements MusicAudioSystemLik
 	/**
 	 * @private
 	 */
-	_onSuppressedChanged(): void {
-		if (this._muted) {
-			this.player._changeMuted(true);
-		} else {
-			this.player._changeMuted(this._isSuppressed);
-		}
+	_setPlaybackRate(rate: number): void {
+		super._setPlaybackRate(rate);
+		this._isSuppressed = rate !== 1.0;
+		this.player._changeMuted(this._isSuppressed || this._muted);
 	}
 
 	/**
@@ -311,7 +304,10 @@ export class SoundAudioSystem extends AudioSystem implements SoundAudioSystemLik
 	/**
 	 * @private
 	 */
-	_onSuppressedChanged(): void {
+	_setPlaybackRate(rate: number): void {
+		super._setPlaybackRate(rate);
+		this._isSuppressed = rate !== 1.0;
+
 		var players = this.players;
 		if (this._isSuppressed) {
 			for (var i = 0; i < players.length; ++i) {

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -234,10 +234,6 @@ export class MusicAudioSystem extends AudioSystem {
 	 * @private
 	 */
 	_onPlayerStopped(e: AudioPlayerEvent): void {
-		// 再生速度が非等倍のまま停止となった場合: この AudioSystem がミュートでなければ AudioPlayer のミュートを解除する。
-		if (this._playbackRate !== 1.0 && !this._muted) {
-			this.player._changeMuted(false);
-		}
 		if (this._destroyRequestedAssets[e.audio.id]) {
 			delete this._destroyRequestedAssets[e.audio.id];
 			e.audio.destroy();

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -1,7 +1,7 @@
 import { ExceptionFactory } from "../commons/ExceptionFactory";
 import { AudioAssetLike } from "../interfaces/AudioAssetLike";
 import { AudioPlayerEvent, AudioPlayerLike } from "../interfaces/AudioPlayerLike";
-import { AudioSystemLike, MusicAudioSystemLike, SoundAudioSystemLike } from "../interfaces/AudioSystemLike";
+import { AudioSystemLike } from "../interfaces/AudioSystemLike";
 import { ResourceFactoryLike } from "../interfaces/ResourceFactoryLike";
 
 export interface AudioSystemParameterObject {
@@ -139,7 +139,7 @@ export abstract class AudioSystem implements AudioSystemLike {
 	abstract _onPlayerStopped(e: AudioPlayerEvent): void;
 }
 
-export class MusicAudioSystem extends AudioSystem implements MusicAudioSystemLike {
+export class MusicAudioSystem extends AudioSystem {
 	/**
 	 * @private
 	 */
@@ -234,7 +234,7 @@ export class MusicAudioSystem extends AudioSystem implements MusicAudioSystemLik
 	}
 }
 
-export class SoundAudioSystem extends AudioSystem implements SoundAudioSystemLike {
+export class SoundAudioSystem extends AudioSystem {
 	players: AudioPlayerLike[];
 
 	constructor(param: AudioSystemParameterObject) {

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -104,6 +104,7 @@ export abstract class AudioSystem implements AudioSystemLike {
 		this._destroyRequestedAssets = {};
 		this._muted = false;
 		this._suppressed = false;
+		this._explicitMuted = false;
 	}
 
 	/**

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -21,12 +21,6 @@ export interface AudioSystemParameterObject {
 	muted?: boolean;
 
 	/**
-	 * 再生速度の倍率。
-	 */
-	// TODO: v3ではゲーム開発者が任意に AudioSystem を追加できるのか仕様確認。
-	playbackRate?: number;
-
-	/**
 	 * 各種リソースのファクトリ
 	 */
 	resourceFactory: ResourceFactoryLike;
@@ -80,7 +74,7 @@ export abstract class AudioSystem implements AudioSystemLike {
 		this._volume = param.volume || 1;
 		this._destroyRequestedAssets = {};
 		this._muted = param.muted || false;
-		this._isSuppressed = param.playbackRate ? param.playbackRate !== 1.0 : false;
+		this._isSuppressed = false;
 		this._resourceFactory = param.resourceFactory;
 	}
 
@@ -133,11 +127,6 @@ export abstract class AudioSystem implements AudioSystemLike {
 	 * @private
 	 */
 	abstract _onMutedChanged(): void;
-
-	/**
-	 * @private
-	 */
-	// abstract _onSuppressedChanged(): void;
 
 	/**
 	 * @private

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -21,7 +21,7 @@ export interface AudioSystemParameterObject {
 	muted?: boolean;
 
 	/**
-	 * 再生速度の倍率
+	 * 再生速度の倍率。
 	 */
 	playbackRate?: number;
 
@@ -79,7 +79,7 @@ export abstract class AudioSystem implements AudioSystemLike {
 		this._volume = param.volume || 1;
 		this._destroyRequestedAssets = {};
 		this._muted = param.muted || false;
-		this._isSuppressed = param.playbackRate !== 1.0 || false;
+		this._isSuppressed = param.playbackRate ? param.playbackRate !== 1.0 : false;
 		this._resourceFactory = param.resourceFactory;
 	}
 

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -21,7 +21,7 @@ export interface AudioSystemParameterObject {
 	muted?: boolean;
 
 	/**
-	 * ゲームの再生速度が抑制されているか否か。
+	 * ゲームの再生が抑制されているか否か。
 	 */
 	isSuppressed?: boolean;
 

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -205,6 +205,9 @@ export class MusicAudioSystem extends AudioSystem {
 	 * @private
 	 */
 	_onMutedChanged(): void {
+		// TODO: _changeMuted() を呼んでいるが、PDI側を修正できるタイミングで `_notifyChangeMuted()` を作成する。
+		//       システムのミュート状態が変更となった時にplayerへ通知し、playerは system._muted を参照する。
+		//       (プレイヤーのミュートは公開APIではないので、プレイヤーミュートをシステムミュートに使用する。)
 		this.player._changeMuted(this._muted);
 	}
 
@@ -212,8 +215,6 @@ export class MusicAudioSystem extends AudioSystem {
 	 * @private
 	 */
 	_onPlaybackRateChanged(): void {
-		// TODO: _changeMuted() を呼んでいるが、PDIのbranchができたら `_notifyChangeMuted()` を作成する。
-		// システムのミュート状態が変更となった時にplayerへ通知し、playerは system._muted を参照する。
 		if (this._playbackRate === 1.0 && !this._muted) {
 			this.player._changeMuted(false);
 		} else if (this._playbackRate !== 1.0) {

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -56,7 +56,7 @@ export abstract class AudioSystem implements AudioSystemLike {
 	_resourceFactory: ResourceFactoryLike;
 
 	/**
-	 * 明示的にミュートされたか否か。
+	 * 明示的に設定された、ミュート中か否か。
 	 * @private
 	 */
 	_explicitMuted: boolean;

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -127,16 +127,6 @@ export abstract class AudioSystem implements AudioSystemLike {
 	 * @private
 	 */
 	abstract _onMutedChanged(): void;
-
-	/**
-	 * @private
-	 */
-	abstract _onPlayerPlayed(e: AudioPlayerEvent): void;
-
-	/**
-	 * @private
-	 */
-	abstract _onPlayerStopped(e: AudioPlayerEvent): void;
 }
 
 export class MusicAudioSystem extends AudioSystem {

--- a/src/interfaces/AudioPlayerLike.ts
+++ b/src/interfaces/AudioPlayerLike.ts
@@ -44,13 +44,6 @@ export interface AudioPlayerLike {
 	 * @private
 	 */
 	_muted: boolean;
-
-	/**
-	 * 再生速度の倍率。
-	 * @private
-	 */
-	_playbackRate: number;
-
 	/**
 	 * `AudioAsset` を再生する。
 	 *
@@ -94,39 +87,4 @@ export interface AudioPlayerLike {
 	 * @private
 	 */
 	_changeMuted(muted: boolean): void;
-
-	/**
-	 * 再生速度を変更する。
-	 *
-	 * エンジンユーザが `AudioPlayer` の派生クラスを実装し、
-	 * かつ `this._supportsPlaybackRate()` をオーバライドして真を返すようにするならば、
-	 * このメソッドもオーバーライドして実際に再生速度を変更する処理を行うこと。
-	 * オーバーライド先のメソッドはこのメソッドを呼びださなければならない。
-	 *
-	 * @param rate 再生速度の倍率。0以上でなければならない。1.0で等倍である。
-	 * @private
-	 */
-	_changePlaybackRate(rate: number): void;
-
-	/**
-	 * 再生速度の変更に対応するか否か。
-	 *
-	 * エンジンユーザが `AudioPlayer` の派生クラスを実装し、
-	 * 再生速度の変更に対応する場合、このメソッドをオーバーライドして真を返さねばならない。
-	 * その場合 `_changePlaybackRate()` もオーバーライドし、実際の再生速度変更処理を実装しなければならない。
-	 *
-	 * なおここで「再生速度の変更に対応する」は、任意の速度で実際に再生できることを意味しない。
-	 * 実装は等倍速 (再生速度1.0) で実際に再生できなければならない。
-	 * しかしそれ以外の再生速度が指定された場合、実装はまるで音量がゼロであるかのように振舞ってもよい。
-	 *
-	 * このメソッドが偽を返す場合、エンジンは音声の非等倍速度再生に対するデフォルトの処理を実行する。
-	 * @private
-	 */
-	_supportsPlaybackRate(): boolean;
-
-	/**
-	 * 音量の変更を通知する。
-	 * @deprecated このメソッドは実験的に導入されたが、利用されていない。将来的に削除される。
-	 */
-	_onVolumeChanged(): void;
 }

--- a/src/interfaces/AudioSystemLike.ts
+++ b/src/interfaces/AudioSystemLike.ts
@@ -20,11 +20,6 @@ export interface AudioSystemLike {
 	 */
 	_destroyRequestedAssets: { [key: string]: AudioAssetLike };
 
-	/**
-	 * @private
-	 */
-	_isSuppressed: boolean;
-
 	stopAll(): void;
 
 	findPlayers(asset: AudioAssetLike): AudioPlayerLike[];
@@ -57,11 +52,6 @@ export interface AudioSystemLike {
 	 * @private
 	 */
 	_onMutedChanged(): void;
-
-	/**
-	 * @private
-	 */
-	_onSuppressedChanged(): void;
 
 	/**
 	 * @private

--- a/src/interfaces/AudioSystemLike.ts
+++ b/src/interfaces/AudioSystemLike.ts
@@ -46,7 +46,7 @@ export interface AudioSystemLike {
 	/**
 	 * @private
 	 */
-	_setSuppressed(suppressed: boolean): void;
+	_setPlaybackRate(value: number): void;
 
 	/**
 	 * @private

--- a/src/interfaces/AudioSystemLike.ts
+++ b/src/interfaces/AudioSystemLike.ts
@@ -23,7 +23,7 @@ export interface AudioSystemLike {
 	/**
 	 * @private
 	 */
-	_playbackRate: number;
+	_isSuppressed: boolean;
 
 	stopAll(): void;
 
@@ -46,7 +46,7 @@ export interface AudioSystemLike {
 	/**
 	 * @private
 	 */
-	_setPlaybackRate(value: number): void;
+	_setSuppressed(suppressed: boolean): void;
 
 	/**
 	 * @private
@@ -61,35 +61,7 @@ export interface AudioSystemLike {
 	/**
 	 * @private
 	 */
-	_onPlaybackRateChanged(): void;
-}
-
-export interface MusicAudioSystemLike extends AudioSystemLike {
-	/**
-	 * @private
-	 */
-	_player: AudioPlayerLike;
-
-	/**
-	 * 再生を抑止されている `AudioAsset` 。
-	 *
-	 * 再生速度に非対応の `AudioPlayer` の場合に、等倍速でない速度で再生を試みたアセット。
-	 * 再生速度が戻された場合に改めて再生されなおす。
-	 * この値は、 `this._player._supportsPlaybackRate()` が偽ある場合にのみ利用される。
-	 * @private
-	 */
-	_suppressingAudio: AudioAssetLike;
-
-	player: AudioPlayerLike;
-
-	/**
-	 * @private
-	 */
-	_onUnsupportedPlaybackRateChanged(): void;
-}
-
-export interface SoundAudioSystemLike extends AudioSystemLike {
-	players: AudioPlayerLike[];
+	_onSuppressedChanged(): void;
 
 	/**
 	 * @private
@@ -100,4 +72,17 @@ export interface SoundAudioSystemLike extends AudioSystemLike {
 	 * @private
 	 */
 	_onPlayerPlayed(e: AudioPlayerEvent): void;
+}
+
+export interface MusicAudioSystemLike extends AudioSystemLike {
+	/**
+	 * @private
+	 */
+	_player: AudioPlayerLike;
+
+	player: AudioPlayerLike;
+}
+
+export interface SoundAudioSystemLike extends AudioSystemLike {
+	players: AudioPlayerLike[];
 }

--- a/src/interfaces/AudioSystemLike.ts
+++ b/src/interfaces/AudioSystemLike.ts
@@ -5,6 +5,11 @@ export interface AudioSystemLike {
 	id: string;
 	volume: number;
 
+	/**
+	 * @private
+	 */
+	_muted: boolean;
+
 	stopAll(): void;
 
 	findPlayers(asset: AudioAssetLike): AudioPlayerLike[];

--- a/src/interfaces/AudioSystemLike.ts
+++ b/src/interfaces/AudioSystemLike.ts
@@ -1,24 +1,9 @@
 import { AudioAssetLike } from "./AudioAssetLike";
-import { AudioPlayerEvent, AudioPlayerLike } from "./AudioPlayerLike";
+import { AudioPlayerLike } from "./AudioPlayerLike";
 
 export interface AudioSystemLike {
 	id: string;
 	volume: number;
-
-	/**
-	 * @private
-	 */
-	_volume: number;
-
-	/**
-	 * @private
-	 */
-	_muted: boolean;
-
-	/**
-	 * @private
-	 */
-	_destroyRequestedAssets: { [key: string]: AudioAssetLike };
 
 	stopAll(): void;
 
@@ -42,37 +27,4 @@ export interface AudioSystemLike {
 	 * @private
 	 */
 	_setPlaybackRate(value: number): void;
-
-	/**
-	 * @private
-	 */
-	_onVolumeChanged(): void;
-
-	/**
-	 * @private
-	 */
-	_onMutedChanged(): void;
-
-	/**
-	 * @private
-	 */
-	_onPlayerStopped(e: AudioPlayerEvent): void;
-
-	/**
-	 * @private
-	 */
-	_onPlayerPlayed(e: AudioPlayerEvent): void;
-}
-
-export interface MusicAudioSystemLike extends AudioSystemLike {
-	/**
-	 * @private
-	 */
-	_player: AudioPlayerLike;
-
-	player: AudioPlayerLike;
-}
-
-export interface SoundAudioSystemLike extends AudioSystemLike {
-	players: AudioPlayerLike[];
 }


### PR DESCRIPTION
## このpull requestが解決する内容

再生速度の変化による、AudioPlayerのミュート状態を変更
 - 非等倍速度の場合は、AudioPlayerをミュートにする。
 - `AudioPlayer#_suppresingAudio` の削除, 
 - `AudioSystem#_playbackRate`の削除し、音声の再生が抑止されているのフラグ  `_suppressed`の追加
 - `AudioSystemManager#_playbackRate`の削除


## 破壊的な変更を含んでいるか?
下記の `AudioPlayer` のfunctionが削除されます。
  - _changePlaybackRate()
  - _supportsPlaybackRate()

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

