### PR TITLE
Fix instantiate Game class without `g`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -557,7 +557,7 @@ export abstract class Game implements Registrable<E> {
 		this.snapshotRequest = new Trigger<void>();
 
 		this.external = {};
-		this._runtimeValueBase = Object.create(g, {
+		this._runtimeValueBase = Object.create(typeof g !== "undefined" ? g : null, {
 			game: {
 				value: this,
 				enumerable: true


### PR DESCRIPTION
## このpull requestが解決する内容
グローバル変数 `g` が存在しない環境でも Game クラスを生成できるようにします。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

