### PR TITLE
Resolve assetManager dependencies

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -544,7 +544,14 @@ export abstract class Game implements Registrable<E> {
 		this._main = gameConfiguration.main;
 		this._mainParameter = undefined;
 		this._configuration = gameConfiguration;
-		this._assetManager = new AssetManager(this, gameConfiguration.assets, gameConfiguration.audio, gameConfiguration.moduleMainScripts);
+		this._assetManager = new AssetManager(
+			this.resourceFactory,
+			this.audio,
+			this.defaultAudioSystemId,
+			gameConfiguration.assets,
+			gameConfiguration.audio,
+			gameConfiguration.moduleMainScripts
+		);
 		this._moduleManager = new ModuleManager(this._runtimeValueBase, this._assetManager);
 
 		var operationPluginsField = <InternalOperationPluginInfo[]>(gameConfiguration.operationPlugins || []);

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -544,14 +544,7 @@ export abstract class Game implements Registrable<E> {
 		this._main = gameConfiguration.main;
 		this._mainParameter = undefined;
 		this._configuration = gameConfiguration;
-		this._assetManager = new AssetManager(
-			this.resourceFactory,
-			this.audio,
-			this.defaultAudioSystemId,
-			gameConfiguration.assets,
-			gameConfiguration.audio,
-			gameConfiguration.moduleMainScripts
-		);
+		this._assetManager = new AssetManager(this, gameConfiguration.assets, gameConfiguration.audio, gameConfiguration.moduleMainScripts);
 		this._moduleManager = new ModuleManager(this._runtimeValueBase, this._assetManager);
 
 		var operationPluginsField = <InternalOperationPluginInfo[]>(gameConfiguration.operationPlugins || []);

--- a/src/__tests__/AssetManagerSpec.ts
+++ b/src/__tests__/AssetManagerSpec.ts
@@ -434,7 +434,7 @@ describe("test AssetManager", () => {
 
 	it("can be instanciated without configuration", () => {
 		const game = new Game(gameConfiguration);
-		const manager = new AssetManager(game.resourceFactory, game.audio, game.defaultAudioSystemId);
+		const manager = new AssetManager(game);
 		expect(manager.configuration).toEqual({});
 		expect(manager.destroyed()).toBe(false);
 
@@ -444,7 +444,7 @@ describe("test AssetManager", () => {
 
 	it("loads dynamically defined assets", done => {
 		const game = new Game(gameConfiguration);
-		const manager = new AssetManager(game.resourceFactory, game.audio, game.defaultAudioSystemId);
+		const manager = new AssetManager(game);
 		manager.requestAsset(
 			{
 				id: "testDynamicAsset",
@@ -489,7 +489,7 @@ describe("test AssetManager", () => {
 
 	it("releases assets when destroyed", done => {
 		const game = new Game(gameConfiguration);
-		const manager = new AssetManager(game.resourceFactory, game.audio, game.defaultAudioSystemId);
+		const manager = new AssetManager(game);
 		manager.requestAsset(
 			{
 				id: "testDynamicAsset",

--- a/src/__tests__/AssetManagerSpec.ts
+++ b/src/__tests__/AssetManagerSpec.ts
@@ -82,8 +82,6 @@ describe("test AssetManager", () => {
 		const game = new Game(gameConfiguration, "/");
 		const manager = game._assetManager;
 
-		expect(manager.game).toBe(game);
-
 		expect(manager.configuration.foo.path).toBe(gameConfiguration.assets.foo.path);
 		expect(manager.configuration.bar.path).toBe(gameConfiguration.assets.bar.path);
 		expect(manager.configuration.zoo.path).toBe(gameConfiguration.assets.zoo.path);
@@ -436,7 +434,7 @@ describe("test AssetManager", () => {
 
 	it("can be instanciated without configuration", () => {
 		const game = new Game(gameConfiguration);
-		const manager = new AssetManager(game);
+		const manager = new AssetManager(game.resourceFactory, game.audio, game.defaultAudioSystemId);
 		expect(manager.configuration).toEqual({});
 		expect(manager.destroyed()).toBe(false);
 
@@ -446,7 +444,7 @@ describe("test AssetManager", () => {
 
 	it("loads dynamically defined assets", done => {
 		const game = new Game(gameConfiguration);
-		const manager = new AssetManager(game);
+		const manager = new AssetManager(game.resourceFactory, game.audio, game.defaultAudioSystemId);
 		manager.requestAsset(
 			{
 				id: "testDynamicAsset",
@@ -491,7 +489,7 @@ describe("test AssetManager", () => {
 
 	it("releases assets when destroyed", done => {
 		const game = new Game(gameConfiguration);
-		const manager = new AssetManager(game);
+		const manager = new AssetManager(game.resourceFactory, game.audio, game.defaultAudioSystemId);
 		manager.requestAsset(
 			{
 				id: "testDynamicAsset",


### PR DESCRIPTION
## このpull requestが解決する内容

AssetManagerからgameの依存を切り離します。
- AssetManagerのconstructorの引数に渡していた `game` をやめ必要なパラメータを渡すように修正。

## 破壊的な変更を含んでいるか?

- なし


