### PR TITLE
Fix AudioSystem#volume set AudioPlayer#volume

### DIFF
--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -198,4 +198,26 @@ describe("test AudioPlayer", () => {
 		system._setPlaybackRate(1.0);
 		expect(player3._muted).toBeTruthy();
 	});
+
+	it("MusicAudioSystem#_onVolumeChanged", () => {
+		const game = new Game({ width: 320, height: 320, main: "" });
+		const system = game.audio.music;
+		const player = system.createPlayer() as AudioPlayer;
+		// systemのvolumeが変更されても、playerの音量は変わらない
+		player.changeVolume(0.2);
+		system.volume = 0.7;
+		expect(player.volume).toBe(0.2);
+		expect(system.volume).toBe(0.7);
+	});
+
+	it("SoundAudioSystem#_onVolumeChanged", () => {
+		const game = new Game({ width: 320, height: 320, main: "" });
+		const system = game.audio.sound;
+		const player = system.createPlayer() as AudioPlayer;
+		// systemのvolumeが変更されても、playerの音量は変わらない
+		player.changeVolume(0.3);
+		system.volume = 0.7;
+		expect(player.volume).toBe(0.3);
+		expect(system.volume).toBe(0.7);
+	});
 });

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -128,7 +128,7 @@ export class AudioPlayer implements AudioPlayerLike {
 	 * @private
 	 */
 	_notifyVolumeChanged(): void {
-		// AudioPlayerの音量を AudioSystem の音量で上書きしていたため、PDI側の最終音量の計算でAudioSystemの音量が二重で計算されていた。
+		// AudioPlayerの音量を AudioSystem の音量で上書きしていたため、最終音量が正常に計算できていなかった。
 		// 暫定対応として、 changeVolume() に AudioPlayer 自身の音量を渡す事により最終音量の計算を実行させる。
 		this.changeVolume(this.volume);
 	}

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -122,4 +122,14 @@ export class AudioPlayer implements AudioPlayerLike {
 	_changeMuted(muted: boolean): void {
 		this._muted = muted;
 	}
+
+	/**
+	 * 音量の変更を通知する。
+	 * @private
+	 */
+	_notifyVolumeChanged(): void {
+		// AudioPlayerの音量を AudioSystem の音量で上書きしていたため、PDI側の最終音量の計算でAudioSystemの音量が二重で計算されていた。
+		// 暫定対応として、 changeVolume() に AudioPlayer 自身の音量を渡す事により最終音量の計算を実行させる。
+		this.changeVolume(this.volume);
+	}
 }

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -202,7 +202,7 @@ export class MusicAudioSystem extends AudioSystem {
 	 * @private
 	 */
 	_onVolumeChanged(): void {
-		this.player.changeVolume(this._volume);
+		this.player._notifyVolumeChanged();
 	}
 
 	/**
@@ -336,7 +336,7 @@ export class SoundAudioSystem extends AudioSystem {
 	 */
 	_onVolumeChanged(): void {
 		for (var i = 0; i < this.players.length; ++i) {
-			this.players[i].changeVolume(this._volume);
+			this.players[i]._notifyVolumeChanged();
 		}
 	}
 }

--- a/src/implementations/ResourceFactory.ts
+++ b/src/implementations/ResourceFactory.ts
@@ -1,18 +1,18 @@
 import { SurfaceAtlas } from "../commons/SurfaceAtlas";
-import { AudioAssetLike } from "../interfaces/AudioAssetLike";
-import { AudioPlayerLike } from "../interfaces/AudioPlayerLike";
-import { AudioSystemLike } from "../interfaces/AudioSystemLike";
-import { GlyphFactoryLike } from "../interfaces/GlyphFactoryLike";
-import { ImageAssetLike } from "../interfaces/ImageAssetLike";
+import { VideoSystem } from "../commons/VideoSystem";
 import { ResourceFactoryLike } from "../interfaces/ResourceFactoryLike";
-import { ScriptAssetLike } from "../interfaces/ScriptAssetLike";
-import { SurfaceLike } from "../interfaces/SurfaceLike";
-import { TextAssetLike } from "../interfaces/TextAssetLike";
-import { VideoAssetLike } from "../interfaces/VideoAssetLike";
-import { VideoSystemLike } from "../interfaces/VideoSystemLike";
 import { AudioAssetHint } from "../types/AssetConfiguration";
 import { FontFamily } from "../types/FontFamily";
 import { FontWeight } from "../types/FontWeight";
+import { AudioAsset } from "./AudioAsset";
+import { AudioPlayer } from "./AudioPlayer";
+import { AudioSystem } from "./AudioSystem";
+import { GlyphFactory } from "./GlyphFactory";
+import { ImageAsset } from "./ImageAsset";
+import { ScriptAsset } from "./ScriptAsset";
+import { Surface } from "./Surface";
+import { TextAsset } from "./TextAsset";
+import { VideoAsset } from "./VideoAsset";
 
 /**
  * リソースの生成を行うクラス。
@@ -22,32 +22,32 @@ import { FontWeight } from "../types/FontWeight";
  * 通常ゲーム開発者が呼び出す必要はない。
  */
 export abstract class ResourceFactory implements ResourceFactoryLike {
-	abstract createImageAsset(id: string, assetPath: string, width: number, height: number): ImageAssetLike;
+	abstract createImageAsset(id: string, assetPath: string, width: number, height: number): ImageAsset;
 
 	abstract createVideoAsset(
 		id: string,
 		assetPath: string,
 		width: number,
 		height: number,
-		system: VideoSystemLike,
+		system: VideoSystem,
 		loop: boolean,
 		useRealSize: boolean
-	): VideoAssetLike;
+	): VideoAsset;
 
 	abstract createAudioAsset(
 		id: string,
 		assetPath: string,
 		duration: number,
-		system: AudioSystemLike,
+		system: AudioSystem,
 		loop: boolean,
 		hint: AudioAssetHint
-	): AudioAssetLike;
+	): AudioAsset;
 
-	abstract createTextAsset(id: string, assetPath: string): TextAssetLike;
+	abstract createTextAsset(id: string, assetPath: string): TextAsset;
 
-	abstract createAudioPlayer(system: AudioSystemLike): AudioPlayerLike;
+	abstract createAudioPlayer(system: AudioSystem): AudioPlayer;
 
-	abstract createScriptAsset(id: string, assetPath: string): ScriptAssetLike;
+	abstract createScriptAsset(id: string, assetPath: string): ScriptAsset;
 
 	/**
 	 * Surface を作成する。
@@ -56,7 +56,7 @@ export abstract class ResourceFactory implements ResourceFactoryLike {
 	 * @param width 幅(ピクセル、整数値)
 	 * @param height 高さ(ピクセル、整数値)
 	 */
-	abstract createSurface(width: number, height: number): SurfaceLike;
+	abstract createSurface(width: number, height: number): Surface;
 
 	/**
 	 * GlyphFactory を作成する。
@@ -80,7 +80,7 @@ export abstract class ResourceFactory implements ResourceFactoryLike {
 		strokeColor?: string,
 		strokeOnly?: boolean,
 		fontWeight?: FontWeight
-	): GlyphFactoryLike;
+	): GlyphFactory;
 
 	createSurfaceAtlas(width: number, height: number): SurfaceAtlas {
 		return new SurfaceAtlas(this.createSurface(width, height));

--- a/src/interfaces/AudioPlayerLike.ts
+++ b/src/interfaces/AudioPlayerLike.ts
@@ -87,4 +87,10 @@ export interface AudioPlayerLike {
 	 * @private
 	 */
 	_changeMuted(muted: boolean): void;
+
+	/**
+	 * 音量の変更を通知する。
+	 * @private
+	 */
+	_notifyVolumeChanged(): void;
 }


### PR DESCRIPTION
## このpull requestが解決する内容

- `AudioSysteSystem` の音量が`AudioPlayer`の音量を上書きしている問題を修正
  (最終音量の計算でAudioSystemの音量が二重で計算され、AudioPlayerの音量が考慮されていない)


**その他修正**
- `implementations/ResourceFactory` で参照していた `interfaces/*Like` を `implementations`の各classに修正

## 破壊的な変更を含んでいるか?

- g.AudioPlayer#_notifyVolumeChanged()の追加
