### PR TITLE
Change type of Game.audio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1080,8 +1080,8 @@ export abstract class Game implements Registrable<E> {
 		this.loadingScene = undefined;
 		this.assetBase = "";
 		this.selfId = undefined;
-		this.audio.music.stopAll();
-		this.audio.sound.stopAll();
+		var audioSystemIds = Object.keys(this.audio);
+		for (var i = 0; i < audioSystemIds.length; ++i) this.audio[audioSystemIds[i]].stopAll();
 		this.audio = undefined;
 		this.defaultAudioSystemId = undefined;
 		this.snapshotRequest.destroy();

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -222,7 +222,7 @@ export abstract class Game implements Registrable<E> {
 	/**
 	 * デフォルトで利用されるオーディオシステムのID。デフォルト値はsound。
 	 */
-	defaultAudioSystemId: string;
+	defaultAudioSystemId: "music" | "sound";
 
 	/**
 	 * スナップショット要求通知。

--- a/src/__tests__/AssetManagerSpec.ts
+++ b/src/__tests__/AssetManagerSpec.ts
@@ -71,29 +71,6 @@ describe("test AssetManager", () => {
 				duration: 5972,
 				loop: true,
 				hint: { streaming: true }
-			},
-			corge: {
-				type: "audio",
-				path: "/path/to/a/file",
-				virtualPath: "path/to/a/file",
-				systemId: "user",
-				duration: 91
-			},
-			grault: {
-				type: "audio",
-				path: "/path/to/a/file",
-				virtualPath: "path/to/a/file",
-				systemId: "user2",
-				duration: 12742
-			},
-			garply: {
-				type: "audio",
-				path: "/path/to/a/file",
-				virtualPath: "path/to/a/file",
-				systemId: "user2",
-				duration: 3474,
-				loop: false,
-				hint: { streaming: false }
 			}
 		}
 	};
@@ -110,9 +87,6 @@ describe("test AssetManager", () => {
 		expect(manager.configuration.baz.path).toBe(gameConfiguration.assets.baz.path);
 		expect(manager.configuration.qux.path).toBe(gameConfiguration.assets.qux.path);
 		expect(manager.configuration.quux.path).toBe(gameConfiguration.assets.quux.path);
-		expect(manager.configuration.corge.path).toBe(gameConfiguration.assets.corge.path);
-		expect(manager.configuration.grault.path).toBe(gameConfiguration.assets.grault.path);
-		expect(manager.configuration.garply.path).toBe(gameConfiguration.assets.grault.path);
 
 		expect(Object.keys(manager._assets).length).toEqual(0);
 		expect(Object.keys(manager._liveAssetVirtualPathTable).length).toEqual(0);
@@ -139,21 +113,6 @@ describe("test AssetManager", () => {
 		expect(manager.configuration.quux.duration).toEqual((gameConfiguration.assets.quux as AudioAssetConfigurationBase).duration);
 		expect(manager.configuration.quux.loop).toEqual(true);
 		expect(manager.configuration.quux.hint).toEqual({ streaming: true });
-
-		expect(manager.configuration.corge.systemId).toEqual("user");
-		expect(manager.configuration.corge.duration).toEqual((gameConfiguration.assets.corge as AudioAssetConfigurationBase).duration);
-		expect(manager.configuration.corge.loop).toEqual(false);
-		expect(manager.configuration.corge.hint).toEqual({});
-
-		expect(manager.configuration.grault.systemId).toEqual("user2");
-		expect(manager.configuration.grault.duration).toEqual((gameConfiguration.assets.grault as AudioAssetConfigurationBase).duration);
-		expect(manager.configuration.grault.loop).toEqual(true);
-		expect(manager.configuration.grault.hint).toEqual({ streaming: true });
-
-		expect(manager.configuration.garply.systemId).toEqual("user2");
-		expect(manager.configuration.garply.duration).toEqual((gameConfiguration.assets.garply as AudioAssetConfigurationBase).duration);
-		expect(manager.configuration.garply.loop).toEqual(false);
-		expect(manager.configuration.garply.hint).toEqual({ streaming: false });
 	});
 
 	it("rejects illegal configuration", () => {
@@ -231,18 +190,17 @@ describe("test AssetManager", () => {
 				"/foo/bar/"
 			);
 		}).toThrowError("AssertionError");
-		expect(() => {
-			return new Game(
-				{
-					width: 320,
-					height: 320,
-					fps: 120 /* out of (0-60] */,
-					assets: legalConf,
-					main: "mainScene"
-				},
-				"/foo/bar/"
-			);
-		}).toThrowError("AssertionError");
+
+		const audioLegalConf: { [id: string]: AudioAssetConfigurationBase } = {
+			corge: {
+				type: "audio",
+				path: "/path/to/a/file",
+				virtualPath: "path/to/a/file",
+				systemId: "user",
+				duration: 91
+			}
+		};
+		expect(() => new Game({ width: 320, height: 320, assets: audioLegalConf, main: "mainScene" })).toThrowError("AssertionError");
 	});
 
 	it("loads/unloads an asset", done => {

--- a/src/__tests__/AssetManagerSpec.ts
+++ b/src/__tests__/AssetManagerSpec.ts
@@ -190,17 +190,29 @@ describe("test AssetManager", () => {
 				"/foo/bar/"
 			);
 		}).toThrowError("AssertionError");
+		expect(() => {
+			return new Game(
+				{
+					width: 320,
+					height: 320,
+					fps: 120 /* out of (0-60] */,
+					assets: legalConf,
+					main: "mainScene"
+				},
+				"/foo/bar/"
+			);
+		}).toThrowError("AssertionError");
 
-		const audioLegalConf: { [id: string]: AudioAssetConfigurationBase } = {
+		const audioIllegalConf: { [id: string]: AudioAssetConfigurationBase } = {
 			corge: {
 				type: "audio",
 				path: "/path/to/a/file",
 				virtualPath: "path/to/a/file",
-				systemId: "user",
+				systemId: "user" as any, // `music` と `sound` 以外のsystemIdはエラーとなる
 				duration: 91
 			}
 		};
-		expect(() => new Game({ width: 320, height: 320, assets: audioLegalConf, main: "mainScene" })).toThrowError("AssertionError");
+		expect(() => new Game({ width: 320, height: 320, assets: audioIllegalConf, main: "mainScene" })).toThrowError("AssertionError");
 	});
 
 	it("loads/unloads an asset", done => {

--- a/src/__tests__/AssetSpec.ts
+++ b/src/__tests__/AssetSpec.ts
@@ -1,4 +1,4 @@
-import { MusicAudioSystem, VideoSystem } from "..";
+import { VideoSystem } from "..";
 import { AudioAsset, Game, VideoAsset } from "./helpers";
 
 describe("test Asset", () => {
@@ -7,11 +7,7 @@ describe("test Asset", () => {
 		const path = "path";
 		const duration = 1984;
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new MusicAudioSystem({
-			id: "music",
-			muted: game._audioSystemManager._muted,
-			resourceFactory: game.resourceFactory
-		});
+		const system = game.audio.music;
 		const hint = { streaming: true };
 		const asset = new AudioAsset(0, id, path, duration, system, true, hint);
 		expect(asset.id).toBe(id);

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -1,15 +1,10 @@
 import { Trigger } from "@akashic/trigger";
-import { MusicAudioSystem, SoundAudioSystem } from "..";
-import { AudioPlayer, Game } from "./helpers";
+import { Game } from "./helpers";
 
 describe("test AudioPlayer", () => {
 	it("初期化-music", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new MusicAudioSystem({
-			id: "music",
-			muted: game._audioSystemManager._muted,
-			resourceFactory: game.resourceFactory
-		});
+		const system = game.audio.music;
 		const player = system.createPlayer();
 		expect(player.volume).toBe(system.volume);
 		expect(player.played.constructor).toBe(Trigger);
@@ -19,11 +14,7 @@ describe("test AudioPlayer", () => {
 
 	it("初期化-sound", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new SoundAudioSystem({
-			id: "voice",
-			muted: game._audioSystemManager._muted,
-			resourceFactory: game.resourceFactory
-		});
+		const system = game.audio.sound;
 		system.volume = 0.5;
 		const player = system.createPlayer();
 		expect(player.volume).toBe(system.volume);

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -1,4 +1,3 @@
-import { MusicAudioSystem } from "..";
 import { AudioPlayer, customMatchers, Game, ResourceFactory } from "./helpers";
 
 expect.extend(customMatchers);
@@ -6,11 +5,7 @@ expect.extend(customMatchers);
 describe("test AudioPlayer", () => {
 	it("AudioSystem#volumeの入力値チェック", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new MusicAudioSystem({
-			id: "music",
-			muted: game._audioSystemManager._muted,
-			resourceFactory: game.resourceFactory
-		});
+		const system = game.audio.music;
 		expect(() => {
 			system.volume = NaN!;
 		}).toThrowError();
@@ -39,11 +34,7 @@ describe("test AudioPlayer", () => {
 
 	it("AudioSystem#_destroyRequestedAssets", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = new MusicAudioSystem({
-			id: "music",
-			muted: game._audioSystemManager._muted,
-			resourceFactory: game.resourceFactory
-		});
+		const system = game.audio.music;
 		const audio = new ResourceFactory().createAudioAsset("testId", "testAssetPath", 0, null, false, null);
 		system.requestDestroy(audio);
 		expect(system._destroyRequestedAssets[audio.id]).toEqual(audio);

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -207,4 +207,26 @@ describe("test AudioPlayer", () => {
 		system._setPlaybackRate(1.0);
 		expect(player3._muted).toBeTruthy();
 	});
+
+	it("MusicAudioSystem#_onVolumeChanged", () => {
+		const game = new Game({ width: 320, height: 320, main: "" });
+		const system = game.audio.music;
+		const player = system.createPlayer() as AudioPlayer;
+
+		player.changeVolume(0.2);
+		system.volume = 0.7;
+		expect(player.volume).toBe(0.2);
+		expect(system.volume).toBe(0.7);
+	});
+
+	it("SoundAudioSystem#_onVolumeChanged", () => {
+		const game = new Game({ width: 320, height: 320, main: "" });
+		const system = game.audio.sound;
+		const player = system.createPlayer() as AudioPlayer;
+
+		player.changeVolume(0.3);
+		system.volume = 0.7;
+		expect(player.volume).toBe(0.3);
+		expect(system.volume).toBe(0.7);
+	});
 });

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -198,26 +198,4 @@ describe("test AudioPlayer", () => {
 		system._setPlaybackRate(1.0);
 		expect(player3._muted).toBeTruthy();
 	});
-
-	it("MusicAudioSystem#_onVolumeChanged", () => {
-		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game.audio.music;
-		const player = system.createPlayer() as AudioPlayer;
-
-		player.changeVolume(0.2);
-		system.volume = 0.7;
-		expect(player.volume).toBe(0.2);
-		expect(system.volume).toBe(0.7);
-	});
-
-	it("SoundAudioSystem#_onVolumeChanged", () => {
-		const game = new Game({ width: 320, height: 320, main: "" });
-		const system = game.audio.sound;
-		const player = system.createPlayer() as AudioPlayer;
-
-		player.changeVolume(0.3);
-		system.volume = 0.7;
-		expect(player.volume).toBe(0.3);
-		expect(system.volume).toBe(0.7);
-	});
 });

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -198,4 +198,26 @@ describe("test AudioPlayer", () => {
 		system._setPlaybackRate(1.0);
 		expect(player3._muted).toBeTruthy();
 	});
+
+	it("MusicAudioSystem#_onVolumeChanged", () => {
+		const game = new Game({ width: 320, height: 320, main: "" });
+		const system = game.audio.music;
+		const player = system.createPlayer() as AudioPlayer;
+		// systemのvolumeが変更されても、playerの音量は変わらない
+		player.changeVolume(0.2);
+		system.volume = 0.7;
+		expect(player.volume).toBe(0.2);
+		expect(system.volume).toBe(0.7);
+	});
+
+	it("SoundAudioSystem#_onVolumeChanged", () => {
+		const game = new Game({ width: 320, height: 320, main: "" });
+		const system = game.audio.sound;
+		const player = system.createPlayer() as AudioPlayer;
+		// systemのvolumeが変更されても、playerの音量は変わらない
+		player.changeVolume(0.3);
+		system.volume = 0.7;
+		expect(player.volume).toBe(0.3);
+		expect(system.volume).toBe(0.7);
+	});
 });

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -897,7 +897,7 @@ describe("test Game", () => {
 	it("controls audio volume", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 
-		expect(game._audioSystemManager._muted).toBe(false);
+		expect(game.audio._muted).toBe(false);
 		expect(() => {
 			game._setAudioPlaybackRate(-0.5);
 		}).toThrowError("AssertionError");
@@ -907,7 +907,7 @@ describe("test Game", () => {
 
 		game._setMuted(true);
 		game._setMuted(true); // 同じ値を設定するパスのカバレッジ稼ぎ
-		expect(game._audioSystemManager._muted).toBe(true);
+		expect(game.audio._muted).toBe(true);
 		expect(game.audio.sound._muted).toBe(true);
 		expect(game.audio.music._muted).toBe(true);
 
@@ -918,7 +918,7 @@ describe("test Game", () => {
 
 		game._setAudioPlaybackRate(1.0);
 		game._setMuted(false);
-		expect(game._audioSystemManager._muted).toBe(false);
+		expect(game.audio._muted).toBe(false);
 		expect(game.audio.sound._muted).toBe(false);
 		expect(game.audio.music._muted).toBe(false);
 	});

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -694,6 +694,7 @@ export interface AudioSystemLike extends g.AudioSystemLike {
 }
 
 export interface AudioSystems {
+	[key: string]: AudioSystemLike;
 	music: AudioSystemLike;
 	sound: AudioSystemLike;
 }

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -573,7 +573,7 @@ export class Game extends g.Game {
 
 	autoTickForInternalEvents: boolean;
 	resourceFactory: ResourceFactory;
-	audio: AudioSystems;
+	audio: AudioSystemManager;
 
 	constructor(
 		gameConfiguration: g.GameConfiguration,
@@ -693,8 +693,7 @@ export interface AudioSystemLike extends g.AudioSystemLike {
 	_destroyRequestedAssets: { [key: string]: g.AudioAssetLike };
 }
 
-export interface AudioSystems {
-	[key: string]: AudioSystemLike;
+export interface AudioSystemManager extends g.AudioSystemManager {
 	music: AudioSystemLike;
 	sound: AudioSystemLike;
 }

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -573,7 +573,7 @@ export class Game extends g.Game {
 
 	autoTickForInternalEvents: boolean;
 	resourceFactory: ResourceFactory;
-	audio: { [key: string]: AudioSystemLike };
+	audio: AudioSystems;
 
 	constructor(
 		gameConfiguration: g.GameConfiguration,
@@ -691,4 +691,9 @@ export class CacheableE extends g.CacheableE {
 
 export interface AudioSystemLike extends g.AudioSystemLike {
 	_destroyRequestedAssets: { [key: string]: g.AudioAssetLike };
+}
+
+export interface AudioSystems {
+	music: AudioSystemLike;
+	sound: AudioSystemLike;
 }

--- a/src/domain/AssetManager.ts
+++ b/src/domain/AssetManager.ts
@@ -363,7 +363,7 @@ export class AssetManager implements AssetLoadHandler {
 				asset.initialize(<ImageAssetHint>conf.hint);
 				return asset;
 			case "audio":
-				var system = conf.systemId === "music" ? this.game.audio.music : this.game.audio.sound;
+				var system = conf.systemId ? this.game.audio[conf.systemId] : this.game.audio[this.game.defaultAudioSystemId];
 				return resourceFactory.createAudioAsset(id, uri, conf.duration, system, conf.loop, <AudioAssetHint>conf.hint);
 			case "text":
 				return resourceFactory.createTextAsset(id, uri);

--- a/src/domain/AssetManager.ts
+++ b/src/domain/AssetManager.ts
@@ -360,7 +360,7 @@ export class AssetManager implements AssetLoadHandler {
 				asset.initialize(<ImageAssetHint>conf.hint);
 				return asset;
 			case "audio":
-				var system = conf.systemId ? this.game.audio[conf.systemId] : this.game.audio[this.game.defaultAudioSystemId];
+				var system = conf.systemId === "music" ? this.game.audio.music : this.game.audio.sound;
 				return resourceFactory.createAudioAsset(id, uri, conf.duration, system, conf.loop, <AudioAssetHint>conf.hint);
 			case "text":
 				return resourceFactory.createTextAsset(id, uri);

--- a/src/domain/AssetManager.ts
+++ b/src/domain/AssetManager.ts
@@ -315,6 +315,9 @@ export class AssetManager implements AssetLoadHandler {
 				if (conf.hint === undefined) {
 					conf.hint = audioSystemConf ? audioSystemConf.hint : {};
 				}
+				if (conf.systemId !== "music" && conf.systemId !== "sound") {
+					throw ExceptionFactory.createAssertionError("AssetManager#_normalize: wrong systemId given for the audio asset: " + p);
+				}
 			}
 			if (conf.type === "video") {
 				if (!conf.useRealSize) {

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -1,4 +1,12 @@
+import { MusicAudioSystem, SoundAudioSystem } from "../implementations/AudioSystem";
 import { AudioSystemLike } from "../interfaces/AudioSystemLike";
+import { ResourceFactoryLike } from "../interfaces/ResourceFactoryLike";
+
+export interface AudioSystems {
+	[key: string]: AudioSystemLike;
+	music: AudioSystemLike;
+	sound: AudioSystemLike;
+}
 
 /**
  * `Game#audio` の管理クラス。
@@ -12,7 +20,10 @@ export class AudioSystemManager {
 	 */
 	_muted: boolean;
 
-	systems: { [key: string]: AudioSystemLike };
+	/*
+	 * @private
+	 */
+	_systems: AudioSystems;
 
 	constructor() {
 		this._muted = false;
@@ -23,9 +34,9 @@ export class AudioSystemManager {
 	 */
 	_reset(): void {
 		this._muted = false;
-		for (var id in this.systems) {
-			if (!this.systems.hasOwnProperty(id)) continue;
-			this.systems[id]._reset();
+		for (var id in this._systems) {
+			if (!this._systems.hasOwnProperty(id)) continue;
+			this._systems[id]._reset();
 		}
 	}
 
@@ -36,9 +47,10 @@ export class AudioSystemManager {
 		if (this._muted === muted) return;
 
 		this._muted = muted;
-		for (var id in this.systems) {
-			if (!this.systems.hasOwnProperty(id)) continue;
-			this.systems[id]._setMuted(muted);
+
+		for (var id in this._systems) {
+			if (!this._systems.hasOwnProperty(id)) continue;
+			this._systems[id]._setMuted(muted);
 		}
 	}
 
@@ -46,9 +58,28 @@ export class AudioSystemManager {
 	 * @private
 	 */
 	_setPlaybackRate(rate: number): void {
-		for (var id in this.systems) {
-			if (!this.systems.hasOwnProperty(id)) continue;
-			this.systems[id]._setPlaybackRate(rate);
+		for (var id in this._systems) {
+			if (!this._systems.hasOwnProperty(id)) continue;
+			this._systems[id]._setPlaybackRate(rate);
 		}
+	}
+
+	/**
+	 * @private
+	 */
+	_createAudioSystems(resourceFactory: ResourceFactoryLike): AudioSystems {
+		this._systems = {
+			music: new MusicAudioSystem({
+				id: "music",
+				muted: this._muted,
+				resourceFactory: resourceFactory
+			}),
+			sound: new SoundAudioSystem({
+				id: "sound",
+				muted: this._muted,
+				resourceFactory: resourceFactory
+			})
+		};
+		return this._systems;
 	}
 }

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -2,31 +2,31 @@ import { MusicAudioSystem, SoundAudioSystem } from "../implementations/AudioSyst
 import { AudioSystemLike } from "../interfaces/AudioSystemLike";
 import { ResourceFactoryLike } from "../interfaces/ResourceFactoryLike";
 
-export interface AudioSystems {
-	[key: string]: AudioSystemLike;
-	music: AudioSystemLike;
-	sound: AudioSystemLike;
-}
-
 /**
- * `Game#audio` の管理クラス。
+ * `AudioSystem` の管理クラス。
  *
  * 複数の `AudioSystem` に一括で必要な状態設定を行う。
  * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
  */
 export class AudioSystemManager {
 	/**
+	 * ゲームの BGM を扱う AudioSystem
+	 */
+	music: AudioSystemLike;
+
+	/**
+	 * BGM以外の音声を扱う AudioSystem
+	 */
+	sound: AudioSystemLike;
+
+	/**
 	 * @private
 	 */
 	_muted: boolean;
 
-	/*
-	 * @private
-	 */
-	_systems: AudioSystems;
-
-	constructor() {
+	constructor(resourceFactory: ResourceFactoryLike) {
 		this._muted = false;
+		this._createAudioSystems(resourceFactory);
 	}
 
 	/**
@@ -34,10 +34,8 @@ export class AudioSystemManager {
 	 */
 	_reset(): void {
 		this._muted = false;
-		for (var id in this._systems) {
-			if (!this._systems.hasOwnProperty(id)) continue;
-			this._systems[id]._reset();
-		}
+		this.music._reset();
+		this.sound._reset();
 	}
 
 	/**
@@ -47,38 +45,31 @@ export class AudioSystemManager {
 		if (this._muted === muted) return;
 
 		this._muted = muted;
-		for (var id in this._systems) {
-			if (!this._systems.hasOwnProperty(id)) continue;
-			this._systems[id]._setMuted(muted);
-		}
+		this.music._setMuted(muted);
+		this.sound._setMuted(muted);
 	}
 
 	/**
 	 * @private
 	 */
 	_setPlaybackRate(rate: number): void {
-		for (var id in this._systems) {
-			if (!this._systems.hasOwnProperty(id)) continue;
-			this._systems[id]._setPlaybackRate(rate);
-		}
+		this.music._setPlaybackRate(rate);
+		this.sound._setPlaybackRate(rate);
 	}
 
 	/**
 	 * @private
 	 */
-	_createAudioSystems(resourceFactory: ResourceFactoryLike): AudioSystems {
-		this._systems = {
-			music: new MusicAudioSystem({
-				id: "music",
-				muted: this._muted,
-				resourceFactory: resourceFactory
-			}),
-			sound: new SoundAudioSystem({
-				id: "sound",
-				muted: this._muted,
-				resourceFactory: resourceFactory
-			})
-		};
-		return this._systems;
+	_createAudioSystems(resourceFactory: ResourceFactoryLike): void {
+		this.music = new MusicAudioSystem({
+			id: "music",
+			muted: this._muted,
+			resourceFactory: resourceFactory
+		});
+		this.sound = new SoundAudioSystem({
+			id: "sound",
+			muted: this._muted,
+			resourceFactory: resourceFactory
+		});
 	}
 }

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -10,12 +10,12 @@ import { ResourceFactoryLike } from "../interfaces/ResourceFactoryLike";
  */
 export class AudioSystemManager {
 	/**
-	 * ゲームの BGM を扱う AudioSystem
+	 * ループ再生可能な AudioSystem
 	 */
 	music: AudioSystemLike;
 
 	/**
-	 * BGM以外の音声を扱う AudioSystem
+	 * 効果音を扱う AudioSystem
 	 */
 	sound: AudioSystemLike;
 
@@ -26,7 +26,7 @@ export class AudioSystemManager {
 
 	constructor(resourceFactory: ResourceFactoryLike) {
 		this._muted = false;
-		this._createAudioSystems(resourceFactory);
+		this._initializeAudioSystems(resourceFactory);
 	}
 
 	/**
@@ -60,7 +60,7 @@ export class AudioSystemManager {
 	/**
 	 * @private
 	 */
-	_createAudioSystems(resourceFactory: ResourceFactoryLike): void {
+	_initializeAudioSystems(resourceFactory: ResourceFactoryLike): void {
 		this.music = new MusicAudioSystem({
 			id: "music",
 			muted: this._muted,

--- a/src/domain/AudioSystemManager.ts
+++ b/src/domain/AudioSystemManager.ts
@@ -47,7 +47,6 @@ export class AudioSystemManager {
 		if (this._muted === muted) return;
 
 		this._muted = muted;
-
 		for (var id in this._systems) {
 			if (!this._systems.hasOwnProperty(id)) continue;
 			this._systems[id]._setMuted(muted);

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -122,14 +122,4 @@ export class AudioPlayer implements AudioPlayerLike {
 	_changeMuted(muted: boolean): void {
 		this._muted = muted;
 	}
-
-	/**
-	 * システム音量の変更を通知する。
-	 * @private
-	 */
-	_notifySystemVolumeChanged(): void {
-		// AudioPlayerの音量を AudioSystem の音量で上書きしていたため、PDI側の最終音量の計算でAudioSystemの音量が二重で計算されていた。
-		// 暫定対応として、 changeVolume() に AudioPlayer 自身の音量を渡す事により最終音量の計算を実行させる。
-		this.changeVolume(this.volume);
-	}
 }

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -122,4 +122,14 @@ export class AudioPlayer implements AudioPlayerLike {
 	_changeMuted(muted: boolean): void {
 		this._muted = muted;
 	}
+
+	/**
+	 * システム音量の変更を通知する。
+	 * @private
+	 */
+	_notifySystemVolumeChanged(): void {
+		// AudioPlayerの音量を AudioSystem の音量で上書きしていたため、PDI側の最終音量の計算でAudioSystemの音量が二重で計算されていた。
+		// 暫定対応として、 changeVolume() に AudioPlayer 自身の音量を渡す事により最終音量の計算を実行させる。
+		this.changeVolume(this.volume);
+	}
 }

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -122,4 +122,14 @@ export class AudioPlayer implements AudioPlayerLike {
 	_changeMuted(muted: boolean): void {
 		this._muted = muted;
 	}
+
+	/**
+	 * 音量の変更を通知する。
+	 * @private
+	 */
+	_notifyVolumeChanged(): void {
+		// AudioPlayerの音量を AudioSystem の音量で上書きしていたため、最終音量が正常に計算できていなかった。
+		// 暫定対応として、 changeVolume() に AudioPlayer 自身の音量を渡す事により最終音量の計算を実行させる。
+		this.changeVolume(this.volume);
+	}
 }

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -202,7 +202,7 @@ export class MusicAudioSystem extends AudioSystem {
 	 * @private
 	 */
 	_onVolumeChanged(): void {
-		this.player.changeVolume(this._volume);
+		this.player._notifyVolumeChanged();
 	}
 
 	/**
@@ -336,7 +336,7 @@ export class SoundAudioSystem extends AudioSystem {
 	 */
 	_onVolumeChanged(): void {
 		for (var i = 0; i < this.players.length; ++i) {
-			this.players[i].changeVolume(this._volume);
+			this.players[i]._notifyVolumeChanged();
 		}
 	}
 }

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -202,7 +202,7 @@ export class MusicAudioSystem extends AudioSystem {
 	 * @private
 	 */
 	_onVolumeChanged(): void {
-		this.player.changeVolume(this._volume);
+		this.player._notifySystemVolumeChanged();
 	}
 
 	/**
@@ -336,7 +336,7 @@ export class SoundAudioSystem extends AudioSystem {
 	 */
 	_onVolumeChanged(): void {
 		for (var i = 0; i < this.players.length; ++i) {
-			this.players[i].changeVolume(this._volume);
+			this.players[i]._notifySystemVolumeChanged();
 		}
 	}
 }

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -202,7 +202,7 @@ export class MusicAudioSystem extends AudioSystem {
 	 * @private
 	 */
 	_onVolumeChanged(): void {
-		this.player._notifySystemVolumeChanged();
+		this.player.changeVolume(this._volume);
 	}
 
 	/**
@@ -336,7 +336,7 @@ export class SoundAudioSystem extends AudioSystem {
 	 */
 	_onVolumeChanged(): void {
 		for (var i = 0; i < this.players.length; ++i) {
-			this.players[i]._notifySystemVolumeChanged();
+			this.players[i].changeVolume(this._volume);
 		}
 	}
 }

--- a/src/implementations/ResourceFactory.ts
+++ b/src/implementations/ResourceFactory.ts
@@ -1,18 +1,18 @@
 import { SurfaceAtlas } from "../commons/SurfaceAtlas";
-import { AudioAssetLike } from "../interfaces/AudioAssetLike";
-import { AudioPlayerLike } from "../interfaces/AudioPlayerLike";
-import { AudioSystemLike } from "../interfaces/AudioSystemLike";
-import { GlyphFactoryLike } from "../interfaces/GlyphFactoryLike";
-import { ImageAssetLike } from "../interfaces/ImageAssetLike";
+import { VideoSystem } from "../commons/VideoSystem";
 import { ResourceFactoryLike } from "../interfaces/ResourceFactoryLike";
-import { ScriptAssetLike } from "../interfaces/ScriptAssetLike";
-import { SurfaceLike } from "../interfaces/SurfaceLike";
-import { TextAssetLike } from "../interfaces/TextAssetLike";
-import { VideoAssetLike } from "../interfaces/VideoAssetLike";
-import { VideoSystemLike } from "../interfaces/VideoSystemLike";
 import { AudioAssetHint } from "../types/AssetConfiguration";
 import { FontFamily } from "../types/FontFamily";
 import { FontWeight } from "../types/FontWeight";
+import { AudioAsset } from "./AudioAsset";
+import { AudioPlayer } from "./AudioPlayer";
+import { AudioSystem } from "./AudioSystem";
+import { GlyphFactory } from "./GlyphFactory";
+import { ImageAsset } from "./ImageAsset";
+import { ScriptAsset } from "./ScriptAsset";
+import { Surface } from "./Surface";
+import { TextAsset } from "./TextAsset";
+import { VideoAsset } from "./VideoAsset";
 
 /**
  * リソースの生成を行うクラス。
@@ -22,32 +22,32 @@ import { FontWeight } from "../types/FontWeight";
  * 通常ゲーム開発者が呼び出す必要はない。
  */
 export abstract class ResourceFactory implements ResourceFactoryLike {
-	abstract createImageAsset(id: string, assetPath: string, width: number, height: number): ImageAssetLike;
+	abstract createImageAsset(id: string, assetPath: string, width: number, height: number): ImageAsset;
 
 	abstract createVideoAsset(
 		id: string,
 		assetPath: string,
 		width: number,
 		height: number,
-		system: VideoSystemLike,
+		system: VideoSystem,
 		loop: boolean,
 		useRealSize: boolean
-	): VideoAssetLike;
+	): VideoAsset;
 
 	abstract createAudioAsset(
 		id: string,
 		assetPath: string,
 		duration: number,
-		system: AudioSystemLike,
+		system: AudioSystem,
 		loop: boolean,
 		hint: AudioAssetHint
-	): AudioAssetLike;
+	): AudioAsset;
 
-	abstract createTextAsset(id: string, assetPath: string): TextAssetLike;
+	abstract createTextAsset(id: string, assetPath: string): TextAsset;
 
-	abstract createAudioPlayer(system: AudioSystemLike): AudioPlayerLike;
+	abstract createAudioPlayer(system: AudioSystem): AudioPlayer;
 
-	abstract createScriptAsset(id: string, assetPath: string): ScriptAssetLike;
+	abstract createScriptAsset(id: string, assetPath: string): ScriptAsset;
 
 	/**
 	 * Surface を作成する。
@@ -56,7 +56,7 @@ export abstract class ResourceFactory implements ResourceFactoryLike {
 	 * @param width 幅(ピクセル、整数値)
 	 * @param height 高さ(ピクセル、整数値)
 	 */
-	abstract createSurface(width: number, height: number): SurfaceLike;
+	abstract createSurface(width: number, height: number): Surface;
 
 	/**
 	 * GlyphFactory を作成する。
@@ -80,7 +80,7 @@ export abstract class ResourceFactory implements ResourceFactoryLike {
 		strokeColor?: string,
 		strokeOnly?: boolean,
 		fontWeight?: FontWeight
-	): GlyphFactoryLike;
+	): GlyphFactory;
 
 	createSurfaceAtlas(width: number, height: number): SurfaceAtlas {
 		return new SurfaceAtlas(this.createSurface(width, height));

--- a/src/interfaces/AudioPlayerLike.ts
+++ b/src/interfaces/AudioPlayerLike.ts
@@ -87,4 +87,10 @@ export interface AudioPlayerLike {
 	 * @private
 	 */
 	_changeMuted(muted: boolean): void;
+
+	/**
+	 * システム音量の変更を通知する。
+	 * @private
+	 */
+	_notifySystemVolumeChanged(): void;
 }

--- a/src/interfaces/AudioPlayerLike.ts
+++ b/src/interfaces/AudioPlayerLike.ts
@@ -87,10 +87,4 @@ export interface AudioPlayerLike {
 	 * @private
 	 */
 	_changeMuted(muted: boolean): void;
-
-	/**
-	 * システム音量の変更を通知する。
-	 * @private
-	 */
-	_notifySystemVolumeChanged(): void;
 }

--- a/src/interfaces/AudioPlayerLike.ts
+++ b/src/interfaces/AudioPlayerLike.ts
@@ -87,4 +87,10 @@ export interface AudioPlayerLike {
 	 * @private
 	 */
 	_changeMuted(muted: boolean): void;
+
+	/**
+	 * 音量の変更を通知する。
+	 * @private
+	 */
+	_notifyVolumeChanged(): void;
 }

--- a/src/types/AssetConfiguration.ts
+++ b/src/types/AssetConfiguration.ts
@@ -146,7 +146,7 @@ export interface AudioAssetConfigurationBase extends AssetConfigurationBase {
 	/**
 	 * AudioAssetのsystem指定。
 	 */
-	systemId: string;
+	systemId: "music" | "sound";
 
 	/**
 	 * 再生時間。

--- a/src/types/DynamicAssetConfiguration.ts
+++ b/src/types/DynamicAssetConfiguration.ts
@@ -91,7 +91,7 @@ export interface DynamicAudioAssetConfigurationBase extends DynamicAssetConfigur
 	/**
 	 * AudioAssetのsystem指定。
 	 */
-	systemId: string;
+	systemId: "music" | "sound";
 
 	/**
 	 * 再生時間。


### PR DESCRIPTION
## このpull requestが解決する内容
- game.audioの型を `AudioSystemManager` へ修正。

## 破壊的な変更を含んでいるか?
-  AudioAsset の `systemId`が `music`, `sound` 以外はエラーとする
- `g.AudioSystemManager.systems` の削除
- `g.AudioSystemManager` のプロパティ `music`と`sound`の追加