### PR TITLE
Add OperationPluginManager#register()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -320,7 +320,6 @@ export abstract class Game implements Registrable<E> {
 
 	/**
 	 * 操作プラグインの管理者。
-	 * @private
 	 */
 	operationPluginManager: OperationPluginManager;
 

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -122,6 +122,7 @@ export interface GameResetParameterObject {
  * 8. 現在フォーカスされているCamera情報を得るため、Game#focusingCameraにアクセスする
  * 9. AudioSystemを直接制御するため、Game#audioにアクセスする
  * 10.Sceneのスタック情報を調べるため、Game#scenesにアクセスする
+ * 11.操作プラグインを直接制御するため、Game#operationPluginManagerにアクセスする
  */
 export abstract class Game implements Registrable<E> {
 	/**
@@ -318,6 +319,12 @@ export abstract class Game implements Registrable<E> {
 	surfaceAtlasSet: SurfaceAtlasSetLike;
 
 	/**
+	 * 操作プラグインの管理者。
+	 * @private
+	 */
+	operationPluginManager: OperationPluginManager;
+
+	/**
 	 * イベントとTriggerのマップ。
 	 * @private
 	 */
@@ -390,12 +397,6 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_audioSystemManager: AudioSystemManager;
-
-	/**
-	 * 操作プラグインの管理者。
-	 * @private
-	 */
-	_operationPluginManager: OperationPluginManager;
 
 	/**
 	 * 操作プラグインによる操作を通知するTrigger。
@@ -574,9 +575,9 @@ export abstract class Game implements Registrable<E> {
 		this._moduleManager = new ModuleManager(this._runtimeValueBase, this._assetManager);
 
 		var operationPluginsField = <InternalOperationPluginInfo[]>(gameConfiguration.operationPlugins || []);
-		this._operationPluginManager = new OperationPluginManager(this, operationPluginViewInfo, operationPluginsField);
+		this.operationPluginManager = new OperationPluginManager(this, operationPluginViewInfo, operationPluginsField);
 		this._operationPluginOperated = new Trigger<InternalOperationPluginOperation>();
-		this._operationPluginManager.operated.add(this._operationPluginOperated.fire, this._operationPluginOperated);
+		this.operationPluginManager.operated.add(this._operationPluginOperated.fire, this._operationPluginOperated);
 
 		this._sceneChanged = new Trigger<Scene>();
 		this._sceneChanged.add(this._updateEventTriggers, this);
@@ -991,7 +992,7 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_decodeOperationPluginOperation(code: number, op: (number | string)[]): any {
-		var plugins = this._operationPluginManager.plugins;
+		const plugins = this.operationPluginManager.plugins;
 		if (!plugins[code] || !plugins[code].decode) return op;
 		return plugins[code].decode(op);
 	}
@@ -1001,7 +1002,7 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_reset(param?: GameResetParameterObject): void {
-		this._operationPluginManager.stopAll();
+		this.operationPluginManager.stopAll();
 		if (this.scene()) {
 			while (this.scene() !== this._initialScene) {
 				this.popScene();
@@ -1062,7 +1063,7 @@ export abstract class Game implements Registrable<E> {
 	 */
 	_destroy(): void {
 		// ユーザコードを扱う操作プラグインを真っ先に破棄
-		this._operationPluginManager.destroy();
+		this.operationPluginManager.destroy();
 
 		// 到達できるシーンを全て破棄
 		if (this.scene()) {
@@ -1129,7 +1130,7 @@ export abstract class Game implements Registrable<E> {
 		this._assetManager.destroy();
 		this._assetManager = undefined;
 		this._audioSystemManager = undefined;
-		this._operationPluginManager = undefined;
+		this.operationPluginManager = undefined;
 		this._operationPluginOperated.destroy();
 		this._operationPluginOperated = undefined;
 		this._idx = 0;
@@ -1274,8 +1275,8 @@ export abstract class Game implements Registrable<E> {
 	}
 
 	private _start(): void {
-		this._operationPluginManager.initialize();
-		this.operationPlugins = this._operationPluginManager.plugins;
+		this.operationPluginManager.initialize();
+		this.operationPlugins = this.operationPluginManager.plugins;
 
 		const mainFun = this._moduleManager._require(this._main);
 		if (!mainFun || typeof mainFun !== "function")

--- a/src/domain/OperationPluginManager.ts
+++ b/src/domain/OperationPluginManager.ts
@@ -89,7 +89,7 @@ export class OperationPluginManager {
 	register(pluginClass: OperationPluginStatic, code: number, option?: any): void {
 		this._infos[code] = {
 			code,
-			_plugin: this._initializeOperationPlugin(pluginClass, code, option)
+			_plugin: this._instantiateOperationPlugin(pluginClass, code, option)
 		};
 	}
 
@@ -141,11 +141,11 @@ export class OperationPluginManager {
 			const info = this._infos[i];
 			if (!info.script) continue;
 			const pluginClass = this._game._moduleManager._require(info.script);
-			info._plugin = this._initializeOperationPlugin(pluginClass, info.code, info.option);
+			info._plugin = this._instantiateOperationPlugin(pluginClass, info.code, info.option);
 		}
 	}
 
-	private _initializeOperationPlugin(pluginClass: OperationPluginStatic, code: number, option?: any): OperationPlugin | undefined {
+	private _instantiateOperationPlugin(pluginClass: OperationPluginStatic, code: number, option?: any): OperationPlugin | undefined {
 		if (!pluginClass.isSupported()) {
 			return;
 		}

--- a/src/types/OperationPluginInfo.ts
+++ b/src/types/OperationPluginInfo.ts
@@ -12,12 +12,13 @@ export interface OperationPluginInfo {
 
 	/**
 	 * プラグインの定義を含むスクリプトファイルのパス。
+	 * スクリプトファイルではない経路で初期化された場合 `undefined` 。
 	 *
 	 * プラグインの定義を得るために、この値が require() に渡される。
 	 * 相対パスであるとき、その基準は game.json のあるディレクトリである。
 	 * また対応するスクリプトアセットは `"global": true` が指定されていなければならない。
 	 */
-	script: string;
+	script?: string;
 
 	/**
 	 * プラグインを new する際に引き渡すオプション。
@@ -39,7 +40,8 @@ export interface OperationPluginInfo {
  */
 export interface InternalOperationPluginInfo extends OperationPluginInfo {
 	/**
+	 * サポートされていない環境など、操作プラグインを初期化できなかった場合 `undefined` 。
 	 * @private
 	 */
-	_plugin: OperationPlugin;
+	_plugin?: OperationPlugin;
 }


### PR DESCRIPTION
## このpull requestが解決する内容
`OperationPluginManger` に以下のメソッドを追加します。
- `OperationPluginManager#register()`
  - 操作プラグインを手動で登録する
- `OperationPluginManager#start()`
  - 操作プラグインを開始する
- `OperationPluginManager#stop()`
  - 操作プラグインを停止する

### コンテンツ側利用例
 ```javascript
import { SamplePlugin } from "...";

...

game.operationPluginManager.register(SamplePlugin, 1);
game.operationPluginManager.start(1);

...
```

## 破壊的な変更を含んでいるか?
- **あり**
  - `Game#_operationPluginManager` が `Game#operationPluginManager` に変更されます
