### PR TITLE
Change game.modified to function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -611,7 +611,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 * @param isBubbling この関数をこのシーンの子の `modified()` から呼び出す場合、真を渡さなくてはならない。省略された場合、偽。
 	 */
 	modified(isBubbling?: boolean): void {
-		this.game.modified = true;
+		this.game.modified();
 	}
 
 	/**

--- a/src/__tests__/ESpec.ts
+++ b/src/__tests__/ESpec.ts
@@ -7,7 +7,7 @@ describe("test E", () => {
 	let runtime: Runtime, e: E;
 
 	function resetUpdated(runtime: Runtime): void {
-		runtime.game.modified = false;
+		runtime.game._modified = false;
 		e.state &= ~EntityStateFlags.Modified;
 	}
 
@@ -350,32 +350,32 @@ describe("test E", () => {
 
 	it("modified", () => {
 		resetUpdated(runtime);
-		expect(runtime.game.modified).toBe(false);
+		expect(runtime.game._modified).toBe(false);
 
 		e.modified();
-		expect(runtime.game.modified).toBe(true);
+		expect(runtime.game._modified).toBe(true);
 
 		resetUpdated(runtime);
 
 		const e2 = new E({ scene: runtime.scene });
 		e.append(e2);
-		expect(runtime.game.modified).toBe(true);
+		expect(runtime.game._modified).toBe(true);
 
 		resetUpdated(runtime);
 		const e3 = new E({ scene: runtime.scene });
 		e.append(e3);
-		expect(runtime.game.modified).toBe(true);
+		expect(runtime.game._modified).toBe(true);
 	});
 
 	it("modified with hide/show", () => {
 		resetUpdated(runtime);
-		expect(runtime.game.modified).toBe(false);
+		expect(runtime.game._modified).toBe(false);
 		e.hide();
-		expect(runtime.game.modified).toBe(true);
+		expect(runtime.game._modified).toBe(true);
 		runtime.game.render();
-		expect(runtime.game.modified).toBe(false);
+		expect(runtime.game._modified).toBe(false);
 		e.show();
-		expect(runtime.game.modified).toBe(true);
+		expect(runtime.game._modified).toBe(true);
 	});
 
 	it("update", () => {

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -28,7 +28,7 @@ describe("test Game", () => {
 		expect(game.scenes.length).toBe(0);
 		expect(game.random).toBe(null);
 		expect(game.events.length).toBe(0);
-		expect(game.modified).toBe(true);
+		expect(game._modified).toBe(true);
 		expect(game.external).toEqual({});
 		expect(game.age).toBe(0);
 		expect(game.fps).toBe(30);
@@ -49,7 +49,7 @@ describe("test Game", () => {
 		expect(game.scenes).toBe(undefined);
 		expect(game.random).toBe(undefined);
 		expect(game.events).toBe(undefined);
-		expect(game.modified).toBe(false);
+		expect(game._modified).toBe(false);
 		expect(game.external).toEqual({}); // external は触らない
 		expect(game.vars).toEqual({}); // vars も触らない
 		expect(game.playId).toBe(undefined);
@@ -936,29 +936,29 @@ describe("test Game", () => {
 		const e = new E({ scene: scene });
 		scene.append(e);
 		expect(e.state).toBe(0);
-		expect(game.modified).toBe(true);
+		expect(game._modified).toBe(true);
 
 		const camera = new Camera2D({});
 		game.focusingCamera = camera;
 		expect(game.focusingCamera).toEqual(camera);
 		expect(e.state).toBe(EntityStateFlags.None);
-		expect(game.modified).toBe(false);
+		expect(game._modified).toBe(false);
 
 		e.modified();
 		expect(e.state).toBe(EntityStateFlags.Modified | EntityStateFlags.ContextLess);
-		expect(game.modified).toBe(true);
+		expect(game._modified).toBe(true);
 		game.focusingCamera = camera;
 		expect(e.state).toBe(EntityStateFlags.Modified | EntityStateFlags.ContextLess);
-		expect(game.modified).toBe(true);
+		expect(game._modified).toBe(true);
 
 		e.modified();
 		const camera2 = new Camera2D({});
 		game.focusingCamera = camera2;
 		expect(game.focusingCamera).toEqual(camera2);
 		expect(e.state).toBe(EntityStateFlags.ContextLess);
-		expect(game.modified).toBe(false);
+		expect(game._modified).toBe(false);
 
-		game.modified = false;
+		game._modified = false;
 		game.focusingCamera = camera;
 		expect(game.focusingCamera).toEqual(camera);
 	});

--- a/src/__tests__/SceneSpec.ts
+++ b/src/__tests__/SceneSpec.ts
@@ -878,7 +878,7 @@ describe("test Scene", () => {
 	it("modified", () => {
 		const scene = new Scene({ game: game });
 		scene.modified();
-		expect(scene.game.modified).toEqual(true);
+		expect(scene.game._modified).toEqual(true);
 	});
 
 	it("state", done => {


### PR DESCRIPTION
## このpull requestが解決する内容

- `g.game#modified` をfunctionへ変更。

## 破壊的な変更を含んでいるか?

- 以前の代入の更新ではなく、`game.modified()` のように関数として呼び出す必要があります。
