### PR TITLE
Rename trigger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.9",
+  "version": "3.0.0-beta.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.10",
+  "version": "3.0.0-beta.11",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -187,17 +187,37 @@ export abstract class Game implements Registrable<E> {
 	/**
 	 * プレイヤーがゲームに参加したことを表すイベント。
 	 */
+	onJoin: Trigger<JoinEvent>;
+	/**
+	 * プレイヤーがゲームに参加したことを表すイベント。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	join: Trigger<JoinEvent>;
 	/**
 	 * プレイヤーがゲームから離脱したことを表すイベント。
+	 */
+	onLeave: Trigger<LeaveEvent>;
+	/**
+	 * プレイヤーがゲームから離脱したことを表すイベント。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	leave: Trigger<LeaveEvent>;
 	/**
 	 * 新しいプレイヤー情報が発生したことを示すイベント。
 	 */
+	onPlayerInfo: Trigger<PlayerInfoEvent>;
+	/**
+	 * 新しいプレイヤー情報が発生したことを示すイベント。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	playerInfo: Trigger<PlayerInfoEvent>;
 	/**
 	 * 新しい乱数シードが発生したことを示すイベント。
+	 */
+	onSeed: Trigger<SeedEvent>;
+	/**
+	 * 新しい乱数シードが発生したことを示すイベント。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	seed: Trigger<SeedEvent>;
 	/**
@@ -270,6 +290,14 @@ export abstract class Game implements Registrable<E> {
 	 * ゲーム開発者はこれをhandleして可能ならスナップショットを作成しGame#saveSnapshotを呼び出すべきである。
 	 */
 	// NOTE: このクラスはこのTriggerをfireしない。派生クラスがfireせねばならない。
+	onSnapshotRequest: Trigger<void>;
+
+	/**
+	 * スナップショット要求通知。
+	 * ゲーム開発者はこれをhandleして可能ならスナップショットを作成しGame#saveSnapshotを呼び出すべきである。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
+	// NOTE: このクラスはこのTriggerをfireしない。派生クラスがfireせねばならない。
 	snapshotRequest: Trigger<void>;
 
 	/**
@@ -318,6 +346,12 @@ export abstract class Game implements Registrable<E> {
 	/**
 	 * 画面サイズの変更時にfireされるTrigger。
 	 */
+	onResized: Trigger<CommonSize>;
+
+	/**
+	 * 画面サイズの変更時にfireされるTrigger。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	resized: Trigger<CommonSize>;
 
 	/**
@@ -329,6 +363,19 @@ export abstract class Game implements Registrable<E> {
 	 * この通知のfire頻度は、ゲームの実行状態などに依存して異なりうることに注意。
 	 * 例えば多人数プレイされている時、それぞれの環境でfireされ方が異なりうる。
 	 * ゲーム開発者は、この通知に起因する処理で、ゲームのグローバルな実行状態を変化させてはならない。
+	 */
+	onSkipChanged: Trigger<boolean>;
+
+	/**
+	 * スキップ状態の変化時にfireされるTrigger。
+	 *
+	 * スキップ状態に遷移する時に真、非スキップ状態に遷移する時に偽が与えられる。
+	 * この通知は、ゲーム開発者が「スキップ中の演出省略」などの最適化を行うために提供されている。
+	 *
+	 * この通知のfire頻度は、ゲームの実行状態などに依存して異なりうることに注意。
+	 * 例えば多人数プレイされている時、それぞれの環境でfireされ方が異なりうる。
+	 * ゲーム開発者は、この通知に起因する処理で、ゲームのグローバルな実行状態を変化させてはならない。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	skippingChanged: Trigger<boolean>;
 
@@ -390,11 +437,26 @@ export abstract class Game implements Registrable<E> {
 	 * このTriggerはアセットロード(Scene#loadedのfire)を待たず、変化した時点で即fireされることに注意。
 	 * @private
 	 */
+	_onSceneChanged: Trigger<Scene>;
+
+	/**
+	 * `this.scenes` の変化時にfireされるTrigger。
+	 * このTriggerはアセットロード(Scene#loadedのfire)を待たず、変化した時点で即fireされることに注意。
+	 * @private
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	_sceneChanged: Trigger<Scene>;
 
 	/**
 	 * グローバルアセットの読み込み待ちハンドラ。
 	 * @private
+	 */
+	_onLoad: Trigger<Game>;
+
+	/**
+	 * グローバルアセットの読み込み待ちハンドラ。
+	 * @private
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	_loaded: Trigger<Game>;
 
@@ -403,6 +465,15 @@ export abstract class Game implements Registrable<E> {
 	 * エントリポイント実行後のシーン遷移直後にfireされる。
 	 * このTriggerのfireは一度とは限らないことに注意。_loadAndStart()呼び出しの度に一度fireされる。
 	 * @private
+	 */
+	_onStart: Trigger<void>;
+
+	/**
+	 * _start() 呼び出しから戻る直前を通知するTrigger。
+	 * エントリポイント実行後のシーン遷移直後にfireされる。
+	 * このTriggerのfireは一度とは限らないことに注意。_loadAndStart()呼び出しの度に一度fireされる。
+	 * @private
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	_started: Trigger<void>;
 
@@ -445,6 +516,13 @@ export abstract class Game implements Registrable<E> {
 	/**
 	 * 操作プラグインによる操作を通知するTrigger。
 	 * @private
+	 */
+	_onOperationPluginOperated: Trigger<InternalOperationPluginOperation>;
+
+	/**
+	 * 操作プラグインによる操作を通知するTrigger。
+	 * @private
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	_operationPluginOperated: Trigger<InternalOperationPluginOperation>;
 
@@ -599,32 +677,42 @@ export abstract class Game implements Registrable<E> {
 		this.assets = {};
 		this.surfaceAtlasSet = undefined;
 
-		this.join = new Trigger<JoinEvent>();
-		this.leave = new Trigger<LeaveEvent>();
-		this.playerInfo = new Trigger<PlayerInfoEvent>();
-		this.seed = new Trigger<SeedEvent>();
+		this.onJoin = new Trigger<JoinEvent>();
+		this.onLeave = new Trigger<LeaveEvent>();
+		this.onPlayerInfo = new Trigger<PlayerInfoEvent>();
+		this.onSeed = new Trigger<SeedEvent>();
+		this.join = this.onJoin;
+		this.leave = this.onLeave;
+		this.playerInfo = this.onPlayerInfo;
+		this.seed = this.onSeed;
 
 		this._eventTriggerMap = {};
-		this._eventTriggerMap[EventType.Join] = this.join;
-		this._eventTriggerMap[EventType.Leave] = this.leave;
-		this._eventTriggerMap[EventType.PlayerInfo] = this.playerInfo;
-		this._eventTriggerMap[EventType.Seed] = this.seed;
+		this._eventTriggerMap[EventType.Join] = this.onJoin;
+		this._eventTriggerMap[EventType.Leave] = this.onLeave;
+		this._eventTriggerMap[EventType.PlayerInfo] = this.onPlayerInfo;
+		this._eventTriggerMap[EventType.Seed] = this.onSeed;
 		this._eventTriggerMap[EventType.Message] = undefined;
 		this._eventTriggerMap[EventType.PointDown] = undefined;
 		this._eventTriggerMap[EventType.PointMove] = undefined;
 		this._eventTriggerMap[EventType.PointUp] = undefined;
 		this._eventTriggerMap[EventType.Operation] = undefined;
 
-		this.resized = new Trigger<CommonSize>();
-		this.skippingChanged = new Trigger<boolean>();
+		this.onResized = new Trigger<CommonSize>();
+		this.onSkipChanged = new Trigger<boolean>();
+		this.resized = this.onResized;
+		this.skippingChanged = this.onSkipChanged;
 
 		this.isLastTickLocal = true;
 		this.lastOmittedLocalTickCount = 0;
 
-		this._loaded = new Trigger<Game>();
-		this._started = new Trigger<void>();
+		this._onLoad = new Trigger<Game>();
+		this._onStart = new Trigger<void>();
+		this._loaded = this._onLoad;
+		this._started = this._onStart;
+
 		this.isLoaded = false;
-		this.snapshotRequest = new Trigger<void>();
+		this.onSnapshotRequest = new Trigger<void>();
+		this.snapshotRequest = this.onSnapshotRequest;
 
 		this.external = {};
 
@@ -643,11 +731,13 @@ export abstract class Game implements Registrable<E> {
 
 		var operationPluginsField = <InternalOperationPluginInfo[]>(gameConfiguration.operationPlugins || []);
 		this.operationPluginManager = new OperationPluginManager(this, operationPluginViewInfo, operationPluginsField);
-		this._operationPluginOperated = new Trigger<InternalOperationPluginOperation>();
-		this.operationPluginManager.operated.add(this._operationPluginOperated.fire, this._operationPluginOperated);
+		this._onOperationPluginOperated = new Trigger<InternalOperationPluginOperation>();
+		this._operationPluginOperated = this._onOperationPluginOperated;
+		this.operationPluginManager.onOperate.add(this._onOperationPluginOperated.fire, this._onOperationPluginOperated);
 
-		this._sceneChanged = new Trigger<Scene>();
-		this._sceneChanged.add(this._updateEventTriggers, this);
+		this._onSceneChanged = new Trigger<Scene>();
+		this._onSceneChanged.add(this._updateEventTriggers, this);
+		this._sceneChanged = this._onSceneChanged;
 
 		this._initialScene = new Scene({
 			game: this,
@@ -655,7 +745,7 @@ export abstract class Game implements Registrable<E> {
 			local: true,
 			name: "akashic:initial-scene"
 		});
-		this._initialScene.loaded.add(this._onInitialSceneLoaded, this);
+		this._initialScene.onLoad.add(this._onInitialSceneLoaded, this);
 
 		this._reset({ age: 0 });
 	}
@@ -753,7 +843,7 @@ export abstract class Game implements Registrable<E> {
 				}
 			}
 
-			scene.update.fire();
+			scene.onUpdate.fire();
 			if (advanceAge) ++this.age;
 		}
 
@@ -1091,12 +1181,12 @@ export abstract class Game implements Registrable<E> {
 		}
 
 		this.audio._reset();
-		this._loaded.removeAll({ func: this._start, owner: this });
-		this.join.removeAll();
-		this.leave.removeAll();
-		this.seed.removeAll();
-		this.resized.removeAll();
-		this.skippingChanged.removeAll();
+		this._onLoad.removeAll({ func: this._start, owner: this });
+		this.onJoin.removeAll();
+		this.onLeave.removeAll();
+		this.onSeed.removeAll();
+		this.onResized.removeAll();
+		this.onSkipChanged.removeAll();
 
 		this._idx = 0;
 		this._localIdx = 0;
@@ -1106,7 +1196,7 @@ export abstract class Game implements Registrable<E> {
 		this._modified = true;
 		this.loadingScene = undefined;
 		this._focusingCamera = undefined;
-		this.snapshotRequest.removeAll();
+		this.onSnapshotRequest.removeAll();
 		this._sceneChangeRequests = [];
 		this._eventConverter = new EventConverter({ game: this, playerId: this.selfId });
 		this._pointEventResolver = new PointEventResolver({ sourceResolver: this, playerId: this.selfId });
@@ -1160,13 +1250,17 @@ export abstract class Game implements Registrable<E> {
 		this.renderers = undefined;
 		this.scenes = undefined;
 		this.random = undefined;
-		this.join.destroy();
+		this.onJoin.destroy();
+		this.onJoin = undefined;
 		this.join = undefined;
-		this.leave.destroy();
+		this.onLeave.destroy();
+		this.onLeave = undefined;
 		this.leave = undefined;
-		this.seed.destroy();
+		this.onSeed.destroy();
+		this.onSeed = undefined;
 		this.seed = undefined;
-		this.playerInfo.destroy();
+		this.onPlayerInfo.destroy();
+		this.onPlayerInfo = undefined;
 		this.playerInfo = undefined;
 		this._modified = false;
 		this.age = 0;
@@ -1179,7 +1273,8 @@ export abstract class Game implements Registrable<E> {
 		this.audio.sound.stopAll();
 		this.audio = undefined;
 		this.defaultAudioSystemId = undefined;
-		this.snapshotRequest.destroy();
+		this.onSnapshotRequest.destroy();
+		this.onSnapshotRequest = undefined;
 		this.snapshotRequest = undefined;
 
 		// TODO より能動的にdestroy処理を入れるべきかもしれない
@@ -1188,18 +1283,23 @@ export abstract class Game implements Registrable<E> {
 
 		this.playId = undefined;
 		this.operationPlugins = undefined; // this._operationPluginManager.pluginsのエイリアスなので、特に破棄処理はしない。
-		this.resized.destroy();
+		this.onResized.destroy();
+		this.onResized = undefined;
 		this.resized = undefined;
-		this.skippingChanged.destroy();
+		this.onSkipChanged.destroy();
+		this.onSkipChanged = undefined;
 		this.skippingChanged = undefined;
 		this._eventTriggerMap = undefined;
 		this._initialScene = undefined;
 		this._defaultLoadingScene = undefined;
-		this._sceneChanged.destroy();
+		this._onSceneChanged.destroy();
+		this._onSceneChanged = undefined;
 		this._sceneChanged = undefined;
-		this._loaded.destroy();
+		this._onLoad.destroy();
+		this._onLoad = undefined;
 		this._loaded = undefined;
-		this._started.destroy();
+		this._onStart.destroy();
+		this._onStart = undefined;
 		this._started = undefined;
 		this._main = undefined;
 		this._mainParameter = undefined;
@@ -1209,7 +1309,8 @@ export abstract class Game implements Registrable<E> {
 		this._pointEventResolver = undefined;
 		this.audio = undefined;
 		this.operationPluginManager = undefined;
-		this._operationPluginOperated.destroy();
+		this._onOperationPluginOperated.destroy();
+		this._onOperationPluginOperated = undefined;
 		this._operationPluginOperated = undefined;
 		this._idx = 0;
 		this._localDb = {};
@@ -1234,7 +1335,7 @@ export abstract class Game implements Registrable<E> {
 	_loadAndStart(param?: GameMainParameterObject): void {
 		this._mainParameter = param || {};
 		if (!this.isLoaded) {
-			this._loaded.add(this._start, this);
+			this._onLoad.add(this._start, this);
 			this.pushScene(this._initialScene);
 			this._flushSceneChangeRequests();
 		} else {
@@ -1267,11 +1368,11 @@ export abstract class Game implements Registrable<E> {
 			return;
 		}
 
-		this._eventTriggerMap[EventType.Message] = scene.message;
-		this._eventTriggerMap[EventType.PointDown] = scene.pointDownCapture;
-		this._eventTriggerMap[EventType.PointMove] = scene.pointMoveCapture;
-		this._eventTriggerMap[EventType.PointUp] = scene.pointUpCapture;
-		this._eventTriggerMap[EventType.Operation] = scene.operation;
+		this._eventTriggerMap[EventType.Message] = scene.onMessage;
+		this._eventTriggerMap[EventType.PointDown] = scene.onPointDownCapture;
+		this._eventTriggerMap[EventType.PointMove] = scene.onPointMoveCapture;
+		this._eventTriggerMap[EventType.PointUp] = scene.onPointUpCapture;
+		this._eventTriggerMap[EventType.Operation] = scene.onOperation;
 		scene._activate();
 	}
 
@@ -1279,10 +1380,10 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_onInitialSceneLoaded(): void {
-		this._initialScene.loaded.remove(this._onInitialSceneLoaded, this);
+		this._initialScene.onLoad.remove(this._onInitialSceneLoaded, this);
 		this.assets = this._initialScene.assets;
 		this.isLoaded = true;
-		this._loaded.fire();
+		this._onLoad.fire();
 	}
 
 	/**
@@ -1349,7 +1450,7 @@ export abstract class Game implements Registrable<E> {
 		if (scene === this._initialScene)
 			throw ExceptionFactory.createAssertionError("Game#_doPopScene: invalid call; attempting to pop the initial scene");
 		if (!preserveCurrent) scene.destroy();
-		if (fireSceneChanged) this._sceneChanged.fire(this.scene());
+		if (fireSceneChanged) this._onSceneChanged.fire(this.scene());
 	}
 
 	private _start(): void {
@@ -1361,7 +1462,7 @@ export abstract class Game implements Registrable<E> {
 			throw ExceptionFactory.createAssertionError("Game#_start: Entry point '" + this._main + "' not found.");
 		mainFun(this._mainParameter);
 		this._flushSceneChangeRequests(); // シーン遷移を要求する可能性がある(というかまずする)
-		this._started.fire();
+		this._onStart.fire();
 	}
 
 	private _doPushScene(scene: Scene, loadingScene?: LoadingScene): void {
@@ -1377,7 +1478,7 @@ export abstract class Game implements Registrable<E> {
 			loadingScene.reset(scene);
 		} else {
 			// 読み込み待ちのアセットがなければその場で(loadingSceneに任せず)ロード、SceneReadyを発生させてからLoadingSceneEndを起こす。
-			this._sceneChanged.fire(scene);
+			this._onSceneChanged.fire(scene);
 			if (!scene._loaded) {
 				scene._load();
 				this._fireSceneLoaded(scene);

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -364,7 +364,7 @@ export abstract class Game implements Registrable<E> {
 	 * 例えば多人数プレイされている時、それぞれの環境でfireされ方が異なりうる。
 	 * ゲーム開発者は、この通知に起因する処理で、ゲームのグローバルな実行状態を変化させてはならない。
 	 */
-	onSkipChanged: Trigger<boolean>;
+	onSkipChange: Trigger<boolean>;
 
 	/**
 	 * スキップ状態の変化時にfireされるTrigger。
@@ -434,14 +434,14 @@ export abstract class Game implements Registrable<E> {
 
 	/**
 	 * `this.scenes` の変化時にfireされるTrigger。
-	 * このTriggerはアセットロード(Scene#loadedのfire)を待たず、変化した時点で即fireされることに注意。
+	 * このTriggerはアセットロード(Scene#onLoadのfire)を待たず、変化した時点で即fireされることに注意。
 	 * @private
 	 */
-	_onSceneChanged: Trigger<Scene>;
+	_onSceneChange: Trigger<Scene>;
 
 	/**
 	 * `this.scenes` の変化時にfireされるTrigger。
-	 * このTriggerはアセットロード(Scene#loadedのfire)を待たず、変化した時点で即fireされることに注意。
+	 * このTriggerはアセットロード(Scene#onLoadのfire)を待たず、変化した時点で即fireされることに注意。
 	 * @private
 	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
@@ -698,9 +698,9 @@ export abstract class Game implements Registrable<E> {
 		this._eventTriggerMap[EventType.Operation] = undefined;
 
 		this.onResized = new Trigger<CommonSize>();
-		this.onSkipChanged = new Trigger<boolean>();
+		this.onSkipChange = new Trigger<boolean>();
 		this.resized = this.onResized;
-		this.skippingChanged = this.onSkipChanged;
+		this.skippingChanged = this.onSkipChange;
 
 		this.isLastTickLocal = true;
 		this.lastOmittedLocalTickCount = 0;
@@ -735,9 +735,9 @@ export abstract class Game implements Registrable<E> {
 		this._operationPluginOperated = this._onOperationPluginOperated;
 		this.operationPluginManager.onOperate.add(this._onOperationPluginOperated.fire, this._onOperationPluginOperated);
 
-		this._onSceneChanged = new Trigger<Scene>();
-		this._onSceneChanged.add(this._updateEventTriggers, this);
-		this._sceneChanged = this._onSceneChanged;
+		this._onSceneChange = new Trigger<Scene>();
+		this._onSceneChange.add(this._updateEventTriggers, this);
+		this._sceneChanged = this._onSceneChange;
 
 		this._initialScene = new Scene({
 			game: this,
@@ -1186,7 +1186,7 @@ export abstract class Game implements Registrable<E> {
 		this.onLeave.removeAll();
 		this.onSeed.removeAll();
 		this.onResized.removeAll();
-		this.onSkipChanged.removeAll();
+		this.onSkipChange.removeAll();
 
 		this._idx = 0;
 		this._localIdx = 0;
@@ -1286,14 +1286,14 @@ export abstract class Game implements Registrable<E> {
 		this.onResized.destroy();
 		this.onResized = undefined;
 		this.resized = undefined;
-		this.onSkipChanged.destroy();
-		this.onSkipChanged = undefined;
+		this.onSkipChange.destroy();
+		this.onSkipChange = undefined;
 		this.skippingChanged = undefined;
 		this._eventTriggerMap = undefined;
 		this._initialScene = undefined;
 		this._defaultLoadingScene = undefined;
-		this._onSceneChanged.destroy();
-		this._onSceneChanged = undefined;
+		this._onSceneChange.destroy();
+		this._onSceneChange = undefined;
 		this._sceneChanged = undefined;
 		this._onLoad.destroy();
 		this._onLoad = undefined;
@@ -1450,7 +1450,7 @@ export abstract class Game implements Registrable<E> {
 		if (scene === this._initialScene)
 			throw ExceptionFactory.createAssertionError("Game#_doPopScene: invalid call; attempting to pop the initial scene");
 		if (!preserveCurrent) scene.destroy();
-		if (fireSceneChanged) this._onSceneChanged.fire(this.scene());
+		if (fireSceneChanged) this._onSceneChange.fire(this.scene());
 	}
 
 	private _start(): void {
@@ -1478,7 +1478,7 @@ export abstract class Game implements Registrable<E> {
 			loadingScene.reset(scene);
 		} else {
 			// 読み込み待ちのアセットがなければその場で(loadingSceneに任せず)ロード、SceneReadyを発生させてからLoadingSceneEndを起こす。
-			this._onSceneChanged.fire(scene);
+			this._onSceneChange.fire(scene);
 			if (!scene._loaded) {
 				scene._load();
 				this._fireSceneLoaded(scene);

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -189,37 +189,17 @@ export abstract class Game implements Registrable<E> {
 	 */
 	onJoin: Trigger<JoinEvent>;
 	/**
-	 * プレイヤーがゲームに参加したことを表すイベント。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	join: Trigger<JoinEvent>;
-	/**
 	 * プレイヤーがゲームから離脱したことを表すイベント。
 	 */
 	onLeave: Trigger<LeaveEvent>;
-	/**
-	 * プレイヤーがゲームから離脱したことを表すイベント。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	leave: Trigger<LeaveEvent>;
 	/**
 	 * 新しいプレイヤー情報が発生したことを示すイベント。
 	 */
 	onPlayerInfo: Trigger<PlayerInfoEvent>;
 	/**
-	 * 新しいプレイヤー情報が発生したことを示すイベント。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	playerInfo: Trigger<PlayerInfoEvent>;
-	/**
 	 * 新しい乱数シードが発生したことを示すイベント。
 	 */
 	onSeed: Trigger<SeedEvent>;
-	/**
-	 * 新しい乱数シードが発生したことを示すイベント。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	seed: Trigger<SeedEvent>;
 	/**
 	 * このコンテンツの累計経過時間。
 	 * 通常は `this.scene().local` が偽である状態で `tick()` の呼ばれた回数だが、シーン切り替え時等 `tick()` が呼ばれた時以外で加算される事もある。
@@ -293,14 +273,6 @@ export abstract class Game implements Registrable<E> {
 	onSnapshotRequest: Trigger<void>;
 
 	/**
-	 * スナップショット要求通知。
-	 * ゲーム開発者はこれをhandleして可能ならスナップショットを作成しGame#saveSnapshotを呼び出すべきである。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	// NOTE: このクラスはこのTriggerをfireしない。派生クラスがfireせねばならない。
-	snapshotRequest: Trigger<void>;
-
-	/**
 	 * 外部インターフェース。
 	 *
 	 * 実行環境によって、環境依存の値が設定される。
@@ -349,12 +321,6 @@ export abstract class Game implements Registrable<E> {
 	onResized: Trigger<CommonSize>;
 
 	/**
-	 * 画面サイズの変更時にfireされるTrigger。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	resized: Trigger<CommonSize>;
-
-	/**
 	 * スキップ状態の変化時にfireされるTrigger。
 	 *
 	 * スキップ状態に遷移する時に真、非スキップ状態に遷移する時に偽が与えられる。
@@ -365,19 +331,6 @@ export abstract class Game implements Registrable<E> {
 	 * ゲーム開発者は、この通知に起因する処理で、ゲームのグローバルな実行状態を変化させてはならない。
 	 */
 	onSkipChange: Trigger<boolean>;
-
-	/**
-	 * スキップ状態の変化時にfireされるTrigger。
-	 *
-	 * スキップ状態に遷移する時に真、非スキップ状態に遷移する時に偽が与えられる。
-	 * この通知は、ゲーム開発者が「スキップ中の演出省略」などの最適化を行うために提供されている。
-	 *
-	 * この通知のfire頻度は、ゲームの実行状態などに依存して異なりうることに注意。
-	 * 例えば多人数プレイされている時、それぞれの環境でfireされ方が異なりうる。
-	 * ゲーム開発者は、この通知に起因する処理で、ゲームのグローバルな実行状態を変化させてはならない。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	skippingChanged: Trigger<boolean>;
 
 	/**
 	 * 直近の `update` の通知が、ローカルティックによるものか否か。
@@ -407,6 +360,57 @@ export abstract class Game implements Registrable<E> {
 	 * 操作プラグインの管理者。
 	 */
 	operationPluginManager: OperationPluginManager;
+
+	/**
+	 * プレイヤーがゲームに参加したことを表すイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onJoin` を利用すること。
+	 */
+	join: Trigger<JoinEvent>;
+
+	/**
+	 * プレイヤーがゲームから離脱したことを表すイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onLeave` を利用すること。
+	 */
+	leave: Trigger<LeaveEvent>;
+
+	/**
+	 * 新しいプレイヤー情報が発生したことを示すイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPlayerInfo` を利用すること。
+	 */
+	playerInfo: Trigger<PlayerInfoEvent>;
+
+	/**
+	 * 新しい乱数シードが発生したことを示すイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onSeed` を利用すること。
+	 */
+	seed: Trigger<SeedEvent>;
+
+	/**
+	 * スナップショット要求通知。
+	 * ゲーム開発者はこれをhandleして可能ならスナップショットを作成しGame#saveSnapshotを呼び出すべきである。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onSnapshotRequest` を利用すること。
+	 */
+	// NOTE: このクラスはこのTriggerをfireしない。派生クラスがfireせねばならない。
+	snapshotRequest: Trigger<void>;
+
+	/**
+	 * 画面サイズの変更時にfireされるTrigger。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onResized` を利用すること。
+	 */
+	resized: Trigger<CommonSize>;
+
+	/**
+	 * スキップ状態の変化時にfireされるTrigger。
+	 *
+	 * スキップ状態に遷移する時に真、非スキップ状態に遷移する時に偽が与えられる。
+	 * この通知は、ゲーム開発者が「スキップ中の演出省略」などの最適化を行うために提供されている。
+	 *
+	 * この通知のfire頻度は、ゲームの実行状態などに依存して異なりうることに注意。
+	 * 例えば多人数プレイされている時、それぞれの環境でfireされ方が異なりうる。
+	 * ゲーム開発者は、この通知に起因する処理で、ゲームのグローバルな実行状態を変化させてはならない。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onSkipChange` を利用すること。
+	 */
+	skippingChanged: Trigger<boolean>;
 
 	/**
 	 * イベントとTriggerのマップ。
@@ -440,25 +444,10 @@ export abstract class Game implements Registrable<E> {
 	_onSceneChange: Trigger<Scene>;
 
 	/**
-	 * `this.scenes` の変化時にfireされるTrigger。
-	 * このTriggerはアセットロード(Scene#onLoadのfire)を待たず、変化した時点で即fireされることに注意。
-	 * @private
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	_sceneChanged: Trigger<Scene>;
-
-	/**
 	 * グローバルアセットの読み込み待ちハンドラ。
 	 * @private
 	 */
 	_onLoad: Trigger<Game>;
-
-	/**
-	 * グローバルアセットの読み込み待ちハンドラ。
-	 * @private
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	_loaded: Trigger<Game>;
 
 	/**
 	 * _start() 呼び出しから戻る直前を通知するTrigger。
@@ -467,15 +456,6 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_onStart: Trigger<void>;
-
-	/**
-	 * _start() 呼び出しから戻る直前を通知するTrigger。
-	 * エントリポイント実行後のシーン遷移直後にfireされる。
-	 * このTriggerのfireは一度とは限らないことに注意。_loadAndStart()呼び出しの度に一度fireされる。
-	 * @private
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	_started: Trigger<void>;
 
 	/**
 	 * エントリポイント(mainスクリプト)のパス。
@@ -518,13 +498,6 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_onOperationPluginOperated: Trigger<InternalOperationPluginOperation>;
-
-	/**
-	 * 操作プラグインによる操作を通知するTrigger。
-	 * @private
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	_operationPluginOperated: Trigger<InternalOperationPluginOperation>;
 
 	/**
 	 * `this.db` のlastInsertId。
@@ -586,6 +559,36 @@ export abstract class Game implements Registrable<E> {
 	 * @private
 	 */
 	_modified: boolean;
+
+	/**
+	 * グローバルアセットの読み込み待ちハンドラ。
+	 * @private
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `_onLoad` を利用すること。
+	 */
+	_loaded: Trigger<Game>;
+	/**
+	 * `this.scenes` の変化時にfireされるTrigger。
+	 * このTriggerはアセットロード(Scene#onLoadのfire)を待たず、変化した時点で即fireされることに注意。
+	 * @private
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `_onSceneChange` を利用すること。
+	 */
+	_sceneChanged: Trigger<Scene>;
+
+	/**
+	 * _start() 呼び出しから戻る直前を通知するTrigger。
+	 * エントリポイント実行後のシーン遷移直後にfireされる。
+	 * このTriggerのfireは一度とは限らないことに注意。_loadAndStart()呼び出しの度に一度fireされる。
+	 * @private
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `_onStart` を利用すること。
+	 */
+	_started: Trigger<void>;
+
+	/**
+	 * 操作プラグインによる操作を通知するTrigger。
+	 * @private
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `_onOperationPluginOperated` を利用すること。
+	 */
+	_operationPluginOperated: Trigger<InternalOperationPluginOperation>;
 
 	/**
 	 * 実行待ちのシーン遷移要求。
@@ -1252,16 +1255,13 @@ export abstract class Game implements Registrable<E> {
 		this.random = undefined;
 		this.onJoin.destroy();
 		this.onJoin = undefined;
-		this.join = undefined;
 		this.onLeave.destroy();
 		this.onLeave = undefined;
-		this.leave = undefined;
 		this.onSeed.destroy();
 		this.onSeed = undefined;
-		this.seed = undefined;
 		this.onPlayerInfo.destroy();
 		this.onPlayerInfo = undefined;
-		this.playerInfo = undefined;
+
 		this._modified = false;
 		this.age = 0;
 		this.assets = undefined; // this._initialScene.assets のエイリアスなので、特に破棄処理はしない。
@@ -1275,7 +1275,6 @@ export abstract class Game implements Registrable<E> {
 		this.defaultAudioSystemId = undefined;
 		this.onSnapshotRequest.destroy();
 		this.onSnapshotRequest = undefined;
-		this.snapshotRequest = undefined;
 
 		// TODO より能動的にdestroy処理を入れるべきかもしれない
 		this.resourceFactory = undefined;
@@ -1285,22 +1284,17 @@ export abstract class Game implements Registrable<E> {
 		this.operationPlugins = undefined; // this._operationPluginManager.pluginsのエイリアスなので、特に破棄処理はしない。
 		this.onResized.destroy();
 		this.onResized = undefined;
-		this.resized = undefined;
 		this.onSkipChange.destroy();
 		this.onSkipChange = undefined;
-		this.skippingChanged = undefined;
 		this._eventTriggerMap = undefined;
 		this._initialScene = undefined;
 		this._defaultLoadingScene = undefined;
 		this._onSceneChange.destroy();
 		this._onSceneChange = undefined;
-		this._sceneChanged = undefined;
 		this._onLoad.destroy();
 		this._onLoad = undefined;
-		this._loaded = undefined;
 		this._onStart.destroy();
 		this._onStart = undefined;
-		this._started = undefined;
 		this._main = undefined;
 		this._mainParameter = undefined;
 		this._assetManager.destroy();
@@ -1311,7 +1305,6 @@ export abstract class Game implements Registrable<E> {
 		this.operationPluginManager = undefined;
 		this._onOperationPluginOperated.destroy();
 		this._onOperationPluginOperated = undefined;
-		this._operationPluginOperated = undefined;
 		this._idx = 0;
 		this._localDb = {};
 		this._localIdx = 0;
@@ -1322,6 +1315,18 @@ export abstract class Game implements Registrable<E> {
 		this._sceneChangeRequests = [];
 		this.surfaceAtlasSet.destroy();
 		this.surfaceAtlasSet = undefined;
+
+		this.join = undefined;
+		this.leave = undefined;
+		this.seed = undefined;
+		this.playerInfo = undefined;
+		this.snapshotRequest = undefined;
+		this.resized = undefined;
+		this.skippingChanged = undefined;
+		this._sceneChanged = undefined;
+		this._loaded = undefined;
+		this._started = undefined;
+		this._operationPluginOperated = undefined;
 	}
 
 	/**

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -392,12 +392,6 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	onUpdate: Trigger<void>;
 
 	/**
-	 * 時間経過イベント。本イベントの一度のfireにつき、常に1フレーム分の時間経過が起こる。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	update: Trigger<void>;
-
-	/**
 	 * 読み込み完了イベント。
 	 *
 	 * このシーンの生成時に(コンストラクタで)指定されたすべてのアセットの読み込みが終了した後、一度だけfireされる。
@@ -406,30 +400,12 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	onLoad: Trigger<Scene>;
 
 	/**
-	 * 読み込み完了イベント。
-	 *
-	 * このシーンの生成時に(コンストラクタで)指定されたすべてのアセットの読み込みが終了した後、一度だけfireされる。
-	 * このシーンのアセットを利用するすべての処理は、このイベントのfire後に実行されなければならない。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	loaded: Trigger<Scene>;
-
-	/**
 	 * アセット読み込み成功イベント。
 	 *
 	 * このシーンのアセットが一つ読み込まれる度にfireされる。
 	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
 	 */
 	onAssetLoad: Trigger<AssetLike>;
-
-	/**
-	 * アセット読み込み成功イベント。
-	 *
-	 * このシーンのアセットが一つ読み込まれる度にfireされる。
-	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	assetLoaded: Trigger<AssetLike>;
 
 	/**
 	 * アセット読み込み失敗イベント。
@@ -441,31 +417,12 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	onAssetLoadFailure: Trigger<AssetLoadFailureInfo>;
 
 	/**
-	 * アセット読み込み失敗イベント。
-	 *
-	 * このシーンのアセットが一つ読み込みに失敗する度にfireされる。
-	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
-	 * このイベントをhandleする場合、ハンドラは `AssetLoadFailureInfo#cancelRetry` を真にすることでゲーム続行を断念することができる。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	assetLoadFailed: Trigger<AssetLoadFailureInfo>;
-
-	/**
 	 * アセット読み込み完了イベント。
 	 *
 	 * このシーンのアセットが一つ読み込みに失敗または成功する度にfireされる。
 	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
 	 */
 	onAssetLoadComplete: Trigger<AssetLike>;
-
-	/**
-	 * アセット読み込み完了イベント。
-	 *
-	 * このシーンのアセットが一つ読み込みに失敗または成功する度にfireされる。
-	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	assetLoadCompleted: Trigger<AssetLike>;
 
 	/**
 	 * シーンの状態。
@@ -479,22 +436,9 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	onStateChange: Trigger<SceneState>;
 
 	/**
-	 * シーンの状態変更イベント。
-	 * 状態が初期化直後の `Standby` 状態以外に変化するときfireされる。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	stateChanged: Trigger<SceneState>;
-
-	/**
 	 * 汎用メッセージイベント。
 	 */
 	onMessage: Trigger<MessageEvent>;
-
-	/**
-	 * 汎用メッセージイベント。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	message: Trigger<MessageEvent>;
 
 	/**
 	 * シーン内でのpoint downイベント。
@@ -505,30 +449,12 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	onPointDownCapture: Trigger<PointDownEvent>;
 
 	/**
-	 * シーン内でのpoint downイベント。
-	 *
-	 * このイベントは `E#onPointDown` とは独立にfireされる。
-	 * すなわち、シーン内に同じ位置でのpoint downイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	pointDownCapture: Trigger<PointDownEvent>;
-
-	/**
 	 * シーン内でのpoint moveイベント。
 	 *
 	 * このイベントは `E#onPointMove` とは独立にfireされる。
 	 * すなわち、シーン内に同じ位置でのpoint moveイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
 	 */
 	onPointMoveCapture: Trigger<PointMoveEvent>;
-
-	/**
-	 * シーン内でのpoint moveイベント。
-	 *
-	 * このイベントは `E#onPointMove` とは独立にfireされる。
-	 * すなわち、シーン内に同じ位置でのpoint moveイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	pointMoveCapture: Trigger<PointMoveEvent>;
 
 	/**
 	 * シーン内でのpoint upイベント。
@@ -539,29 +465,103 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	onPointUpCapture: Trigger<PointUpEvent>;
 
 	/**
-	 * シーン内でのpoint upイベント。
-	 *
-	 * このイベントは `E#onPointUp` とは独立にfireされる。
-	 * すなわち、シーン内に同じ位置でのpoint upイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	pointUpCapture: Trigger<PointUpEvent>;
-
-	/**
 	 * シーン内での操作イベント。
 	 */
 	onOperation: Trigger<OperationEvent>;
 
 	/**
-	 * シーン内での操作イベント。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	operation: Trigger<OperationEvent>;
-
-	/**
 	 * シーン内で利用可能なストレージの値を保持する `StorageValueStore`。
 	 */
 	storageValues: StorageValueStore;
+
+	/**
+	 * 時間経過イベント。本イベントの一度のfireにつき、常に1フレーム分の時間経過が起こる。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onUpdate` を利用すること。
+	 */
+	update: Trigger<void>;
+
+	/**
+	 * 読み込み完了イベント。
+	 *
+	 * このシーンの生成時に(コンストラクタで)指定されたすべてのアセットの読み込みが終了した後、一度だけfireされる。
+	 * このシーンのアセットを利用するすべての処理は、このイベントのfire後に実行されなければならない。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onLoad` を利用すること。
+	 */
+	loaded: Trigger<Scene>;
+
+	/**
+	 * アセット読み込み成功イベント。
+	 *
+	 * このシーンのアセットが一つ読み込まれる度にfireされる。
+	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onAssetLoad` を利用すること。
+	 */
+	assetLoaded: Trigger<AssetLike>;
+
+	/**
+	 * アセット読み込み失敗イベント。
+	 *
+	 * このシーンのアセットが一つ読み込みに失敗する度にfireされる。
+	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
+	 * このイベントをhandleする場合、ハンドラは `AssetLoadFailureInfo#cancelRetry` を真にすることでゲーム続行を断念することができる。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onAssetLoadFailure` を利用すること。
+	 */
+	assetLoadFailed: Trigger<AssetLoadFailureInfo>;
+
+	/**
+	 * アセット読み込み完了イベント。
+	 *
+	 * このシーンのアセットが一つ読み込みに失敗または成功する度にfireされる。
+	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onAssetLoadComplete` を利用すること。
+	 */
+	assetLoadCompleted: Trigger<AssetLike>;
+
+	/**
+	 * シーンの状態変更イベント。
+	 * 状態が初期化直後の `Standby` 状態以外に変化するときfireされる。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onStateChange` を利用すること。
+	 */
+	stateChanged: Trigger<SceneState>;
+
+	/**
+	 * 汎用メッセージイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onMessage` を利用すること。
+	 */
+	message: Trigger<MessageEvent>;
+
+	/**
+	 * シーン内でのpoint downイベント。
+	 *
+	 * このイベントは `E#onPointDown` とは独立にfireされる。
+	 * すなわち、シーン内に同じ位置でのpoint downイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPointDownCapture` を利用すること。
+	 */
+	pointDownCapture: Trigger<PointDownEvent>;
+
+	/**
+	 * シーン内でのpoint moveイベント。
+	 *
+	 * このイベントは `E#onPointMove` とは独立にfireされる。
+	 * すなわち、シーン内に同じ位置でのpoint moveイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPointMoveCapture` を利用すること。
+	 */
+	pointMoveCapture: Trigger<PointMoveEvent>;
+
+	/**
+	 * シーン内でのpoint upイベント。
+	 *
+	 * このイベントは `E#onPointUp` とは独立にfireされる。
+	 * すなわち、シーン内に同じ位置でのpoint upイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPointUpCapture` を利用すること。
+	 */
+	pointUpCapture: Trigger<PointUpEvent>;
+
+	/**
+	 * シーン内での操作イベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onOperation` を利用すること。
+	 */
+	operation: Trigger<OperationEvent>;
 
 	/**
 	 * @private
@@ -577,7 +577,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	/**
 	 * アセットとストレージの読み込みが終わったことを通知するTrigger。
 	 * @private
-	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `_onReady` を利用すること。
 	 */
 	_ready: Trigger<Scene>;
 

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -171,14 +171,14 @@ export class SceneAssetHolder {
 			error: error,
 			cancelRetry: false
 		};
-		this._scene.assetLoadFailed.fire(failureInfo);
+		this._scene.onAssetLoadFailure.fire(failureInfo);
 		if (error.retriable && !failureInfo.cancelRetry) {
 			this._assetManager.retryLoad(asset);
 		} else {
 			// game.json に定義されていればゲームを止める。それ以外 (DynamicAsset) では続行。
 			if (this._assetManager.configuration[asset.id]) this._scene.game.terminateGame();
 		}
-		this._scene.assetLoadCompleted.fire(asset);
+		this._scene.onAssetLoadComplete.fire(asset);
 	}
 
 	/**
@@ -188,8 +188,8 @@ export class SceneAssetHolder {
 		if (this.destroyed() || this._scene.destroyed()) return;
 
 		this._scene.assets[asset.id] = asset;
-		this._scene.assetLoaded.fire(asset);
-		this._scene.assetLoadCompleted.fire(asset);
+		this._scene.onAssetLoad.fire(asset);
+		this._scene.onAssetLoadComplete.fire(asset);
 		this._assets.push(asset);
 
 		--this.waitingAssetsCount;
@@ -252,7 +252,7 @@ export interface SceneParameterObject {
 	 * * `LocalTickMode.FullLocal` が与えられた場合、このシーンはローカルシーンと呼ばれる。
 	 *   ローカルシーンでは、他プレイヤーと独立な時間進行処理(ローカルティックの消化)が行われる。
 	 * * `LocalTickMode.NonLocal` が与えられた場合、このシーンは非ローカルシーンと呼ばれる。
-	 *   非ローカルシーンでは、他プレイヤーと共通の時間進行処理((非ローカル)ティックの消化)が行われる(updateがfireされる)。
+	 *   非ローカルシーンでは、他プレイヤーと共通の時間進行処理((非ローカル)ティックの消化)が行われる(onUpdateがfireされる)。
 	 *   ローカルティックを消化することはない。
 	 * * `LocalTickMode.InterpolateLocal` が与えられた場合、このシーンはローカルティック補間シーンと呼ばれる。
 	 *   ローカルティック補間シーンでは、非ローカルシーン同様にティックを消化するが、
@@ -356,7 +356,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 * このシーンのローカルティック消化ポリシー。
 	 *
 	 * * `LocalTickMode.NonLocal` が与えられた場合、このシーンは非ローカルシーンと呼ばれる。
-	 *   非ローカルシーンでは、他プレイヤーと共通の時間進行処理((非ローカル)ティックの消化)が行われる(updateがfireされる)。
+	 *   非ローカルシーンでは、他プレイヤーと共通の時間進行処理((非ローカル)ティックの消化)が行われる(onUpdateがfireされる)。
 	 * * `LocalTickMode.FullLocal` が与えられた場合、このシーンはローカルシーンと呼ばれる。
 	 *   ローカルシーンでは、他プレイヤーと独立な時間進行処理(ローカルティックの消化)が行われる。
 	 * * `LocalTickMode.InterpolateLocal` が与えられた場合、このシーンはローカルティック補間シーンと呼ばれる。
@@ -389,6 +389,12 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	/**
 	 * 時間経過イベント。本イベントの一度のfireにつき、常に1フレーム分の時間経過が起こる。
 	 */
+	onUpdate: Trigger<void>;
+
+	/**
+	 * 時間経過イベント。本イベントの一度のfireにつき、常に1フレーム分の時間経過が起こる。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	update: Trigger<void>;
 
 	/**
@@ -397,6 +403,15 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 * このシーンの生成時に(コンストラクタで)指定されたすべてのアセットの読み込みが終了した後、一度だけfireされる。
 	 * このシーンのアセットを利用するすべての処理は、このイベントのfire後に実行されなければならない。
 	 */
+	onLoad: Trigger<Scene>;
+
+	/**
+	 * 読み込み完了イベント。
+	 *
+	 * このシーンの生成時に(コンストラクタで)指定されたすべてのアセットの読み込みが終了した後、一度だけfireされる。
+	 * このシーンのアセットを利用するすべての処理は、このイベントのfire後に実行されなければならない。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	loaded: Trigger<Scene>;
 
 	/**
@@ -404,6 +419,15 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 *
 	 * このシーンのアセットが一つ読み込まれる度にfireされる。
 	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
+	 */
+	onAssetLoad: Trigger<AssetLike>;
+
+	/**
+	 * アセット読み込み成功イベント。
+	 *
+	 * このシーンのアセットが一つ読み込まれる度にfireされる。
+	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	assetLoaded: Trigger<AssetLike>;
 
@@ -414,6 +438,16 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
 	 * このイベントをhandleする場合、ハンドラは `AssetLoadFailureInfo#cancelRetry` を真にすることでゲーム続行を断念することができる。
 	 */
+	onAssetLoadFailure: Trigger<AssetLoadFailureInfo>;
+
+	/**
+	 * アセット読み込み失敗イベント。
+	 *
+	 * このシーンのアセットが一つ読み込みに失敗する度にfireされる。
+	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
+	 * このイベントをhandleする場合、ハンドラは `AssetLoadFailureInfo#cancelRetry` を真にすることでゲーム続行を断念することができる。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	assetLoadFailed: Trigger<AssetLoadFailureInfo>;
 
 	/**
@@ -421,6 +455,15 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 *
 	 * このシーンのアセットが一つ読み込みに失敗または成功する度にfireされる。
 	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
+	 */
+	onAssetLoadComplete: Trigger<AssetLike>;
+
+	/**
+	 * アセット読み込み完了イベント。
+	 *
+	 * このシーンのアセットが一つ読み込みに失敗または成功する度にfireされる。
+	 * アセット読み込み中の動作をカスタマイズしたい場合に用いる。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	assetLoadCompleted: Trigger<AssetLike>;
 
@@ -433,39 +476,85 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 * シーンの状態変更イベント。
 	 * 状態が初期化直後の `Standby` 状態以外に変化するときfireされる。
 	 */
+	onStateChange: Trigger<SceneState>;
+
+	/**
+	 * シーンの状態変更イベント。
+	 * 状態が初期化直後の `Standby` 状態以外に変化するときfireされる。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	stateChanged: Trigger<SceneState>;
 
 	/**
 	 * 汎用メッセージイベント。
+	 */
+	onMessage: Trigger<MessageEvent>;
+
+	/**
+	 * 汎用メッセージイベント。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	message: Trigger<MessageEvent>;
 
 	/**
 	 * シーン内でのpoint downイベント。
 	 *
-	 * このイベントは `E#pointDown` とは独立にfireされる。
+	 * このイベントは `E#onPointDown` とは独立にfireされる。
 	 * すなわち、シーン内に同じ位置でのpoint downイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
+	 */
+	onPointDownCapture: Trigger<PointDownEvent>;
+
+	/**
+	 * シーン内でのpoint downイベント。
+	 *
+	 * このイベントは `E#onPointDown` とは独立にfireされる。
+	 * すなわち、シーン内に同じ位置でのpoint downイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	pointDownCapture: Trigger<PointDownEvent>;
 
 	/**
 	 * シーン内でのpoint moveイベント。
 	 *
-	 * このイベントは `E#pointMove` とは独立にfireされる。
+	 * このイベントは `E#onPointMove` とは独立にfireされる。
 	 * すなわち、シーン内に同じ位置でのpoint moveイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
+	 */
+	onPointMoveCapture: Trigger<PointMoveEvent>;
+
+	/**
+	 * シーン内でのpoint moveイベント。
+	 *
+	 * このイベントは `E#onPointMove` とは独立にfireされる。
+	 * すなわち、シーン内に同じ位置でのpoint moveイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	pointMoveCapture: Trigger<PointMoveEvent>;
 
 	/**
 	 * シーン内でのpoint upイベント。
 	 *
-	 * このイベントは `E#pointUp` とは独立にfireされる。
+	 * このイベントは `E#onPointUp` とは独立にfireされる。
 	 * すなわち、シーン内に同じ位置でのpoint upイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
+	 */
+	onPointUpCapture: Trigger<PointUpEvent>;
+
+	/**
+	 * シーン内でのpoint upイベント。
+	 *
+	 * このイベントは `E#onPointUp` とは独立にfireされる。
+	 * すなわち、シーン内に同じ位置でのpoint upイベントに反応する `E` がある場合もない場合もこのイベントはfireされる。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	pointUpCapture: Trigger<PointUpEvent>;
 
 	/**
 	 * シーン内での操作イベント。
+	 */
+	onOperation: Trigger<OperationEvent>;
+
+	/**
+	 * シーン内での操作イベント。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	operation: Trigger<OperationEvent>;
 
@@ -483,22 +572,29 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 * アセットとストレージの読み込みが終わったことを通知するTrigger。
 	 * @private
 	 */
+	_onReady: Trigger<Scene>;
+
+	/**
+	 * アセットとストレージの読み込みが終わったことを通知するTrigger。
+	 * @private
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	_ready: Trigger<Scene>;
 
 	/**
 	 * 読み込みが開始されたか否か。
 	 * すなわち、 `_load()` が呼び出された後か否か。
 	 *
-	 * 歴史的経緯により、このフラグの意味は「読み込みが終わった後」でも「loadedがfireされた後」でもない点に注意。
+	 * 歴史的経緯により、このフラグの意味は「読み込みが終わった後」でも「onLoadがfireされた後」でもない点に注意。
 	 * なお前者「(アセットとストレージの)読み込みが終わった後」は `_loadingState === SceneLoadState.Ready` に与えられる。
 	 *
 	 * シーンの読み込みは概ね次の順で処理が進行する。
 	 * * `_loaded` が真になる
 	 * * 各種読み込みが完了する
 	 * * `_loadingState` が `SceneLoadState.Ready` になる
-	 * * `_ready` がfireされる
+	 * * `_onReady` がfireされる
 	 * * `_loadingState` が `SceneLoadState.ReadyFired` になる
-	 * * `loaded` がfireされる
+	 * * `onLoad` がfireされる
 	 * * `_loadingState` が `SceneLoadState.LoadedFired` になる
 	 * @private
 	 */
@@ -513,7 +609,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 
 	/**
 	 * アセットとストレージの読み込みが終わった後か否か。
-	 * 「 `loaded` がfireされた後」ではない点に注意。
+	 * 「 `onLoad` がfireされた後」ではない点に注意。
 	 * @private
 	 */
 	_loadingState: SceneLoadState;
@@ -565,8 +661,10 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 		this.local = local;
 		this.tickGenerationMode = tickGenerationMode;
 
-		this.loaded = new Trigger<Scene>();
-		this._ready = new Trigger<Scene>();
+		this.onLoad = new Trigger<Scene>();
+		this.loaded = this.onLoad;
+		this._onReady = new Trigger<Scene>();
+		this._ready = this._onReady;
 		this.assets = {};
 		this.asset = new AssetAccessor(game._assetManager);
 
@@ -574,22 +672,32 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 		this._prefetchRequested = false;
 		this._loadingState = SceneLoadState.Initial;
 
-		this.update = new Trigger<void>();
-		this._timer = new TimerManager(this.update, this.game.fps);
+		this.onUpdate = new Trigger<void>();
+		this.update = this.onUpdate;
+		this._timer = new TimerManager(this.onUpdate, this.game.fps);
 
-		this.assetLoaded = new Trigger<AssetLike>();
-		this.assetLoadFailed = new Trigger<AssetLoadFailureInfo>();
-		this.assetLoadCompleted = new Trigger<AssetLike>();
+		this.onAssetLoad = new Trigger<AssetLike>();
+		this.onAssetLoadFailure = new Trigger<AssetLoadFailureInfo>();
+		this.onAssetLoadComplete = new Trigger<AssetLike>();
+		this.assetLoaded = this.onAssetLoad;
+		this.assetLoadFailed = this.onAssetLoadFailure;
+		this.assetLoadCompleted = this.onAssetLoadComplete;
 
-		this.message = new Trigger<MessageEvent>();
-		this.pointDownCapture = new Trigger<PointDownEvent>();
-		this.pointMoveCapture = new Trigger<PointMoveEvent>();
-		this.pointUpCapture = new Trigger<PointUpEvent>();
-		this.operation = new Trigger<OperationEvent>();
+		this.onMessage = new Trigger<MessageEvent>();
+		this.onPointDownCapture = new Trigger<PointDownEvent>();
+		this.onPointMoveCapture = new Trigger<PointMoveEvent>();
+		this.onPointUpCapture = new Trigger<PointUpEvent>();
+		this.onOperation = new Trigger<OperationEvent>();
+		this.message = this.onMessage;
+		this.pointDownCapture = this.onPointDownCapture;
+		this.pointMoveCapture = this.onPointMoveCapture;
+		this.pointUpCapture = this.onPointUpCapture;
+		this.operation = this.onOperation;
 
 		this.children = [];
 		this.state = SceneState.Standby;
-		this.stateChanged = new Trigger<SceneState>();
+		this.onStateChange = new Trigger<SceneState>();
+		this.stateChanged = this.onStateChange;
 
 		this._assetHolders = [];
 		this._sceneAssetHolder = new SceneAssetHolder({
@@ -617,8 +725,8 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	/**
 	 * このシーンを破棄する。
 	 *
-	 * 破棄処理の開始時に、このシーンの `stateChanged` が引数 `BeforeDestroyed` でfireされる。
-	 * 破棄処理の終了時に、このシーンの `stateChanged` が引数 `Destroyed` でfireされる。
+	 * 破棄処理の開始時に、このシーンの `onStateChange` が引数 `BeforeDestroyed` でfireされる。
+	 * 破棄処理の終了時に、このシーンの `onStateChange` が引数 `Destroyed` でfireされる。
 	 * このシーンに紐づいている全ての `E` と全てのTimerは破棄される。
 	 * `Scene#setInterval()`, `Scene#setTimeout()` に渡された関数は呼び出されなくなる。
 	 *
@@ -627,7 +735,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 */
 	destroy(): void {
 		this.state = SceneState.BeforeDestroyed;
-		this.stateChanged.fire(this.state);
+		this.onStateChange.fire(this.state);
 
 		// TODO: (GAMEDEV-483) Sceneスタックがそれなりの量になると重くなるのでScene#dbが必要かもしれない
 		var gameDb = this.game.db;
@@ -640,16 +748,16 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 		}
 
 		this._timer.destroy();
-		this.update.destroy();
-		this.message.destroy();
-		this.pointDownCapture.destroy();
-		this.pointMoveCapture.destroy();
-		this.pointUpCapture.destroy();
-		this.operation.destroy();
-		this.loaded.destroy();
-		this.assetLoaded.destroy();
-		this.assetLoadFailed.destroy();
-		this.assetLoadCompleted.destroy();
+		this.onUpdate.destroy();
+		this.onMessage.destroy();
+		this.onPointDownCapture.destroy();
+		this.onPointMoveCapture.destroy();
+		this.onPointUpCapture.destroy();
+		this.onOperation.destroy();
+		this.onLoad.destroy();
+		this.onAssetLoad.destroy();
+		this.onAssetLoadFailure.destroy();
+		this.onAssetLoadComplete.destroy();
 		this.assets = {};
 
 		// アセットを参照しているEより先に解放しないよう最後に解放する
@@ -661,8 +769,8 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 		this.game = undefined;
 
 		this.state = SceneState.Destroyed;
-		this.stateChanged.fire(this.state);
-		this.stateChanged.destroy();
+		this.onStateChange.fire(this.state);
+		this.onStateChange.destroy();
 	}
 
 	/**
@@ -677,7 +785,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 *
 	 * 戻り値は作成されたTimerである。
 	 * 通常は `Scene#setInterval` を利用すればよく、ゲーム開発者がこのメソッドを呼び出す必要はない。
-	 * `Timer` はフレーム経過処理(`Scene#update`)で実現される疑似的なタイマーである。実時間の影響は受けない。
+	 * `Timer` はフレーム経過処理(`Scene#onUpdate`)で実現される疑似的なタイマーである。実時間の影響は受けない。
 	 * @param interval Timerの実行間隔（ミリ秒）
 	 */
 	createTimer(interval: number): Timer {
@@ -697,7 +805,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 *
 	 * `interval` ミリ秒おきに `owner` を `this` として `handler` を呼び出す。
 	 * 戻り値は `Scene#clearInterval` の引数に指定して定期実行を解除するために使える値である。
-	 * このタイマーはフレーム経過処理(`Scene#update`)で実現される疑似的なタイマーである。実時間の影響は受けない。
+	 * このタイマーはフレーム経過処理(`Scene#onUpdate`)で実現される疑似的なタイマーである。実時間の影響は受けない。
 	 * 関数は指定時間の経過直後ではなく、経過後最初のフレームで呼び出される。
 	 * @param handler 処理
 	 * @param interval 実行間隔(ミリ秒)
@@ -721,10 +829,10 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 * `milliseconds` ミリ秒後(以降)に、一度だけ `owner` を `this` として `handler` を呼び出す。
 	 * 戻り値は `Scene#clearTimeout` の引数に指定して処理を削除するために使える値である。
 	 *
-	 * このタイマーはフレーム経過処理(`Scene#update`)で実現される疑似的なタイマーである。実時間の影響は受けない。
+	 * このタイマーはフレーム経過処理(`Scene#onUpdate`)で実現される疑似的なタイマーである。実時間の影響は受けない。
 	 * 関数は指定時間の経過直後ではなく、経過後最初のフレームで呼び出される。
 	 * (理想的なケースでは、30FPSなら50msのコールバックは66.6ms時点で呼び出される)
-	 * 時間経過に対して厳密な処理を行う必要があれば、自力で `Scene#update` 通知を処理すること。
+	 * 時間経過に対して厳密な処理を行う必要があれば、自力で `Scene#onUpdate` 通知を処理すること。
 	 *
 	 * @param handler 処理
 	 * @param milliseconds 時間(ミリ秒)
@@ -923,7 +1031,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 */
 	_activate(): void {
 		this.state = SceneState.Active;
-		this.stateChanged.fire(this.state);
+		this.onStateChange.fire(this.state);
 	}
 
 	/**
@@ -931,7 +1039,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 */
 	_deactivate(): void {
 		this.state = SceneState.Deactive;
-		this.stateChanged.fire(this.state);
+		this.onStateChange.fire(this.state);
 	}
 
 	/**
@@ -991,7 +1099,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 * @private
 	 */
 	_notifySceneReady(): void {
-		// 即座に `_ready` をfireすることはしない。tick()のタイミングで行うため、リクエストをgameに投げておく。
+		// 即座に `_onReady` をfireすることはしない。tick()のタイミングで行うため、リクエストをgameに投げておく。
 		this._loadingState = SceneLoadState.Ready;
 		this.game._fireSceneReady(this);
 	}
@@ -1000,7 +1108,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 * @private
 	 */
 	_fireReady(): void {
-		this._ready.fire(this);
+		this._onReady.fire(this);
 		this._loadingState = SceneLoadState.ReadyFired;
 	}
 
@@ -1008,7 +1116,7 @@ export class Scene implements Destroyable, Registrable<E>, StorageLoaderHandler 
 	 * @private
 	 */
 	_fireLoaded(): void {
-		this.loaded.fire(this);
+		this.onLoad.fire(this);
 		this._loadingState = SceneLoadState.LoadedFired;
 	}
 }

--- a/src/__tests__/AudioPlayerSpec.ts
+++ b/src/__tests__/AudioPlayerSpec.ts
@@ -7,8 +7,8 @@ describe("test AudioPlayer", () => {
 		const system = game.audio.music;
 		const player = system.createPlayer();
 		expect(player.volume).toBe(system.volume);
-		expect(player.played.constructor).toBe(Trigger);
-		expect(player.stopped.constructor).toBe(Trigger);
+		expect(player.onPlay.constructor).toBe(Trigger);
+		expect(player.onStop.constructor).toBe(Trigger);
 		expect(player.currentAudio).toBeUndefined();
 	});
 
@@ -18,8 +18,8 @@ describe("test AudioPlayer", () => {
 		system.volume = 0.5;
 		const player = system.createPlayer();
 		expect(player.volume).toBe(system.volume);
-		expect(player.played.constructor).toBe(Trigger);
-		expect(player.stopped.constructor).toBe(Trigger);
+		expect(player.onPlay.constructor).toBe(Trigger);
+		expect(player.onStop.constructor).toBe(Trigger);
 		expect(player.currentAudio).toBeUndefined();
 	});
 });

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -115,10 +115,10 @@ describe("test AudioPlayer", () => {
 			stoppedCalled = 0;
 		}
 
-		player1.played.add(() => {
+		player1.onPlay.add(() => {
 			++playedCalled;
 		});
-		player1.stopped.add(() => {
+		player1.onStop.add(() => {
 			++stoppedCalled;
 		});
 
@@ -161,10 +161,10 @@ describe("test AudioPlayer", () => {
 			stoppedCalled = 0;
 		}
 
-		player1.played.add(() => {
+		player1.onPlay.add(() => {
 			++playedCalled;
 		});
-		player1.stopped.add(() => {
+		player1.onStop.add(() => {
 			++stoppedCalled;
 		});
 
@@ -183,7 +183,7 @@ describe("test AudioPlayer", () => {
 		// 再生速度が非等倍の状態で再生された場合、ミュートとなる
 		const player2 = system.createPlayer() as AudioPlayer;
 		resetCalledCount();
-		player2.played.add(() => {
+		player2.onPlay.add(() => {
 			++playedCalled;
 		});
 		player2.play(asset);

--- a/src/__tests__/ESpec.ts
+++ b/src/__tests__/ESpec.ts
@@ -333,19 +333,19 @@ describe("test E", () => {
 		e.onPointUp.add(() => {
 			/* do nothing */
 		});
-		expect((e as any)._onMessage).toBeDefined();
-		expect((e as any)._onPointDown).toBeDefined();
-		expect((e as any)._onPointMove).toBeDefined();
-		expect((e as any)._onPointUp).toBeDefined();
+		expect((e as any)._message).toBeDefined();
+		expect((e as any)._pointDown).toBeDefined();
+		expect((e as any)._pointMove).toBeDefined();
+		expect((e as any)._pointUp).toBeDefined();
 
 		e.destroy();
 		expect(e.parent).toBe(undefined);
 		expect(e.destroyed()).toBe(true);
 		expect(e.children).toBe(undefined);
-		expect((e as any)._onMessage).toBeUndefined();
-		expect((e as any)._onPointDown).toBeUndefined();
-		expect((e as any)._onPointMove).toBeUndefined();
-		expect((e as any)._onPointUp).toBeUndefined();
+		expect((e as any)._message).toBeUndefined();
+		expect((e as any)._pointDown).toBeUndefined();
+		expect((e as any)._pointMove).toBeUndefined();
+		expect((e as any)._pointUp).toBeUndefined();
 	});
 
 	it("modified", () => {
@@ -379,14 +379,14 @@ describe("test E", () => {
 	});
 
 	it("update", () => {
-		expect((e as any)._onUpdate).toBeUndefined();
+		expect((e as any)._update).toBeUndefined();
 		expect(runtime.scene.onUpdate.length > 0).toBe(false);
 		runtime.game.tick(true);
 
 		// auto chain
 		expect(e.onUpdate).not.toBeUndefined();
-		expect((e as any)._onUpdate).not.toBeUndefined();
-		expect((e as any)._onUpdate.chain).not.toBeUndefined();
+		expect((e as any)._update).not.toBeUndefined();
+		expect((e as any)._update.chain).not.toBeUndefined();
 		expect(runtime.scene.onUpdate.length > 0).toBe(false);
 
 		runtime.game.tick(true);
@@ -429,11 +429,11 @@ describe("test E", () => {
 	});
 
 	it("operate", () => {
-		expect((e as any)._onPointDown).toBeUndefined();
+		expect((e as any)._pointDown).toBeUndefined();
 		expect(runtime.scene.onPointDownCapture.length > 0).toBe(false);
 		expect(e.onPointDown).not.toBeUndefined();
-		expect((e as any)._onPointDown).not.toBeUndefined();
-		expect((e as any)._onPointDown.chain).not.toBeUndefined();
+		expect((e as any)._pointDown).not.toBeUndefined();
+		expect((e as any)._pointDown.chain).not.toBeUndefined();
 		expect(runtime.scene.onPointDownCapture.length > 0).toBe(false);
 
 		const operationTick = () => {
@@ -759,11 +759,11 @@ describe("test E", () => {
 	it("get update", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._onUpdate).toBeUndefined();
+		expect((e as any)._update).toBeUndefined();
 
 		const u = e.onUpdate;
 
-		expect((e as any)._onUpdate).toBe(u);
+		expect((e as any)._update).toBe(u);
 		expect(e.onUpdate).toBe(u);
 
 		let firedFlg = false;
@@ -781,11 +781,11 @@ describe("test E", () => {
 	it("get message", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._onMessage).toBeUndefined();
+		expect((e as any)._message).toBeUndefined();
 
 		const m = e.onMessage;
 
-		expect((e as any)._onMessage).toBe(m);
+		expect((e as any)._message).toBe(m);
 		expect(e.onMessage).toBe(m);
 
 		let firedFlg = false;
@@ -803,11 +803,11 @@ describe("test E", () => {
 	it("get pointDown", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._onPointDown).toBeUndefined();
+		expect((e as any)._pointDown).toBeUndefined();
 
 		const p = e.onPointDown;
 
-		expect((e as any)._onPointDown).toBe(p);
+		expect((e as any)._pointDown).toBe(p);
 		expect(e.onPointDown).toBe(p);
 
 		let firedFlg = false;
@@ -825,11 +825,11 @@ describe("test E", () => {
 	it("get pointUp", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._onPointUp).toBeUndefined();
+		expect((e as any)._pointUp).toBeUndefined();
 
 		const p = e.onPointUp;
 
-		expect((e as any)._onPointUp).toBe(p);
+		expect((e as any)._pointUp).toBe(p);
 		expect(e.onPointUp).toBe(p);
 
 		let firedFlg = false;
@@ -847,11 +847,11 @@ describe("test E", () => {
 	it("get pointMove", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._onPointMove).toBeUndefined();
+		expect((e as any)._pointMove).toBeUndefined();
 
 		const p = e.onPointMove;
 
-		expect((e as any)._onPointMove).toBe(p);
+		expect((e as any)._pointMove).toBe(p);
 		expect(e.onPointMove).toBe(p);
 
 		let firedFlg = false;

--- a/src/__tests__/ESpec.ts
+++ b/src/__tests__/ESpec.ts
@@ -321,31 +321,31 @@ describe("test E", () => {
 	});
 
 	it("destroy - has handles", () => {
-		e.message.add(() => {
+		e.onMessage.add(() => {
 			/* do nothing */
 		});
-		e.pointDown.add(() => {
+		e.onPointDown.add(() => {
 			/* do nothing */
 		});
-		e.pointMove.add(() => {
+		e.onPointMove.add(() => {
 			/* do nothing */
 		});
-		e.pointUp.add(() => {
+		e.onPointUp.add(() => {
 			/* do nothing */
 		});
-		expect((e as any)._message).toBeDefined();
-		expect((e as any)._pointDown).toBeDefined();
-		expect((e as any)._pointMove).toBeDefined();
-		expect((e as any)._pointUp).toBeDefined();
+		expect((e as any)._onMessage).toBeDefined();
+		expect((e as any)._onPointDown).toBeDefined();
+		expect((e as any)._onPointMove).toBeDefined();
+		expect((e as any)._onPointUp).toBeDefined();
 
 		e.destroy();
 		expect(e.parent).toBe(undefined);
 		expect(e.destroyed()).toBe(true);
 		expect(e.children).toBe(undefined);
-		expect((e as any)._message).toBeUndefined();
-		expect((e as any)._pointDown).toBeUndefined();
-		expect((e as any)._pointMove).toBeUndefined();
-		expect((e as any)._pointUp).toBeUndefined();
+		expect((e as any)._onMessage).toBeUndefined();
+		expect((e as any)._onPointDown).toBeUndefined();
+		expect((e as any)._onPointMove).toBeUndefined();
+		expect((e as any)._onPointUp).toBeUndefined();
 	});
 
 	it("modified", () => {
@@ -379,25 +379,25 @@ describe("test E", () => {
 	});
 
 	it("update", () => {
-		expect((e as any)._update).toBeUndefined();
-		expect(runtime.scene.update.length > 0).toBe(false);
+		expect((e as any)._onUpdate).toBeUndefined();
+		expect(runtime.scene.onUpdate.length > 0).toBe(false);
 		runtime.game.tick(true);
 
 		// auto chain
-		expect(e.update).not.toBeUndefined();
-		expect((e as any)._update).not.toBeUndefined();
-		expect((e as any)._update.chain).not.toBeUndefined();
-		expect(runtime.scene.update.length > 0).toBe(false);
+		expect(e.onUpdate).not.toBeUndefined();
+		expect((e as any)._onUpdate).not.toBeUndefined();
+		expect((e as any)._onUpdate.chain).not.toBeUndefined();
+		expect(runtime.scene.onUpdate.length > 0).toBe(false);
 
 		runtime.game.tick(true);
 
 		let estate = false;
 		let esuccess = false;
-		e.update.add(() => {
+		e.onUpdate.add(() => {
 			if (!estate) fail("efail");
 			esuccess = true;
 		});
-		expect(runtime.scene.update.length > 0).toBe(true);
+		expect(runtime.scene.onUpdate.length > 0).toBe(true);
 
 		estate = true;
 		runtime.game.tick(true);
@@ -423,18 +423,18 @@ describe("test E", () => {
 		runtime.game._flushSceneChangeRequests();
 		estate = false;
 
-		expect(scene3.update.length > 0).toBe(false);
-		expect(runtime.scene.update.destroyed()).toBe(true);
+		expect(scene3.onUpdate.length > 0).toBe(false);
+		expect(runtime.scene.onUpdate.destroyed()).toBe(true);
 		runtime.game.tick(true);
 	});
 
 	it("operate", () => {
-		expect((e as any)._pointDown).toBeUndefined();
-		expect(runtime.scene.pointDownCapture.length > 0).toBe(false);
-		expect(e.pointDown).not.toBeUndefined();
-		expect((e as any)._pointDown).not.toBeUndefined();
-		expect((e as any)._pointDown.chain).not.toBeUndefined();
-		expect(runtime.scene.pointDownCapture.length > 0).toBe(false);
+		expect((e as any)._onPointDown).toBeUndefined();
+		expect(runtime.scene.onPointDownCapture.length > 0).toBe(false);
+		expect(e.onPointDown).not.toBeUndefined();
+		expect((e as any)._onPointDown).not.toBeUndefined();
+		expect((e as any)._onPointDown.chain).not.toBeUndefined();
+		expect(runtime.scene.onPointDownCapture.length > 0).toBe(false);
 
 		const operationTick = () => {
 			const event = runtime.game._pointEventResolver.pointDown({
@@ -447,7 +447,7 @@ describe("test E", () => {
 
 		let estate = false;
 		let esuccess = false;
-		e.pointDown.add(() => {
+		e.onPointDown.add(() => {
 			if (!estate) fail("efail");
 			esuccess = true;
 		});
@@ -479,7 +479,7 @@ describe("test E", () => {
 		runtime.game._flushSceneChangeRequests();
 		estate = false;
 
-		expect(runtime.scene.pointDownCapture.destroyed()).toBe(true);
+		expect(runtime.scene.onPointDownCapture.destroyed()).toBe(true);
 		operationTick();
 	});
 
@@ -759,12 +759,12 @@ describe("test E", () => {
 	it("get update", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._update).toBeUndefined();
+		expect((e as any)._onUpdate).toBeUndefined();
 
-		const u = e.update;
+		const u = e.onUpdate;
 
-		expect((e as any)._update).toBe(u);
-		expect(e.update).toBe(u);
+		expect((e as any)._onUpdate).toBe(u);
+		expect(e.onUpdate).toBe(u);
 
 		let firedFlg = false;
 		u.add(() => {
@@ -781,12 +781,12 @@ describe("test E", () => {
 	it("get message", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._message).toBeUndefined();
+		expect((e as any)._onMessage).toBeUndefined();
 
-		const m = e.message;
+		const m = e.onMessage;
 
-		expect((e as any)._message).toBe(m);
-		expect(e.message).toBe(m);
+		expect((e as any)._onMessage).toBe(m);
+		expect(e.onMessage).toBe(m);
 
 		let firedFlg = false;
 		m.add(() => {
@@ -803,12 +803,12 @@ describe("test E", () => {
 	it("get pointDown", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._pointDown).toBeUndefined();
+		expect((e as any)._onPointDown).toBeUndefined();
 
-		const p = e.pointDown;
+		const p = e.onPointDown;
 
-		expect((e as any)._pointDown).toBe(p);
-		expect(e.pointDown).toBe(p);
+		expect((e as any)._onPointDown).toBe(p);
+		expect(e.onPointDown).toBe(p);
 
 		let firedFlg = false;
 		p.add(() => {
@@ -825,12 +825,12 @@ describe("test E", () => {
 	it("get pointUp", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._pointUp).toBeUndefined();
+		expect((e as any)._onPointUp).toBeUndefined();
 
-		const p = e.pointUp;
+		const p = e.onPointUp;
 
-		expect((e as any)._pointUp).toBe(p);
-		expect(e.pointUp).toBe(p);
+		expect((e as any)._onPointUp).toBe(p);
+		expect(e.onPointUp).toBe(p);
 
 		let firedFlg = false;
 		p.add(() => {
@@ -847,12 +847,12 @@ describe("test E", () => {
 	it("get pointMove", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._pointMove).toBeUndefined();
+		expect((e as any)._onPointMove).toBeUndefined();
 
-		const p = e.pointMove;
+		const p = e.onPointMove;
 
-		expect((e as any)._pointMove).toBe(p);
-		expect(e.pointMove).toBe(p);
+		expect((e as any)._onPointMove).toBe(p);
+		expect(e.onPointMove).toBe(p);
 
 		let firedFlg = false;
 		p.add(() => {

--- a/src/__tests__/ESpec.ts
+++ b/src/__tests__/ESpec.ts
@@ -333,19 +333,19 @@ describe("test E", () => {
 		e.onPointUp.add(() => {
 			/* do nothing */
 		});
-		expect((e as any)._message).toBeDefined();
-		expect((e as any)._pointDown).toBeDefined();
-		expect((e as any)._pointMove).toBeDefined();
-		expect((e as any)._pointUp).toBeDefined();
+		expect((e as any)._onMessage).toBeDefined();
+		expect((e as any)._onPointDown).toBeDefined();
+		expect((e as any)._onPointMove).toBeDefined();
+		expect((e as any)._onPointUp).toBeDefined();
 
 		e.destroy();
 		expect(e.parent).toBe(undefined);
 		expect(e.destroyed()).toBe(true);
 		expect(e.children).toBe(undefined);
-		expect((e as any)._message).toBeUndefined();
-		expect((e as any)._pointDown).toBeUndefined();
-		expect((e as any)._pointMove).toBeUndefined();
-		expect((e as any)._pointUp).toBeUndefined();
+		expect((e as any)._onMessage).toBeUndefined();
+		expect((e as any)._onPointDown).toBeUndefined();
+		expect((e as any)._onPointMove).toBeUndefined();
+		expect((e as any)._onPointUp).toBeUndefined();
 	});
 
 	it("modified", () => {
@@ -429,11 +429,11 @@ describe("test E", () => {
 	});
 
 	it("operate", () => {
-		expect((e as any)._pointDown).toBeUndefined();
+		expect((e as any)._onPointDown).toBeUndefined();
 		expect(runtime.scene.onPointDownCapture.length > 0).toBe(false);
 		expect(e.onPointDown).not.toBeUndefined();
-		expect((e as any)._pointDown).not.toBeUndefined();
-		expect((e as any)._pointDown.chain).not.toBeUndefined();
+		expect((e as any)._onPointDown).not.toBeUndefined();
+		expect((e as any)._onPointDown.chain).not.toBeUndefined();
 		expect(runtime.scene.onPointDownCapture.length > 0).toBe(false);
 
 		const operationTick = () => {
@@ -781,11 +781,11 @@ describe("test E", () => {
 	it("get message", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._message).toBeUndefined();
+		expect((e as any)._onMessage).toBeUndefined();
 
 		const m = e.onMessage;
 
-		expect((e as any)._message).toBe(m);
+		expect((e as any)._onMessage).toBe(m);
 		expect(e.onMessage).toBe(m);
 
 		let firedFlg = false;
@@ -803,11 +803,11 @@ describe("test E", () => {
 	it("get pointDown", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._pointDown).toBeUndefined();
+		expect((e as any)._onPointDown).toBeUndefined();
 
 		const p = e.onPointDown;
 
-		expect((e as any)._pointDown).toBe(p);
+		expect((e as any)._onPointDown).toBe(p);
 		expect(e.onPointDown).toBe(p);
 
 		let firedFlg = false;
@@ -825,11 +825,11 @@ describe("test E", () => {
 	it("get pointUp", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._pointUp).toBeUndefined();
+		expect((e as any)._onPointUp).toBeUndefined();
 
 		const p = e.onPointUp;
 
-		expect((e as any)._pointUp).toBe(p);
+		expect((e as any)._onPointUp).toBe(p);
 		expect(e.onPointUp).toBe(p);
 
 		let firedFlg = false;
@@ -847,11 +847,11 @@ describe("test E", () => {
 	it("get pointMove", () => {
 		const e = new E({ scene: runtime.scene });
 
-		expect((e as any)._pointMove).toBeUndefined();
+		expect((e as any)._onPointMove).toBeUndefined();
 
 		const p = e.onPointMove;
 
-		expect((e as any)._pointMove).toBe(p);
+		expect((e as any)._onPointMove).toBe(p);
 		expect(e.onPointMove).toBe(p);
 
 		let firedFlg = false;

--- a/src/__tests__/FrameSpriteSpec.ts
+++ b/src/__tests__/FrameSpriteSpec.ts
@@ -196,7 +196,7 @@ describe("test FrameSprite", () => {
 			loop: true
 		});
 		let isFired = false;
-		sprite.finished.add(() => {
+		sprite.onFinish.add(() => {
 			isFired = true;
 		});
 		sprite.start();
@@ -232,7 +232,7 @@ describe("test FrameSprite", () => {
 			loop: false
 		});
 		let isFired = false;
-		sprite.finished.add(() => {
+		sprite.onFinish.add(() => {
 			isFired = true;
 		});
 		sprite.start();

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -35,7 +35,7 @@ describe("test Game", () => {
 		expect(game.height).toBe(270);
 		expect(game.selfId).toBe("foo");
 		expect(game.playId).toBe(undefined);
-		expect(game.onSkipChanged).not.toBe(undefined);
+		expect(game.onSkipChange).not.toBe(undefined);
 		expect(game).toHaveProperty("_assetManager");
 		expect(game).toHaveProperty("_initialScene");
 	});
@@ -51,7 +51,7 @@ describe("test Game", () => {
 		expect(game.external).toEqual({}); // external は触らない
 		expect(game.vars).toEqual({}); // vars も触らない
 		expect(game.playId).toBe(undefined);
-		expect(game.onSkipChanged).toBe(undefined);
+		expect(game.onSkipChange).toBe(undefined);
 	});
 
 	it("global assets", done => {
@@ -403,7 +403,7 @@ describe("test Game", () => {
 					expect(logs).toEqual(["Scene2Load", "Scene2AssetLoaded", "TargetLoaded"]);
 
 					setTimeout(() => {
-						expect(game.loadingScene.onLoad.length).toBe(1); // loadingSceneのloadedハンドラが増えていかないことを確認
+						expect(game.loadingScene.onLoad.length).toBe(1); // loadingSceneのonLoadハンドラが増えていかないことを確認
 						done();
 					}, 1);
 				});
@@ -608,7 +608,7 @@ describe("test Game", () => {
 
 		let topIsLocal: LocalTickMode = undefined;
 		let sceneChangedCount = 0;
-		game._onSceneChanged.add(scene => {
+		game._onSceneChange.add(scene => {
 			sceneChangedCount++;
 			topIsLocal = scene.local;
 		});

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -553,7 +553,7 @@ describe("test Game", () => {
 			resetCount++;
 			expect(loadingScene.getTargetWaitingAssetsCount()).toBe(1); // 下記 const scene の assetIds: ["zoo"] しかこないので
 		}, loadingScene);
-		loadingScene.onTargetAssetLoaded.add(() => {
+		loadingScene.onTargetAssetLoad.add(() => {
 			invalidEndTrialCount++;
 			expect(() => {
 				loadingScene.end();

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -35,7 +35,7 @@ describe("test Game", () => {
 		expect(game.height).toBe(270);
 		expect(game.selfId).toBe("foo");
 		expect(game.playId).toBe(undefined);
-		expect(game.skippingChanged).not.toBe(undefined);
+		expect(game.onSkipChanged).not.toBe(undefined);
 		expect(game).toHaveProperty("_assetManager");
 		expect(game).toHaveProperty("_initialScene");
 	});
@@ -51,7 +51,7 @@ describe("test Game", () => {
 		expect(game.external).toEqual({}); // external は触らない
 		expect(game.vars).toEqual({}); // vars も触らない
 		expect(game.playId).toBe(undefined);
-		expect(game.skippingChanged).toBe(undefined);
+		expect(game.onSkipChanged).toBe(undefined);
 	});
 
 	it("global assets", done => {
@@ -76,7 +76,7 @@ describe("test Game", () => {
 			}
 		});
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			expect(game.assets.foo).not.toBe(undefined);
 			expect(game.assets.foo instanceof ImageAsset).toBe(true);
 			expect(game.assets).not.toHaveProperty("bar");
@@ -98,10 +98,10 @@ describe("test Game", () => {
 		const game = new Game({ width: 320, height: 320, assets: assets, main: "./dummy/dummy.js" });
 
 		let loadedFired = false;
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			loadedFired = true;
 		});
-		game._started.add(() => {
+		game._onStart.add(() => {
 			expect(loadedFired).toBe(true);
 			expect(game.assets.mainScene).not.toBe(undefined);
 			expect(game.assets.mainScene instanceof ScriptAsset).toBe(true);
@@ -137,7 +137,7 @@ describe("test Game", () => {
 		(game as any).__test__ = () => {
 			const scene = new Scene({ game: game });
 			expect(game.age).toBe(0);
-			scene.loaded.add(() => {
+			scene.onLoad.add(() => {
 				expect(game.age).toBe(0);
 				testPass = true;
 			});
@@ -159,10 +159,10 @@ describe("test Game", () => {
 		};
 		const game = new Game({ width: 320, height: 320, assets: assets, main: "./dummy/dummy.js" }, "/");
 		let loadedFired = false;
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			loadedFired = true;
 		});
-		game._started.add(() => {
+		game._onStart.add(() => {
 			expect(loadedFired).toBe(true);
 			expect(game.assets.dummy).not.toBe(undefined);
 			expect(game.assets.dummy instanceof ScriptAsset).toBe(true);
@@ -189,9 +189,9 @@ describe("test Game", () => {
 			return new Scene({ game: game });
 		};
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const scene = new Scene({ game: game });
-			scene.loaded.add(() => {
+			scene.onLoad.add(() => {
 				game._loadAndStart();
 			});
 			game.pushScene(scene);
@@ -206,7 +206,7 @@ describe("test Game", () => {
 	it("pushScene", done => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			// game.scenes テストのため _loaded を待つ必要がある
 			const scene = new Scene({ game: game });
 			game.pushScene(scene);
@@ -224,7 +224,7 @@ describe("test Game", () => {
 	it("popScene", done => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			// game.scenes テストのため _loaded を待つ必要がある
 			const scene = new Scene({ game: game, name: "SCENE1" });
 			const scene2 = new Scene({ game: game, name: "SCENE2" });
@@ -244,7 +244,7 @@ describe("test Game", () => {
 	it("popScene - specified step", done => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			// game.scenes テストのため _loaded を待つ必要がある
 			// popSceneで指定したシーンまで戻る際に経過したシーンは全て削除
 			const scene = new Scene({ game: game, name: "SCENE1" });
@@ -279,7 +279,7 @@ describe("test Game", () => {
 	it("replaceScene", done => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			// game.scenes テストのため _loaded を待つ必要がある
 			const scene = new Scene({ game: game });
 			const scene2 = new Scene({ game: game });
@@ -303,7 +303,7 @@ describe("test Game", () => {
 			}
 		};
 		const game = new Game({ width: 320, height: 320, assets: assets, main: "./dummy/dummy.js" });
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const scene = new Scene({ game: game });
 			game.pushScene(scene);
 			expect(game.age).toBe(0);
@@ -345,10 +345,10 @@ describe("test Game", () => {
 		class TestLoadingScene extends LoadingScene {
 			constructor(param: LoadingSceneParameterObject) {
 				super(param);
-				this.loaded.add(() => {
+				this.onLoad.add(() => {
 					logs.push("LoadingSceneLoaded");
 				});
-				this.targetReady.add(() => {
+				this.onTargetReady.add(() => {
 					logs.push("TargetLoaded");
 				}, this);
 			}
@@ -359,7 +359,7 @@ describe("test Game", () => {
 			name: "testLoadingScene"
 		});
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			game.loadingScene = loadingScene;
 
 			class MockScene1 extends Scene {
@@ -374,10 +374,10 @@ describe("test Game", () => {
 				assetIds: ["foo"],
 				name: "scene1"
 			});
-			scene.assetLoaded.add(a => {
+			scene.onAssetLoad.add(a => {
 				logs.push("SceneAssetLoaded");
 			});
-			scene.loaded.add(() => {
+			scene.onLoad.add(() => {
 				expect(logs).toEqual([
 					"LoadingSceneLoaded", // これ(LoagingSceneの読み込み完了)の後に
 					"SceneLoad", // 遷移先シーンの読み込みが開始されることが重要
@@ -396,14 +396,14 @@ describe("test Game", () => {
 				}
 
 				const scene2 = new MockScene2({ game: game, assetIds: ["foo"] });
-				scene2.assetLoaded.add(a => {
+				scene2.onAssetLoad.add(a => {
 					logs.push("Scene2AssetLoaded");
 				});
-				scene2.loaded.add(() => {
+				scene2.onLoad.add(() => {
 					expect(logs).toEqual(["Scene2Load", "Scene2AssetLoaded", "TargetLoaded"]);
 
 					setTimeout(() => {
-						expect(game.loadingScene.loaded.length).toBe(1); // loadingSceneのloadedハンドラが増えていかないことを確認
+						expect(game.loadingScene.onLoad.length).toBe(1); // loadingSceneのloadedハンドラが増えていかないことを確認
 						done();
 					}, 1);
 				});
@@ -444,13 +444,13 @@ describe("test Game", () => {
 		class TestLoadingScene extends LoadingScene {
 			constructor(param: LoadingSceneParameterObject) {
 				super(param);
-				this.assetLoaded.add(() => {
+				this.onAssetLoad.add(() => {
 					logs.push("LoadingSceneAssetLoaded");
 				});
-				this.loaded.add(() => {
+				this.onLoad.add(() => {
 					logs.push("LoadingSceneLoaded");
 				});
-				this.targetReady.add(() => {
+				this.onTargetReady.add(() => {
 					logs.push("TargetLoaded");
 				}, this);
 			}
@@ -461,7 +461,7 @@ describe("test Game", () => {
 			assetIds: ["foo", "zoo"]
 		});
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			game.loadingScene = loadingScene;
 
 			class MockScene1 extends Scene {
@@ -472,10 +472,10 @@ describe("test Game", () => {
 			}
 
 			const scene = new MockScene1({ game: game, assetIds: ["zoo"] });
-			scene.assetLoaded.add(a => {
+			scene.onAssetLoad.add(a => {
 				logs.push("SceneAssetLoaded");
 			});
-			scene.loaded.add(() => {
+			scene.onLoad.add(() => {
 				expect(logs).toEqual([
 					"LoadingSceneAssetLoaded",
 					"LoadingSceneAssetLoaded",
@@ -496,14 +496,14 @@ describe("test Game", () => {
 				}
 
 				const scene2 = new MockScene2({ game: game, assetIds: ["zoo"] });
-				scene2.assetLoaded.add(a => {
+				scene2.onAssetLoad.add(a => {
 					logs.push("Scene2AssetLoaded");
 				});
-				scene2.loaded.add(() => {
+				scene2.onLoad.add(() => {
 					expect(logs).toEqual(["Scene2Load", "Scene2AssetLoaded", "TargetLoaded"]);
 
 					setTimeout(() => {
-						expect(game.loadingScene.loaded.length).toBe(1); // loadingSceneのloadedハンドラが増えていかないことを確認
+						expect(game.loadingScene.onLoad.length).toBe(1); // loadingSceneのloadedハンドラが増えていかないことを確認
 						done();
 					}, 1);
 				});
@@ -549,27 +549,27 @@ describe("test Game", () => {
 			assetIds: ["foo", "zoo"],
 			explicitEnd: true
 		});
-		loadingScene.targetReset.add(() => {
+		loadingScene.onTargetReset.add(() => {
 			resetCount++;
 			expect(loadingScene.getTargetWaitingAssetsCount()).toBe(1); // 下記 const scene の assetIds: ["zoo"] しかこないので
 		}, loadingScene);
-		loadingScene.targetAssetLoaded.add(() => {
+		loadingScene.onTargetAssetLoaded.add(() => {
 			invalidEndTrialCount++;
 			expect(() => {
 				loadingScene.end();
 			}).toThrow();
 		}, loadingScene);
-		loadingScene.targetReady.add(() => {
+		loadingScene.onTargetReady.add(() => {
 			setTimeout(() => {
 				asyncEndCalled = true;
 				loadingScene.end();
 			}, 10);
 		}, loadingScene);
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			game.loadingScene = loadingScene;
 			const scene = new Scene({ game: game, assetIds: ["zoo"] });
-			scene.loaded.add(() => {
+			scene.onLoad.add(() => {
 				expect(asyncEndCalled).toBe(true);
 				expect(invalidEndTrialCount).toBe(1);
 				expect(resetCount).toBe(1);
@@ -608,11 +608,11 @@ describe("test Game", () => {
 
 		let topIsLocal: LocalTickMode = undefined;
 		let sceneChangedCount = 0;
-		game._sceneChanged.add(scene => {
+		game._onSceneChanged.add(scene => {
 			sceneChangedCount++;
 			topIsLocal = scene.local;
 		});
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			// game.scenes テストのため _loaded を待つ必要がある
 			const scene = new Scene({ game: game });
 			const scene2 = new Scene({ game: game, assetIds: ["foo"] });
@@ -622,37 +622,37 @@ describe("test Game", () => {
 				local: true
 			});
 
-			scene.loaded.add(() => {
+			scene.onLoad.add(() => {
 				expect(sceneChangedCount).toBe(2); // _initialScene と scene (いずれも loadingSceneなし) で 2
 				expect(topIsLocal).toBe(LocalTickMode.NonLocal);
 				expect(game.scenes).toEqual([game._initialScene, scene]);
-				expect(game._eventTriggerMap[EventType.PointDown]).toBe(scene.pointDownCapture);
+				expect(game._eventTriggerMap[EventType.PointDown]).toBe(scene.onPointDownCapture);
 
-				scene2.loaded.add(() => {
+				scene2.onLoad.add(() => {
 					expect(sceneChangedCount).toBe(4); // loadingScene が pop されて 1 増えたので 4
 					expect(topIsLocal).toBe(LocalTickMode.NonLocal);
 					expect(game.scenes).toEqual([game._initialScene, scene2]);
-					expect(game._eventTriggerMap[EventType.PointDown]).toBe(scene2.pointDownCapture);
+					expect(game._eventTriggerMap[EventType.PointDown]).toBe(scene2.onPointDownCapture);
 
-					scene3.loaded.add(() => {
+					scene3.onLoad.add(() => {
 						expect(sceneChangedCount).toBe(6);
 						expect(topIsLocal).toBe(LocalTickMode.FullLocal);
 						expect(game.scenes).toEqual([game._initialScene, scene2, scene3]);
-						expect(game._eventTriggerMap[EventType.PointDown]).toBe(scene3.pointDownCapture);
+						expect(game._eventTriggerMap[EventType.PointDown]).toBe(scene3.onPointDownCapture);
 
 						game.popScene();
 						game._flushSceneChangeRequests();
 						expect(sceneChangedCount).toBe(7);
 						expect(topIsLocal).toBe(LocalTickMode.NonLocal);
 						expect(game.scenes).toEqual([game._initialScene, scene2]);
-						expect(game._eventTriggerMap[EventType.PointDown]).toBe(scene2.pointDownCapture);
+						expect(game._eventTriggerMap[EventType.PointDown]).toBe(scene2.onPointDownCapture);
 
 						game.popScene();
 						game._flushSceneChangeRequests();
 						expect(sceneChangedCount).toBe(8);
 						expect(topIsLocal).toBe(LocalTickMode.FullLocal);
 						expect(game.scenes).toEqual([game._initialScene]);
-						expect(game._eventTriggerMap[EventType.PointDown]).toBe(game._initialScene.pointDownCapture);
+						expect(game._eventTriggerMap[EventType.PointDown]).toBe(game._initialScene.onPointDownCapture);
 						done();
 					});
 					game.pushScene(scene3);
@@ -660,19 +660,19 @@ describe("test Game", () => {
 					expect(sceneChangedCount).toBe(5);
 					expect(topIsLocal).toBe(LocalTickMode.FullLocal);
 					expect(game.scenes).toEqual([game._initialScene, scene2, scene3, game._defaultLoadingScene]);
-					expect(game._eventTriggerMap[EventType.PointDown]).toBe(game._defaultLoadingScene.pointDownCapture);
+					expect(game._eventTriggerMap[EventType.PointDown]).toBe(game._defaultLoadingScene.onPointDownCapture);
 				});
 				game.replaceScene(scene2);
 				game._flushSceneChangeRequests();
 				expect(sceneChangedCount).toBe(3); // scene2とloadingSceneが乗るが、scene2はまだ_sceneStackTopChangeCountをfireしてない
 				expect(topIsLocal).toBe(LocalTickMode.FullLocal); // loadingScene がトップなので local
 				expect(game.scenes).toEqual([game._initialScene, scene2, game._defaultLoadingScene]);
-				expect(game._eventTriggerMap[EventType.PointDown]).toBe(game._defaultLoadingScene.pointDownCapture);
+				expect(game._eventTriggerMap[EventType.PointDown]).toBe(game._defaultLoadingScene.onPointDownCapture);
 			});
 			expect(sceneChangedCount).toBe(1); // _initialScene (loadingSceneなし) が push された分で 1
 			expect(topIsLocal).toBe(LocalTickMode.FullLocal);
 			expect(game.scenes).toEqual([game._initialScene]);
-			expect(game._eventTriggerMap[EventType.PointDown]).toBe(game._initialScene.pointDownCapture);
+			expect(game._eventTriggerMap[EventType.PointDown]).toBe(game._initialScene.onPointDownCapture);
 			game.pushScene(scene);
 			game._flushSceneChangeRequests();
 		});
@@ -734,7 +734,7 @@ describe("test Game", () => {
 		const scene = new Scene({ game: game });
 
 		let count = 0;
-		scene.update.add(() => {
+		scene.onUpdate.add(() => {
 			++count;
 		});
 		game.pushScene(scene);
@@ -756,12 +756,12 @@ describe("test Game", () => {
 	it("no crash on Scene#destroy()", done => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const scene = new Scene({ game: game });
 			let timerFired = false;
 
-			scene.loaded.add(() => {
-				scene.update.add(() => {
+			scene.onLoad.add(() => {
+				scene.onUpdate.add(() => {
 					game.popScene();
 				});
 				scene.setInterval(() => {
@@ -769,7 +769,7 @@ describe("test Game", () => {
 					timerFired = true;
 				}, 1);
 
-				game._initialScene.stateChanged.add(state => {
+				game._initialScene.onStateChange.add(state => {
 					if (state === SceneState.Active) {
 						// ↑のpopScene()後、例外を投げずにシーン遷移してここに来れたらOK
 						expect(timerFired).toBe(true);
@@ -821,7 +821,7 @@ describe("test Game", () => {
 		expect(game.age).toBe(0);
 		expect(game.random).toBe(null);
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			expect(game.isLoaded).toBe(true);
 
 			const scene = new Scene({ game: game });
@@ -877,18 +877,18 @@ describe("test Game", () => {
 		expect(game.random).toBe(null);
 
 		let testDone = false;
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			expect(testDone).toBe(true);
 			done();
 		});
 
 		const loadScene = game._defaultLoadingScene;
-		expect(game._initialScene.loaded.contains(game._onInitialSceneLoaded, game)).toBe(true);
-		expect(loadScene.loaded.contains(loadScene._doReset, loadScene)).toBe(false);
+		expect(game._initialScene.onLoad.contains(game._onInitialSceneLoaded, game)).toBe(true);
+		expect(loadScene.onLoad.contains(loadScene._doReset, loadScene)).toBe(false);
 
 		game._loadAndStart();
 		expect(game.isLoaded).toBe(false); // _loadAndStartしたがまだ読み込みは終わっていない
-		expect(game._initialScene.loaded.contains(game._onInitialSceneLoaded, game)).toBe(true);
+		expect(game._initialScene.onLoad.contains(game._onInitialSceneLoaded, game)).toBe(true);
 		expect(game.scenes.length).toBe(2);
 		expect(game.scenes[0]).toBe(game._initialScene);
 		expect(game.scenes[1]).toBe(loadScene);
@@ -898,8 +898,8 @@ describe("test Game", () => {
 		expect(loadScene2).not.toBe(loadScene);
 		expect(loadScene.destroyed()).toBe(true);
 		expect(game.isLoaded).toBe(false);
-		expect(game._initialScene.loaded.contains(game._onInitialSceneLoaded, game)).toBe(true);
-		expect(loadScene2.loaded.contains(loadScene2._doReset, loadScene2)).toBe(false);
+		expect(game._initialScene.onLoad.contains(game._onInitialSceneLoaded, game)).toBe(true);
+		expect(loadScene2.onLoad.contains(loadScene2._doReset, loadScene2)).toBe(false);
 		expect(game.scenes.length).toBe(0);
 
 		game._loadAndStart();

--- a/src/__tests__/ModuleSpec.ts
+++ b/src/__tests__/ModuleSpec.ts
@@ -265,7 +265,7 @@ describe("test Module", () => {
 		const game = new Game(gameConfiguration, "/");
 		const manager = game._moduleManager;
 		game.resourceFactory.scriptContents = scriptContents;
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const module = new Module({
 				id: "moduleid",
 				path,
@@ -297,7 +297,7 @@ describe("test Module", () => {
 		const manager = game._moduleManager;
 		game.resourceFactory.scriptContents = scriptContents;
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const mod = manager._require("noPackageJson");
 			expect(mod.me).toBe("noPackageJson-index");
 			expect(mod.thisModule instanceof Module).toBe(true);
@@ -312,7 +312,7 @@ describe("test Module", () => {
 		const manager = game._moduleManager;
 		const path = "/script/dummypath.js";
 		game.resourceFactory.scriptContents = scriptContents;
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const module = new Module({
 				id: "dummymod",
 				path,
@@ -376,7 +376,7 @@ describe("test Module", () => {
 				game: game,
 				assetIds: ["aNonGlobalAssetBar"]
 			});
-			scene.loaded.add(() => {
+			scene.onLoad.add(() => {
 				let mod = module.require("aNonGlobalAssetBar");
 				expect(mod.me).toBe("script-bar");
 				expect(mod.thisModule instanceof Module).toBe(true);
@@ -416,7 +416,7 @@ describe("test Module", () => {
 		const manager = game._moduleManager;
 		const path = assetBase + "/script/dummypath.js";
 		game.resourceFactory.scriptContents = scripts;
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const module = new Module({
 				runtimeValueBase: game._runtimeValueBase,
 				id: "dummymod",
@@ -452,7 +452,7 @@ describe("test Module", () => {
 				game: game,
 				assetIds: ["aNonGlobalAssetBar"]
 			});
-			scene.loaded.add(() => {
+			scene.onLoad.add(() => {
 				let mod = module.require("aNonGlobalAssetBar");
 				expect(mod.me).toBe("script-bar");
 				expect(mod.thisModule.filename).toBe(assetBase + "/script/bar.js");
@@ -488,7 +488,7 @@ describe("test Module", () => {
 		const manager = game._moduleManager;
 		const path = assetBase + "/script/dummypath.js";
 		game.resourceFactory.scriptContents = scripts;
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const module = new Module({
 				runtimeValueBase: game._runtimeValueBase,
 				id: "dummymod",
@@ -524,7 +524,7 @@ describe("test Module", () => {
 				game: game,
 				assetIds: ["aNonGlobalAssetBar"]
 			});
-			scene.loaded.add(() => {
+			scene.onLoad.add(() => {
 				let mod = module.require("aNonGlobalAssetBar");
 				expect(mod.me).toBe("script-bar");
 				expect(mod.thisModule.filename).toBe(assetBase + "/script/bar.js");
@@ -550,7 +550,7 @@ describe("test Module", () => {
 		const manager = game._moduleManager;
 		const path = "/script/dummypath.js";
 		game.resourceFactory.scriptContents = scriptContents;
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const module = new Module({
 				runtimeValueBase: game._runtimeValueBase,
 				id: "dummymod",
@@ -620,7 +620,7 @@ describe("test Module", () => {
 		const path = assetBase + "/script/dummypath.js";
 		game.resourceFactory.scriptContents = scripts;
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const module = new Module({
 				runtimeValueBase: game._runtimeValueBase,
 				id: "dummymod",
@@ -662,7 +662,7 @@ describe("test Module", () => {
 		const manager = game._moduleManager;
 		const path = "/script/dummypath.js";
 		game.resourceFactory.scriptContents = scriptContents;
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const module = new Module({
 				runtimeValueBase: game._runtimeValueBase,
 				id: "dummymod",
@@ -702,7 +702,7 @@ describe("test Module", () => {
 		const manager = game._moduleManager;
 		const path = "/script/realpath.js";
 		game.resourceFactory.scriptContents = scriptContents;
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const module = new Module({
 				runtimeValueBase: game._runtimeValueBase,
 				id: "dummymod",
@@ -728,7 +728,7 @@ describe("test Module", () => {
 		const path = "/script/dummypath.js";
 		game.resourceFactory.scriptContents = scriptContents;
 		game.random = new XorshiftRandomGenerator(1);
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const module = new Module({
 				runtimeValueBase: game._runtimeValueBase,
 				id: "dummymod",
@@ -751,7 +751,7 @@ describe("test Module", () => {
 		const manager = game._moduleManager;
 		const path = "/script/dummypath.js";
 		game.resourceFactory.scriptContents = scriptContents;
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const module = new Module({
 				runtimeValueBase: game._runtimeValueBase,
 				id: "dummymod",
@@ -776,7 +776,7 @@ describe("test Module", () => {
 		const manager = game._moduleManager;
 		const path = "/cascaded/script.js";
 		game.resourceFactory.scriptContents = scriptContents;
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const module = new Module({
 				runtimeValueBase: game._runtimeValueBase,
 				id: "dummymod",

--- a/src/__tests__/OperationPluginManagerSpec.ts
+++ b/src/__tests__/OperationPluginManagerSpec.ts
@@ -70,9 +70,9 @@ describe("test OperationPluginManager", () => {
 	});
 
 	it("初期化", done => {
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			expect(game.operationPluginManager).not.toBeFalsy();
-			expect(game.operationPluginManager.operated instanceof Trigger).toBe(true);
+			expect(game.operationPluginManager.onOperate instanceof Trigger).toBe(true);
 			expect(game.operationPluginManager.plugins).toEqual({});
 			done();
 		});
@@ -80,7 +80,7 @@ describe("test OperationPluginManager", () => {
 	});
 
 	it("initialize()", done => {
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const self = game.operationPluginManager;
 			expect((self as any)._initialized).toBe(false);
 			self.initialize();
@@ -98,12 +98,12 @@ describe("test OperationPluginManager", () => {
 	});
 
 	it("operated", done => {
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const self = game.operationPluginManager;
 			self.initialize();
 
 			const ops: InternalOperationPluginOperation[] = [];
-			self.operated.add(op => {
+			self.onOperate.add(op => {
 				ops.push(op);
 			});
 
@@ -122,7 +122,7 @@ describe("test OperationPluginManager", () => {
 	});
 
 	it("register", done => {
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const self = game.operationPluginManager;
 			self.initialize();
 
@@ -160,11 +160,11 @@ describe("test OperationPluginManager", () => {
 	});
 
 	it("destroy", done => {
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const self = game.operationPluginManager;
 			self.initialize();
 			self.destroy();
-			expect(self.operated).toBeFalsy();
+			expect(self.onOperate).toBeFalsy();
 			expect(self.plugins).toBeFalsy();
 			done();
 		});

--- a/src/__tests__/SceneSpec.ts
+++ b/src/__tests__/SceneSpec.ts
@@ -1025,23 +1025,23 @@ describe("test Scene", () => {
 		const timer = scene.createTimer(100);
 		expect(scene._timer._timers.length).toBe(1);
 		expect(scene._timer._timers[0]).toBe(timer);
-		timer.onElapsed.add(() => {
+		timer.onElapse.add(() => {
 			fail("invalid call");
 		}, undefined);
 		game.tick(true);
 		game.tick(true);
 		game.tick(true);
-		timer.onElapsed.removeAll({ owner: undefined });
+		timer.onElapse.removeAll({ owner: undefined });
 		expect(scene._timer._timers.length).toBe(1);
 		let success = false;
-		timer.onElapsed.add(() => {
+		timer.onElapse.add(() => {
 			success = true;
 		});
 		game.tick(true);
 		expect(success).toBe(true);
 
 		expect(timer.canDelete()).toBe(false);
-		timer.onElapsed.removeAll();
+		timer.onElapse.removeAll();
 		expect(timer.canDelete()).toBe(true);
 
 		scene.deleteTimer(timer);

--- a/src/__tests__/SceneSpec.ts
+++ b/src/__tests__/SceneSpec.ts
@@ -49,10 +49,10 @@ describe("test Scene", () => {
 			name: "myScene"
 		});
 		expect(scene.game).toBe(game);
-		expect(scene.assetLoaded.length).toEqual(0);
-		expect(scene.assetLoadFailed.length).toEqual(0);
-		expect(scene.assetLoadCompleted.length).toEqual(0);
-		expect(scene.loaded.length).toEqual(0);
+		expect(scene.onAssetLoad.length).toEqual(0);
+		expect(scene.onAssetLoadFailure.length).toEqual(0);
+		expect(scene.onAssetLoadComplete.length).toEqual(0);
+		expect(scene.onLoad.length).toEqual(0);
 		expect(scene.children).not.toBeFalsy();
 		expect(scene.children.length).toBe(0);
 		expect(scene._sceneAssetHolder._assetIds).toEqual(["foo"]);
@@ -61,17 +61,17 @@ describe("test Scene", () => {
 		expect(scene.tickGenerationMode).toBe(TickGenerationMode.Manual);
 		expect(scene.name).toEqual("myScene");
 
-		expect(scene.update instanceof Trigger).toBe(true);
-		expect(scene.loaded instanceof Trigger).toBe(true);
-		expect(scene.assetLoaded instanceof Trigger).toBe(true);
-		expect(scene.assetLoadFailed instanceof Trigger).toBe(true);
-		expect(scene.assetLoadCompleted instanceof Trigger).toBe(true);
-		expect(scene.stateChanged instanceof Trigger).toBe(true);
-		expect(scene.message instanceof Trigger).toBe(true);
-		expect(scene.pointDownCapture instanceof Trigger).toBe(true);
-		expect(scene.pointMoveCapture instanceof Trigger).toBe(true);
-		expect(scene.pointUpCapture instanceof Trigger).toBe(true);
-		expect(scene.operation instanceof Trigger).toBe(true);
+		expect(scene.onUpdate instanceof Trigger).toBe(true);
+		expect(scene.onLoad instanceof Trigger).toBe(true);
+		expect(scene.onAssetLoad instanceof Trigger).toBe(true);
+		expect(scene.onAssetLoadFailure instanceof Trigger).toBe(true);
+		expect(scene.onAssetLoadComplete instanceof Trigger).toBe(true);
+		expect(scene.onStateChange instanceof Trigger).toBe(true);
+		expect(scene.onMessage instanceof Trigger).toBe(true);
+		expect(scene.onPointDownCapture instanceof Trigger).toBe(true);
+		expect(scene.onPointMoveCapture instanceof Trigger).toBe(true);
+		expect(scene.onPointUpCapture instanceof Trigger).toBe(true);
+		expect(scene.onOperation instanceof Trigger).toBe(true);
 	});
 
 	it("初期化 - Storage", () => {
@@ -136,7 +136,7 @@ describe("test Scene", () => {
 			name: "SceneToLoadAsset"
 		});
 
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(scene.assets.foo).not.toBeUndefined();
 			expect(scene.assets.bar).toBeUndefined();
 			expect(scene.assets.baa).not.toBeUndefined();
@@ -166,7 +166,7 @@ describe("test Scene", () => {
 		game.storage._registerLoad((keys, loader) => {
 			loader._onLoaded(values);
 		});
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(scene._storageLoader._loaded).toBe(true);
 			expect(scene.storageValues.get(0)).toBe(values[0]);
 			done();
@@ -190,7 +190,7 @@ describe("test Scene", () => {
 		game.storage._registerLoad((keys, loader) => {
 			loader._onLoaded(values);
 		});
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(scene._storageLoader._loaded).toBe(true);
 			expect(scene.serializeStorageValues()).toBeUndefined();
 			done();
@@ -224,7 +224,7 @@ describe("test Scene", () => {
 				loader._onLoaded(serializedValues);
 			}
 		});
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(scene._storageLoader._loaded).toBe(true);
 			expect(scene.serializeStorageValues()).toBe("myserialization1");
 			expect(scene.storageValues.get(0)).toBe(serializedValues[0]);
@@ -253,7 +253,7 @@ describe("test Scene", () => {
 			l._onLoaded(values);
 		});
 
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(scene._storageLoader).toBeDefined();
 			expect(scene.storageValues.get(0)).toBe(values[0]);
 			expect(scene.assets.foo).toBeDefined();
@@ -276,7 +276,7 @@ describe("test Scene", () => {
 		});
 		game.resourceFactory.createsDelayedAsset = true;
 
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(scene._loaded).toBe(true);
 			expect(scene._prefetchRequested).toBe(false);
 			done();
@@ -307,7 +307,7 @@ describe("test Scene", () => {
 		});
 		game.resourceFactory.createsDelayedAsset = true;
 
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			done();
 		});
 		scene.prefetch();
@@ -328,7 +328,7 @@ describe("test Scene", () => {
 		const scene = new Scene({ game: game });
 		game.resourceFactory.createsDelayedAsset = true;
 
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			done();
 		});
 		scene.prefetch();
@@ -381,7 +381,7 @@ describe("test Scene", () => {
 		game.resourceFactory.createsDelayedAsset = true;
 		let ready = false;
 
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(ready).toBe(true);
 			expect(scene._sceneAssetHolder.waitingAssetsCount).toBe(0);
 			done();
@@ -416,7 +416,7 @@ describe("test Scene", () => {
 		game.resourceFactory.createsDelayedAsset = true;
 		let ready = false;
 
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(ready).toBe(true);
 			expect(scene._sceneAssetHolder.waitingAssetsCount).toBe(0);
 			done();
@@ -469,7 +469,7 @@ describe("test Scene", () => {
 		});
 
 		let ready = false;
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(ready).toBe(true);
 			expect(scene._sceneAssetHolder.waitingAssetsCount).toBe(0);
 			done();
@@ -524,7 +524,7 @@ describe("test Scene", () => {
 		});
 		let ready = false;
 
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(ready).toBe(true);
 			expect(scene._sceneAssetHolder.waitingAssetsCount).toBe(0);
 			done();
@@ -581,7 +581,7 @@ describe("test Scene", () => {
 		});
 
 		let ready = false;
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(ready).toBe(true);
 			expect(scene._sceneAssetHolder.waitingAssetsCount).toBe(0);
 			done();
@@ -611,7 +611,7 @@ describe("test Scene", () => {
 			assets: assetsConfiguration
 		});
 
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			const scene = new Scene({
 				game: game,
 				assetIds: [
@@ -625,7 +625,7 @@ describe("test Scene", () => {
 					}
 				]
 			});
-			scene.loaded.add(() => {
+			scene.onLoad.add(() => {
 				const foo = scene.assets.foo;
 				const dynamicImage = scene.assets.dynamicImage as ImageAsset;
 				expect(foo instanceof ImageAsset).toBe(true);
@@ -721,13 +721,13 @@ describe("test Scene", () => {
 
 		let failureCount = 0;
 		let loadedCount = 0;
-		scene.assetLoaded.add(asset => {
+		scene.onAssetLoad.add(asset => {
 			expect(asset instanceof Asset).toBe(true);
 			expect(asset.id).toBe("foo");
 			expect(failureCount).toBe(2);
 			++loadedCount;
 		});
-		scene.assetLoadFailed.add(failureInfo => {
+		scene.onAssetLoadFailure.add(failureInfo => {
 			expect(failureInfo.asset instanceof Asset).toBe(true);
 			expect(failureInfo.asset.id).toBe("foo");
 			expect(failureInfo.error instanceof Error).toBe(true);
@@ -736,7 +736,7 @@ describe("test Scene", () => {
 			expect(failureInfo.cancelRetry).toBe(false);
 			++failureCount;
 		});
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(failureCount).toBe(2);
 			expect(loadedCount).toBe(1);
 			expect(scene.assets.foo).not.toBeUndefined();
@@ -760,7 +760,7 @@ describe("test Scene", () => {
 			assetIds: ["foo"]
 		});
 
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			expect(scene.assets.foo).not.toBeUndefined();
 			done();
 		});
@@ -783,10 +783,10 @@ describe("test Scene", () => {
 		});
 
 		let failureCount = 0;
-		scene.assetLoaded.add(asset => {
+		scene.onAssetLoad.add(asset => {
 			fail("should not be loaded");
 		});
-		scene.assetLoadFailed.add(failureInfo => {
+		scene.onAssetLoadFailure.add(failureInfo => {
 			expect(failureInfo.asset instanceof Asset).toBe(true);
 			expect(failureInfo.asset.id).toBe("foo");
 			expect(failureInfo.error instanceof Error).toBe(true);
@@ -799,7 +799,7 @@ describe("test Scene", () => {
 				done();
 			}
 		});
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			fail("should not fire loaded");
 		});
 
@@ -821,10 +821,10 @@ describe("test Scene", () => {
 		});
 
 		let failureCount = 0;
-		scene.assetLoaded.add(asset => {
+		scene.onAssetLoad.add(asset => {
 			fail("should not be loaded");
 		});
-		scene.assetLoadFailed.add(failureInfo => {
+		scene.onAssetLoadFailure.add(failureInfo => {
 			expect(failureInfo.asset instanceof Asset).toBe(true);
 			expect(failureInfo.asset.id).toBe("foo");
 			expect(failureInfo.error instanceof Error).toBe(true);
@@ -839,7 +839,7 @@ describe("test Scene", () => {
 				done();
 			}, 0);
 		});
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			fail("should not fire loaded");
 		});
 
@@ -854,13 +854,13 @@ describe("test Scene", () => {
 			assetIds: ["foo"]
 		});
 
-		scene._ready.add(() => {
+		scene._onReady.add(() => {
 			const child = new Scene({
 				game: game,
 				assetIds: ["foo", "baa"]
 			});
 
-			child._ready.add(() => {
+			child._onReady.add(() => {
 				expect(scene.assets.foo).not.toBeUndefined();
 				expect(scene.assets.baa).toBeUndefined();
 				expect(scene.assets.zoo).toBeUndefined();
@@ -887,7 +887,7 @@ describe("test Scene", () => {
 		const stateChangeHandler = () => {
 			raisedEvent = true;
 		};
-		scene.stateChanged.add(stateChangeHandler);
+		scene.onStateChange.add(stateChangeHandler);
 
 		const sceneLoaded = () => {
 			expect(scene.state).toBe(SceneState.Active);
@@ -905,12 +905,12 @@ describe("test Scene", () => {
 		};
 		const steps = [
 			() => {
-				scene.loaded.add(sceneLoaded);
+				scene.onLoad.add(sceneLoaded);
 				game.pushScene(scene);
 			},
 			() => {
 				const scene2 = new Scene({ game: game });
-				scene2.loaded.add(scene2Loaded);
+				scene2.onLoad.add(scene2Loaded);
 				game.pushScene(scene2);
 			},
 			() => {
@@ -969,29 +969,29 @@ describe("test Scene", () => {
 		function makeScene(name: string): Scene {
 			const scene = new Scene({ game: game });
 			(scene as any)._testName = name;
-			scene.stateChanged.add(stateChangeHandler, scene);
+			scene.onStateChange.add(stateChangeHandler, scene);
 			return scene;
 		}
 
 		const steps = [
 			() => {
 				const scene1 = makeScene("S1");
-				scene1.loaded.add(nextStep);
+				scene1.onLoad.add(nextStep);
 				game.pushScene(scene1);
 			},
 			() => {
 				const scene2 = makeScene("S2");
-				scene2.loaded.add(nextStep);
+				scene2.onLoad.add(nextStep);
 				game.replaceScene(scene2);
 			},
 			() => {
 				const scene3 = makeScene("S3");
-				scene3.loaded.add(nextStep);
+				scene3.onLoad.add(nextStep);
 				game.pushScene(scene3);
 			},
 			() => {
 				const scene4 = makeScene("S4");
-				scene4.loaded.add(nextStep);
+				scene4.onLoad.add(nextStep);
 				game.replaceScene(scene4);
 			},
 			() => {
@@ -1025,23 +1025,23 @@ describe("test Scene", () => {
 		const timer = scene.createTimer(100);
 		expect(scene._timer._timers.length).toBe(1);
 		expect(scene._timer._timers[0]).toBe(timer);
-		timer.elapsed.add(() => {
+		timer.onElapsed.add(() => {
 			fail("invalid call");
 		}, undefined);
 		game.tick(true);
 		game.tick(true);
 		game.tick(true);
-		timer.elapsed.removeAll({ owner: undefined });
+		timer.onElapsed.removeAll({ owner: undefined });
 		expect(scene._timer._timers.length).toBe(1);
 		let success = false;
-		timer.elapsed.add(() => {
+		timer.onElapsed.add(() => {
 			success = true;
 		});
 		game.tick(true);
 		expect(success).toBe(true);
 
 		expect(timer.canDelete()).toBe(false);
-		timer.elapsed.removeAll();
+		timer.onElapsed.removeAll();
 		expect(timer.canDelete()).toBe(true);
 
 		scene.deleteTimer(timer);
@@ -1254,7 +1254,7 @@ describe("test Scene", () => {
 	it("isCurrentScene/gotoScene/end", done => {
 		jasmine.addMatchers(require("./helpers/customMatchers"));
 		const game = new Game({ width: 320, height: 320, main: "" });
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			// game.scenes テストのため _loaded を待つ必要がある
 			const scene1 = new Scene({ game: game });
 			const scene2 = new Scene({ game: game });
@@ -1288,7 +1288,7 @@ describe("test Scene", () => {
 	it("gotoScene - AssertionError", done => {
 		jasmine.addMatchers(require("./helpers/customMatchers"));
 		const game = new Game({ width: 320, height: 320, main: "" });
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			// game.scenes テストのため _loaded を待つ必要がある
 			const scene1 = new Scene({ game: game });
 			const scene2 = new Scene({ game: game });
@@ -1303,7 +1303,7 @@ describe("test Scene", () => {
 	it("end - AssertionError", done => {
 		jasmine.addMatchers(require("./helpers/customMatchers"));
 		const game = new Game({ width: 320, height: 320, main: "" });
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			// game.scenes テストのため _loaded を待つ必要がある
 			const scene1 = new Scene({ game: game });
 			expect(() => {

--- a/src/__tests__/SpriteSpec.ts
+++ b/src/__tests__/SpriteSpec.ts
@@ -5,8 +5,8 @@ describe("test Sprite", () => {
 	let updated = false;
 
 	class MonitorSprite extends Sprite {
-		_onUpdate(): void {
-			super._onUpdate();
+		_onUpdated(): void {
+			super._onUpdated();
 			updated = true;
 		}
 	}
@@ -79,14 +79,14 @@ describe("test Sprite", () => {
 		expect(sprite._surface).toBe(surface);
 		expect(sprite._beforeSurface).toEqual(sprite._surface);
 
-		sprite.update.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(false);
-		surface.animatingStarted.fire();
-		sprite.update.fire();
+		surface.onAnimationStart.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(true);
 		updated = false;
-		surface.animatingStopped.fire();
-		sprite.update.fire();
+		surface.onAnimationStop.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(false);
 	});
 
@@ -110,7 +110,7 @@ describe("test Sprite", () => {
 		expect(sprite._surface).toBe(surface);
 		expect(sprite._beforeSurface).toEqual(sprite._surface);
 
-		sprite.update.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(true);
 	});
 
@@ -172,14 +172,14 @@ describe("test Sprite", () => {
 		expect(sprite._surface).toEqual(surface);
 		expect(sprite._beforeSurface).toEqual(sprite._surface);
 
-		sprite.update.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(false);
-		surface.animatingStarted.fire();
-		sprite.update.fire();
+		surface.onAnimationStart.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(true);
 		updated = false;
-		surface.animatingStopped.fire();
-		sprite.update.fire();
+		surface.onAnimationStop.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(false);
 	});
 
@@ -206,7 +206,7 @@ describe("test Sprite", () => {
 		expect(sprite._surface).toEqual(surface);
 		expect(sprite._beforeSurface).toEqual(sprite._surface);
 
-		sprite.update.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(true);
 	});
 
@@ -273,20 +273,20 @@ describe("test Sprite", () => {
 			src: surface1
 		});
 
-		surface1.animatingStarted.fire();
-		sprite.update.fire();
+		surface1.onAnimationStart.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(true);
 
 		sprite._surface = surface2;
 		sprite.invalidate();
 		updated = false;
 
-		surface1.animatingStarted.fire();
-		sprite.update.fire();
+		surface1.onAnimationStart.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(false);
 
-		surface2.animatingStarted.fire();
-		sprite.update.fire();
+		surface2.onAnimationStart.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(true);
 	});
 
@@ -300,15 +300,15 @@ describe("test Sprite", () => {
 			src: surface1
 		});
 
-		surface1.animatingStarted.fire();
-		sprite.update.fire();
+		surface1.onAnimationStart.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(true);
 
 		sprite._surface = surface2;
 		sprite.invalidate();
 		updated = false;
 
-		sprite.update.fire();
+		sprite.onUpdate.fire();
 		expect(updated).toBe(true);
 	});
 

--- a/src/__tests__/SpriteSpec.ts
+++ b/src/__tests__/SpriteSpec.ts
@@ -5,8 +5,8 @@ describe("test Sprite", () => {
 	let updated = false;
 
 	class MonitorSprite extends Sprite {
-		_onUpdated(): void {
-			super._onUpdated();
+		_onUpdate(): void {
+			super._onUpdate();
 			updated = true;
 		}
 	}

--- a/src/__tests__/SurfaceSpec.ts
+++ b/src/__tests__/SurfaceSpec.ts
@@ -12,8 +12,8 @@ describe("test Surface", () => {
 		expect(surface.width).toBe(width);
 		expect(surface.height).toBe(height);
 		expect(surface.isDynamic).toBe(false);
-		expect(surface.animatingStarted).toBeUndefined();
-		expect(surface.animatingStopped).toBeUndefined();
+		expect(surface.onAnimationStart).toBeUndefined();
+		expect(surface.onAnimationStop).toBeUndefined();
 	});
 
 	it("初期化 - enable drawable", () => {
@@ -25,8 +25,8 @@ describe("test Surface", () => {
 		expect(surface.height).toBe(height);
 		expect(surface._drawable).toBe(true);
 		expect(surface.isDynamic).toBe(false);
-		expect(surface.animatingStarted).toBeUndefined();
-		expect(surface.animatingStopped).toBeUndefined();
+		expect(surface.onAnimationStart).toBeUndefined();
+		expect(surface.onAnimationStop).toBeUndefined();
 	});
 
 	it("初期化 - invalid params", () => {
@@ -45,7 +45,7 @@ describe("test Surface", () => {
 		expect(surface.height).toBe(height);
 		expect(surface._drawable).toBe(drawable);
 		expect(surface.isDynamic).toBe(isDynamic);
-		expect(surface.animatingStarted.constructor).toBe(Trigger);
-		expect(surface.animatingStopped.constructor).toBe(Trigger);
+		expect(surface.onAnimationStop.constructor).toBe(Trigger);
+		expect(surface.onAnimationStop.constructor).toBe(Trigger);
 	});
 });

--- a/src/__tests__/SurfaceUtilSpec.ts
+++ b/src/__tests__/SurfaceUtilSpec.ts
@@ -29,7 +29,7 @@ describe("test SurfaceUtil", () => {
 				}
 			}
 		});
-		game._loaded.add(() => {
+		game._onLoad.add(() => {
 			expect(SurfaceUtil.asSurface(game.assets.foo as ImageAsset)).toEqual((game.assets.foo as ImageAsset).asSurface());
 			done();
 		});

--- a/src/__tests__/TimerSpec.ts
+++ b/src/__tests__/TimerSpec.ts
@@ -7,7 +7,7 @@ describe("test Timer", () => {
 		const timer = new Timer(interval, 30);
 
 		expect(timer.interval).toEqual(interval);
-		expect(timer.onElapsed instanceof Trigger).toBe(true);
+		expect(timer.onElapse instanceof Trigger).toBe(true);
 		expect(timer._scaledElapsed).toEqual(0);
 		expect(timer._scaledInterval).toEqual(interval * 30);
 
@@ -15,7 +15,7 @@ describe("test Timer", () => {
 		const timer2 = new Timer(interval, 30);
 
 		expect(timer2.interval).toEqual(interval);
-		expect(timer2.onElapsed instanceof Trigger).toBe(true);
+		expect(timer2.onElapse instanceof Trigger).toBe(true);
 		expect(timer2._scaledElapsed).toEqual(0);
 		expect(timer2._scaledInterval).toEqual(interval * 30);
 
@@ -23,7 +23,7 @@ describe("test Timer", () => {
 		const timer3 = new Timer(interval, 30);
 
 		expect(timer3.interval).toEqual(interval);
-		expect(timer3.onElapsed instanceof Trigger).toBe(true);
+		expect(timer3.onElapse instanceof Trigger).toBe(true);
 		expect(timer3._scaledElapsed).toEqual(0);
 		expect(timer3._scaledInterval).toEqual(Math.round(interval * 30));
 	});
@@ -32,7 +32,7 @@ describe("test Timer", () => {
 		const interval = 1;
 		const timer = new Timer(interval, 30);
 		let firedCounter = 0;
-		timer.onElapsed.fire = () => {
+		timer.onElapse.fire = () => {
 			firedCounter++;
 		};
 		timer.tick();
@@ -55,7 +55,7 @@ describe("test Timer", () => {
 
 		expect(timer.canDelete()).toBe(true);
 
-		timer.onElapsed.add(() => {
+		timer.onElapse.add(() => {
 			/* do nothing */
 		});
 
@@ -66,7 +66,7 @@ describe("test Timer", () => {
 		const interval = 1;
 		const timer = new Timer(interval, 30);
 		let elapsedDestoyFlg = false;
-		timer.onElapsed.destroy = () => {
+		timer.onElapse.destroy = () => {
 			elapsedDestoyFlg = true;
 		};
 
@@ -76,7 +76,7 @@ describe("test Timer", () => {
 
 		expect(timer.destroyed()).toBe(true);
 		expect(timer.interval).toBeUndefined();
-		expect(timer.onElapsed).toBeUndefined();
+		expect(timer.onElapse).toBeUndefined();
 		expect(elapsedDestoyFlg).toBe(true);
 	});
 });

--- a/src/__tests__/TimerSpec.ts
+++ b/src/__tests__/TimerSpec.ts
@@ -7,7 +7,7 @@ describe("test Timer", () => {
 		const timer = new Timer(interval, 30);
 
 		expect(timer.interval).toEqual(interval);
-		expect(timer.elapsed instanceof Trigger).toBe(true);
+		expect(timer.onElapsed instanceof Trigger).toBe(true);
 		expect(timer._scaledElapsed).toEqual(0);
 		expect(timer._scaledInterval).toEqual(interval * 30);
 
@@ -15,7 +15,7 @@ describe("test Timer", () => {
 		const timer2 = new Timer(interval, 30);
 
 		expect(timer2.interval).toEqual(interval);
-		expect(timer2.elapsed instanceof Trigger).toBe(true);
+		expect(timer2.onElapsed instanceof Trigger).toBe(true);
 		expect(timer2._scaledElapsed).toEqual(0);
 		expect(timer2._scaledInterval).toEqual(interval * 30);
 
@@ -23,7 +23,7 @@ describe("test Timer", () => {
 		const timer3 = new Timer(interval, 30);
 
 		expect(timer3.interval).toEqual(interval);
-		expect(timer3.elapsed instanceof Trigger).toBe(true);
+		expect(timer3.onElapsed instanceof Trigger).toBe(true);
 		expect(timer3._scaledElapsed).toEqual(0);
 		expect(timer3._scaledInterval).toEqual(Math.round(interval * 30));
 	});
@@ -32,7 +32,7 @@ describe("test Timer", () => {
 		const interval = 1;
 		const timer = new Timer(interval, 30);
 		let firedCounter = 0;
-		timer.elapsed.fire = () => {
+		timer.onElapsed.fire = () => {
 			firedCounter++;
 		};
 		timer.tick();
@@ -55,7 +55,7 @@ describe("test Timer", () => {
 
 		expect(timer.canDelete()).toBe(true);
 
-		timer.elapsed.add(() => {
+		timer.onElapsed.add(() => {
 			/* do nothing */
 		});
 
@@ -66,7 +66,7 @@ describe("test Timer", () => {
 		const interval = 1;
 		const timer = new Timer(interval, 30);
 		let elapsedDestoyFlg = false;
-		timer.elapsed.destroy = () => {
+		timer.onElapsed.destroy = () => {
 			elapsedDestoyFlg = true;
 		};
 
@@ -76,7 +76,7 @@ describe("test Timer", () => {
 
 		expect(timer.destroyed()).toBe(true);
 		expect(timer.interval).toBeUndefined();
-		expect(timer.elapsed).toBeUndefined();
+		expect(timer.onElapsed).toBeUndefined();
 		expect(elapsedDestoyFlg).toBe(true);
 	});
 });

--- a/src/__tests__/VideoPlayerSpec.ts
+++ b/src/__tests__/VideoPlayerSpec.ts
@@ -6,8 +6,8 @@ describe("VideoPlayer", () => {
 		const player = new VideoPlayer();
 		expect(player._loop).toBe(false);
 		expect(player.volume).toBe(1.0);
-		expect(player.played.constructor).toBe(Trigger);
-		expect(player.stopped.constructor).toBe(Trigger);
+		expect(player.onPlay.constructor).toBe(Trigger);
+		expect(player.onStop.constructor).toBe(Trigger);
 		expect(player.currentVideo).toBeUndefined();
 	});
 });

--- a/src/domain/DefaultLoadingScene.ts
+++ b/src/domain/DefaultLoadingScene.ts
@@ -107,7 +107,7 @@ export class DefaultLoadingScene extends LoadingScene {
 		this._totalWaitingAssetCount = 0;
 		this.onLoad.add(this._onLoaded, this);
 		this.onTargetReset.add(this._onTargetReset, this);
-		this.onTargetAssetLoaded.add(this._onTargetAssetLoaded, this);
+		this.onTargetAssetLoad.add(this._onTargetAssetLoaded, this);
 	}
 
 	/**

--- a/src/domain/DefaultLoadingScene.ts
+++ b/src/domain/DefaultLoadingScene.ts
@@ -105,9 +105,9 @@ export class DefaultLoadingScene extends LoadingScene {
 		this._gauge = undefined;
 		this._gaugeUpdateCount = 0;
 		this._totalWaitingAssetCount = 0;
-		this.loaded.add(this._onLoaded, this);
-		this.targetReset.add(this._onTargetReset, this);
-		this.targetAssetLoaded.add(this._onTargetAssetLoaded, this);
+		this.onLoad.add(this._onLoaded, this);
+		this.onTargetReset.add(this._onTargetReset, this);
+		this.onTargetAssetLoaded.add(this._onTargetAssetLoaded, this);
 	}
 
 	/**
@@ -157,7 +157,7 @@ export class DefaultLoadingScene extends LoadingScene {
 				]
 			})
 		);
-		gauge.update.add(this._onUpdateGuage, this);
+		gauge.onUpdate.add(this._onUpdateGuage, this);
 		this._gauge = gauge;
 		return true; // Trigger 登録を解除する
 	}

--- a/src/domain/LoadingScene.ts
+++ b/src/domain/LoadingScene.ts
@@ -33,15 +33,33 @@ export class LoadingScene extends Scene {
 	 * ローディングシーンの読み込み待ち対象シーンが切り替わった場合にfireされるTrigger。
 	 * ゲーム開発者は、このTriggerにaddしてローディングシーンの内容を初期化することができる。
 	 */
+	onTargetReset: Trigger<Scene>;
+	/**
+	 * ローディングシーンの読み込み待ち対象シーンが切り替わった場合にfireされるTrigger。
+	 * ゲーム開発者は、このTriggerにaddしてローディングシーンの内容を初期化することができる。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	targetReset: Trigger<Scene>;
 	/**
 	 * ローディングシーンの読み込みが完了した時にfireされるTrigger。
 	 * `explicitEnd` に真を渡して生成した場合、ローディングシーンを終了するには
 	 * このTriggerのfire後に明示的に `end()` を呼び出す必要がある。
 	 */
+	onTargetReady: Trigger<Scene>;
+	/**
+	 * ローディングシーンの読み込みが完了した時にfireされるTrigger。
+	 * `explicitEnd` に真を渡して生成した場合、ローディングシーンを終了するには
+	 * このTriggerのfire後に明示的に `end()` を呼び出す必要がある。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	targetReady: Trigger<Scene>;
 	/**
 	 * ローディングシーンの読み込み待ち対象シーンがアセットを読み込む度にfireされるTrigger。
+	 */
+	onTargetAssetLoaded: Trigger<AssetLike>;
+	/**
+	 * ローディングシーンの読み込み待ち対象シーンがアセットを読み込む度にfireされるTrigger。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	targetAssetLoaded: Trigger<AssetLike>;
 
@@ -62,9 +80,12 @@ export class LoadingScene extends Scene {
 	constructor(param: LoadingSceneParameterObject) {
 		param.local = true; // LoadingScene は強制的にローカルにする
 		super(param);
-		this.targetReset = new Trigger<Scene>();
-		this.targetReady = new Trigger<Scene>();
-		this.targetAssetLoaded = new Trigger<AssetLike>();
+		this.onTargetReset = new Trigger<Scene>();
+		this.targetReset = this.onTargetReset;
+		this.onTargetReady = new Trigger<Scene>();
+		this.targetReady = this.onTargetReady;
+		this.onTargetAssetLoaded = new Trigger<AssetLike>();
+		this.targetAssetLoaded = this.onTargetAssetLoaded;
 		this._explicitEnd = !!param.explicitEnd;
 		this._targetScene = undefined;
 	}
@@ -87,7 +108,7 @@ export class LoadingScene extends Scene {
 		this._clearTargetScene();
 		this._targetScene = targetScene;
 		if (this._loadingState < SceneLoadState.LoadedFired) {
-			this.loaded.addOnce(this._doReset, this);
+			this.onLoad.addOnce(this._doReset, this);
 		} else {
 			this._doReset();
 		}
@@ -123,8 +144,8 @@ export class LoadingScene extends Scene {
 	 */
 	_clearTargetScene(): void {
 		if (!this._targetScene) return;
-		this._targetScene._ready.removeAll({ owner: this });
-		this._targetScene.assetLoaded.removeAll({ owner: this });
+		this._targetScene._onReady.removeAll({ owner: this });
+		this._targetScene.onAssetLoad.removeAll({ owner: this });
 		this._targetScene = undefined;
 	}
 
@@ -132,10 +153,10 @@ export class LoadingScene extends Scene {
 	 * @private
 	 */
 	_doReset(): void {
-		this.targetReset.fire(this._targetScene);
+		this.onTargetReset.fire(this._targetScene);
 		if (this._targetScene._loadingState < SceneLoadState.ReadyFired) {
-			this._targetScene._ready.add(this._fireTriggerOnTargetReady, this);
-			this._targetScene.assetLoaded.add(this._fireTriggerOnTargetAssetLoad, this);
+			this._targetScene._onReady.add(this._fireTriggerOnTargetReady, this);
+			this._targetScene.onAssetLoad.add(this._fireTriggerOnTargetAssetLoad, this);
 			this._targetScene._load();
 		} else {
 			this._fireTriggerOnTargetReady(this._targetScene);
@@ -146,14 +167,14 @@ export class LoadingScene extends Scene {
 	 * @private
 	 */
 	_fireTriggerOnTargetAssetLoad(asset: AssetLike): void {
-		this.targetAssetLoaded.fire(asset);
+		this.onTargetAssetLoaded.fire(asset);
 	}
 
 	/**
 	 * @private
 	 */
 	_fireTriggerOnTargetReady(scene: Scene): void {
-		this.targetReady.fire(scene);
+		this.onTargetReady.fire(scene);
 		if (!this._explicitEnd) {
 			this.end();
 		}

--- a/src/domain/LoadingScene.ts
+++ b/src/domain/LoadingScene.ts
@@ -35,31 +35,31 @@ export class LoadingScene extends Scene {
 	 */
 	onTargetReset: Trigger<Scene>;
 	/**
-	 * ローディングシーンの読み込み待ち対象シーンが切り替わった場合にfireされるTrigger。
-	 * ゲーム開発者は、このTriggerにaddしてローディングシーンの内容を初期化することができる。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	targetReset: Trigger<Scene>;
-	/**
 	 * ローディングシーンの読み込みが完了した時にfireされるTrigger。
 	 * `explicitEnd` に真を渡して生成した場合、ローディングシーンを終了するには
 	 * このTriggerのfire後に明示的に `end()` を呼び出す必要がある。
 	 */
 	onTargetReady: Trigger<Scene>;
 	/**
+	 * ローディングシーンの読み込み待ち対象シーンがアセットを読み込む度にfireされるTrigger。
+	 */
+	onTargetAssetLoad: Trigger<AssetLike>;
+	/**
+	 * ローディングシーンの読み込み待ち対象シーンが切り替わった場合にfireされるTrigger。
+	 * ゲーム開発者は、このTriggerにaddしてローディングシーンの内容を初期化することができる。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onTargetReset` を利用すること。
+	 */
+	targetReset: Trigger<Scene>;
+	/**
 	 * ローディングシーンの読み込みが完了した時にfireされるTrigger。
 	 * `explicitEnd` に真を渡して生成した場合、ローディングシーンを終了するには
 	 * このTriggerのfire後に明示的に `end()` を呼び出す必要がある。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onTargetReady` を利用すること。
 	 */
 	targetReady: Trigger<Scene>;
 	/**
 	 * ローディングシーンの読み込み待ち対象シーンがアセットを読み込む度にfireされるTrigger。
-	 */
-	onTargetAssetLoaded: Trigger<AssetLike>;
-	/**
-	 * ローディングシーンの読み込み待ち対象シーンがアセットを読み込む度にfireされるTrigger。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onTargetAssetLoad` を利用すること。
 	 */
 	targetAssetLoaded: Trigger<AssetLike>;
 
@@ -81,11 +81,11 @@ export class LoadingScene extends Scene {
 		param.local = true; // LoadingScene は強制的にローカルにする
 		super(param);
 		this.onTargetReset = new Trigger<Scene>();
-		this.targetReset = this.onTargetReset;
 		this.onTargetReady = new Trigger<Scene>();
+		this.onTargetAssetLoad = new Trigger<AssetLike>();
+		this.targetReset = this.onTargetReset;
 		this.targetReady = this.onTargetReady;
-		this.onTargetAssetLoaded = new Trigger<AssetLike>();
-		this.targetAssetLoaded = this.onTargetAssetLoaded;
+		this.targetAssetLoaded = this.onTargetAssetLoad;
 		this._explicitEnd = !!param.explicitEnd;
 		this._targetScene = undefined;
 	}
@@ -167,7 +167,7 @@ export class LoadingScene extends Scene {
 	 * @private
 	 */
 	_fireTriggerOnTargetAssetLoad(asset: AssetLike): void {
-		this.onTargetAssetLoaded.fire(asset);
+		this.onTargetAssetLoad.fire(asset);
 	}
 
 	/**

--- a/src/domain/OperationPluginManager.ts
+++ b/src/domain/OperationPluginManager.ts
@@ -45,6 +45,11 @@ export class OperationPluginManager {
 	/**
 	 * 操作プラグインの操作を通知する `Trigger` 。
 	 */
+	onOperate: Trigger<InternalOperationPluginOperation>;
+	/**
+	 * 操作プラグインの操作を通知する `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	operated: Trigger<InternalOperationPluginOperation>;
 
 	/**
@@ -58,7 +63,8 @@ export class OperationPluginManager {
 	private _initialized: boolean;
 
 	constructor(game: Game, viewInfo: OperationPluginViewInfo, infos: InternalOperationPluginInfo[]) {
-		this.operated = new Trigger<InternalOperationPluginOperation>();
+		this.onOperate = new Trigger<InternalOperationPluginOperation>();
+		this.operated = this.onOperate;
 		this.plugins = {};
 		this._game = game;
 		this._viewInfo = viewInfo;
@@ -113,7 +119,8 @@ export class OperationPluginManager {
 
 	destroy(): void {
 		this.stopAll();
-		this.operated.destroy();
+		this.onOperate.destroy();
+		this.onOperate = undefined;
 		this.operated = undefined;
 		this.plugins = undefined;
 		this._game = undefined;
@@ -157,7 +164,7 @@ export class OperationPluginManager {
 		}
 		const plugin = new pluginClass(this._game, this._viewInfo, option);
 		this.plugins[code] = plugin;
-		const handler = new OperationHandler(code, this.operated, this.operated.fire);
+		const handler = new OperationHandler(code, this.onOperate, this.onOperate.fire);
 		plugin.operationTrigger.add(handler.onOperation, handler);
 		return plugin;
 	}

--- a/src/domain/OperationPluginManager.ts
+++ b/src/domain/OperationPluginManager.ts
@@ -48,7 +48,7 @@ export class OperationPluginManager {
 	onOperate: Trigger<InternalOperationPluginOperation>;
 	/**
 	 * 操作プラグインの操作を通知する `Trigger` 。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onOperate` を利用すること。
 	 */
 	operated: Trigger<InternalOperationPluginOperation>;
 

--- a/src/domain/SurfaceUtil.ts
+++ b/src/domain/SurfaceUtil.ts
@@ -44,8 +44,8 @@ export module SurfaceUtil {
 	 */
 	export function setupAnimatingHandler(animatingHandler: AnimatingHandler, surface: SurfaceLike): void {
 		if (surface.isDynamic) {
-			surface.animatingStarted.add(animatingHandler._onAnimatingStarted, animatingHandler);
-			surface.animatingStopped.add(animatingHandler._onAnimatingStopped, animatingHandler);
+			surface.onAnimationStart.add(animatingHandler._onAnimatingStarted, animatingHandler);
+			surface.onAnimationStop.add(animatingHandler._onAnimatingStopped, animatingHandler);
 			if (surface.isPlaying()) {
 				animatingHandler._onAnimatingStarted();
 			}
@@ -69,13 +69,13 @@ export module SurfaceUtil {
 		animatingHandler._onAnimatingStopped();
 
 		if (!beforeSurface.destroyed() && beforeSurface.isDynamic) {
-			beforeSurface.animatingStarted.remove(animatingHandler._onAnimatingStarted, animatingHandler);
-			beforeSurface.animatingStopped.remove(animatingHandler._onAnimatingStopped, animatingHandler);
+			beforeSurface.onAnimationStart.remove(animatingHandler._onAnimatingStarted, animatingHandler);
+			beforeSurface.onAnimationStop.remove(animatingHandler._onAnimatingStopped, animatingHandler);
 		}
 
 		if (afterSurface.isDynamic) {
-			afterSurface.animatingStarted.add(animatingHandler._onAnimatingStarted, animatingHandler);
-			afterSurface.animatingStopped.add(animatingHandler._onAnimatingStopped, animatingHandler);
+			afterSurface.onAnimationStart.add(animatingHandler._onAnimatingStarted, animatingHandler);
+			afterSurface.onAnimationStop.add(animatingHandler._onAnimatingStopped, animatingHandler);
 			if (afterSurface.isPlaying()) {
 				animatingHandler._onAnimatingStarted();
 			}

--- a/src/domain/Timer.ts
+++ b/src/domain/Timer.ts
@@ -17,6 +17,12 @@ export class Timer implements Destroyable {
 	/**
 	 * `this.interval` 経過時にfireされるTrigger。
 	 */
+	onElapsed: Trigger<void>;
+
+	/**
+	 * `this.interval` 経過時にfireされるTrigger。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	elapsed: Trigger<void>;
 
 	/**
@@ -37,7 +43,8 @@ export class Timer implements Destroyable {
 		this.interval = interval;
 		// NOTE: intervalが浮動小数の場合があるため念のため四捨五入する
 		this._scaledInterval = Math.round(interval * fps);
-		this.elapsed = new Trigger<void>();
+		this.onElapsed = new Trigger<void>();
+		this.elapsed = this.onElapsed;
 		this._scaledElapsed = 0;
 	}
 
@@ -46,27 +53,28 @@ export class Timer implements Destroyable {
 		this._scaledElapsed += 1000;
 		while (this._scaledElapsed >= this._scaledInterval) {
 			// NOTE: this.elapsed.fire()内でdestroy()される可能性があるため、destroyed()を判定する
-			if (!this.elapsed) {
+			if (!this.onElapsed) {
 				break;
 			}
-			this.elapsed.fire();
+			this.onElapsed.fire();
 			this._scaledElapsed -= this._scaledInterval;
 		}
 	}
 
 	canDelete(): boolean {
-		return !this.elapsed || this.elapsed.length === 0;
+		return !this.onElapsed || this.onElapsed.length === 0;
 	}
 
 	destroy(): void {
 		this.interval = undefined;
-		this.elapsed.destroy();
+		this.onElapsed.destroy();
+		this.onElapsed = undefined;
 		this.elapsed = undefined;
 		this._scaledInterval = 0;
 		this._scaledElapsed = 0;
 	}
 
 	destroyed(): boolean {
-		return this.elapsed === undefined;
+		return this.onElapsed === undefined;
 	}
 }

--- a/src/domain/Timer.ts
+++ b/src/domain/Timer.ts
@@ -17,11 +17,11 @@ export class Timer implements Destroyable {
 	/**
 	 * `this.interval` 経過時にfireされるTrigger。
 	 */
-	onElapsed: Trigger<void>;
+	onElapse: Trigger<void>;
 
 	/**
 	 * `this.interval` 経過時にfireされるTrigger。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onElapse` を利用すること。
 	 */
 	elapsed: Trigger<void>;
 
@@ -43,8 +43,8 @@ export class Timer implements Destroyable {
 		this.interval = interval;
 		// NOTE: intervalが浮動小数の場合があるため念のため四捨五入する
 		this._scaledInterval = Math.round(interval * fps);
-		this.onElapsed = new Trigger<void>();
-		this.elapsed = this.onElapsed;
+		this.onElapse = new Trigger<void>();
+		this.elapsed = this.onElapse;
 		this._scaledElapsed = 0;
 	}
 
@@ -53,28 +53,28 @@ export class Timer implements Destroyable {
 		this._scaledElapsed += 1000;
 		while (this._scaledElapsed >= this._scaledInterval) {
 			// NOTE: this.elapsed.fire()内でdestroy()される可能性があるため、destroyed()を判定する
-			if (!this.onElapsed) {
+			if (!this.onElapse) {
 				break;
 			}
-			this.onElapsed.fire();
+			this.onElapse.fire();
 			this._scaledElapsed -= this._scaledInterval;
 		}
 	}
 
 	canDelete(): boolean {
-		return !this.onElapsed || this.onElapsed.length === 0;
+		return !this.onElapse || this.onElapse.length === 0;
 	}
 
 	destroy(): void {
 		this.interval = undefined;
-		this.onElapsed.destroy();
-		this.onElapsed = undefined;
+		this.onElapse.destroy();
+		this.onElapse = undefined;
 		this.elapsed = undefined;
 		this._scaledInterval = 0;
 		this._scaledElapsed = 0;
 	}
 
 	destroyed(): boolean {
-		return this.onElapsed === undefined;
+		return this.onElapse === undefined;
 	}
 }

--- a/src/domain/TimerManager.ts
+++ b/src/domain/TimerManager.ts
@@ -40,11 +40,11 @@ export class TimerIdentifier implements Destroyable {
 		this._handlerOwner = handlerOwner;
 		this._fired = fired;
 		this._firedOwner = firedOwner;
-		this._timer.elapsed.add(this._fire, this);
+		this._timer.onElapsed.add(this._fire, this);
 	}
 
 	destroy(): void {
-		this._timer.elapsed.remove(this._fire, this);
+		this._timer.onElapsed.remove(this._fire, this);
 		this._timer = undefined;
 		this._handler = undefined;
 		this._handlerOwner = undefined;

--- a/src/domain/TimerManager.ts
+++ b/src/domain/TimerManager.ts
@@ -40,11 +40,11 @@ export class TimerIdentifier implements Destroyable {
 		this._handlerOwner = handlerOwner;
 		this._fired = fired;
 		this._firedOwner = firedOwner;
-		this._timer.onElapsed.add(this._fire, this);
+		this._timer.onElapse.add(this._fire, this);
 	}
 
 	destroy(): void {
-		this._timer.onElapsed.remove(this._fire, this);
+		this._timer.onElapse.remove(this._fire, this);
 		this._timer = undefined;
 		this._handler = undefined;
 		this._handlerOwner = undefined;

--- a/src/domain/entities/E.ts
+++ b/src/domain/entities/E.ts
@@ -200,30 +200,51 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	_hasTouchableChildren: boolean;
 
-	private _update: Trigger<void>;
-	private _message: Trigger<MessageEvent>;
-	private _pointDown: Trigger<PointDownEvent>;
-	private _pointUp: Trigger<PointUpEvent>;
-	private _pointMove: Trigger<PointMoveEvent>;
+	private _onUpdate: Trigger<void>;
+	private _onMessage: Trigger<MessageEvent>;
+	private _onPointDown: Trigger<PointDownEvent>;
+	private _onPointUp: Trigger<PointUpEvent>;
+	private _onPointMove: Trigger<PointMoveEvent>;
 	private _touchable: boolean;
 
 	/**
 	 * 時間経過イベント。本イベントの一度のfireにつき、常に1フレーム分の時間経過が起こる。
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
-	get update(): Trigger<void> {
-		if (!this._update) this._update = new ChainTrigger<void>(this.scene.update);
-		return this._update;
+	get onUpdate(): Trigger<void> {
+		if (!this._onUpdate) this._onUpdate = new ChainTrigger<void>(this.scene.onUpdate);
+		return this._onUpdate;
 	}
 	// updateは代入する必要がないのでsetterを定義しない
+
+	/**
+	 * 時間経過イベント。本イベントの一度のfireにつき、常に1フレーム分の時間経過が起こる。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
+	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
+	get update(): Trigger<void> {
+		if (!this._onUpdate) this._onUpdate = new ChainTrigger<void>(this.scene.onUpdate);
+		return this._onUpdate;
+	}
 
 	/**
 	 * このエンティティのmessageイベント。
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
+	get onMessage(): Trigger<MessageEvent> {
+		if (!this._onMessage) this._onMessage = new ChainTrigger<MessageEvent>(this.scene.onMessage);
+		return this._onMessage;
+	}
+	// messageは代入する必要がないのでsetterを定義しない
+
+	/**
+	 * このエンティティのmessageイベント。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
+	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get message(): Trigger<MessageEvent> {
-		if (!this._message) this._message = new ChainTrigger<MessageEvent>(this.scene.message);
-		return this._message;
+		if (!this._onMessage) this._onMessage = new ChainTrigger<MessageEvent>(this.scene.onMessage);
+		return this._onMessage;
 	}
 	// messageは代入する必要がないのでsetterを定義しない
 
@@ -231,10 +252,22 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 * このエンティティのpoint downイベント。
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
+	get onPointDown(): Trigger<PointDownEvent> {
+		if (!this._onPointDown)
+			this._onPointDown = new ChainTrigger<PointDownEvent>(this.scene.onPointDownCapture, this._isTargetOperation, this);
+		return this._onPointDown;
+	}
+	// pointDownは代入する必要がないのでsetterを定義しない
+
+	/**
+	 * このエンティティのpoint downイベント。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
+	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get pointDown(): Trigger<PointDownEvent> {
-		if (!this._pointDown)
-			this._pointDown = new ChainTrigger<PointDownEvent>(this.scene.pointDownCapture, this._isTargetOperation, this);
-		return this._pointDown;
+		if (!this._onPointDown)
+			this._onPointDown = new ChainTrigger<PointDownEvent>(this.scene.onPointDownCapture, this._isTargetOperation, this);
+		return this._onPointDown;
 	}
 	// pointDownは代入する必要がないのでsetterを定義しない
 
@@ -242,9 +275,20 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 * このエンティティのpoint upイベント。
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
+	get onPointUp(): Trigger<PointUpEvent> {
+		if (!this._onPointUp) this._onPointUp = new ChainTrigger<PointUpEvent>(this.scene.onPointUpCapture, this._isTargetOperation, this);
+		return this._onPointUp;
+	}
+	// pointUpは代入する必要がないのでsetterを定義しない
+
+	/**
+	 * このエンティティのpoint upイベント。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
+	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get pointUp(): Trigger<PointUpEvent> {
-		if (!this._pointUp) this._pointUp = new ChainTrigger<PointUpEvent>(this.scene.pointUpCapture, this._isTargetOperation, this);
-		return this._pointUp;
+		if (!this._onPointUp) this._onPointUp = new ChainTrigger<PointUpEvent>(this.scene.onPointUpCapture, this._isTargetOperation, this);
+		return this._onPointUp;
 	}
 	// pointUpは代入する必要がないのでsetterを定義しない
 
@@ -252,10 +296,22 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 * このエンティティのpoint moveイベント。
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
+	get onPointMove(): Trigger<PointMoveEvent> {
+		if (!this._onPointMove)
+			this._onPointMove = new ChainTrigger<PointMoveEvent>(this.scene.onPointMoveCapture, this._isTargetOperation, this);
+		return this._onPointMove;
+	}
+	// pointMoveは代入する必要がないのでsetterを定義しない
+
+	/**
+	 * このエンティティのpoint moveイベント。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
+	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get pointMove(): Trigger<PointMoveEvent> {
-		if (!this._pointMove)
-			this._pointMove = new ChainTrigger<PointMoveEvent>(this.scene.pointMoveCapture, this._isTargetOperation, this);
-		return this._pointMove;
+		if (!this._onPointMove)
+			this._onPointMove = new ChainTrigger<PointMoveEvent>(this.scene.onPointMoveCapture, this._isTargetOperation, this);
+		return this._onPointMove;
 	}
 	// pointMoveは代入する必要がないのでsetterを定義しない
 
@@ -292,11 +348,11 @@ export class E extends Object2D implements CommonArea, Destroyable {
 		this._touchable = false;
 		this.state = EntityStateFlags.None;
 		this._hasTouchableChildren = false;
-		this._update = undefined;
-		this._message = undefined;
-		this._pointDown = undefined;
-		this._pointMove = undefined;
-		this._pointUp = undefined;
+		this._onUpdate = undefined;
+		this._onMessage = undefined;
+		this._onPointDown = undefined;
+		this._onPointMove = undefined;
+		this._onPointUp = undefined;
 		this.tag = param.tag;
 		this.shaderProgram = param.shaderProgram;
 
@@ -476,25 +532,25 @@ export class E extends Object2D implements CommonArea, Destroyable {
 		}
 
 		// この解放はstringとforeachを使って書きたいが、minifyする時は.アクセスの方がいいのでやむを得ない
-		if (this._update) {
-			this._update.destroy();
-			this._update = undefined;
+		if (this._onUpdate) {
+			this._onUpdate.destroy();
+			this._onUpdate = undefined;
 		}
-		if (this._message) {
-			this._message.destroy();
-			this._message = undefined;
+		if (this._onMessage) {
+			this._onMessage.destroy();
+			this._onMessage = undefined;
 		}
-		if (this._pointDown) {
-			this._pointDown.destroy();
-			this._pointDown = undefined;
+		if (this._onPointDown) {
+			this._onPointDown.destroy();
+			this._onPointDown = undefined;
 		}
-		if (this._pointMove) {
-			this._pointMove.destroy();
-			this._pointMove = undefined;
+		if (this._onPointMove) {
+			this._onPointMove.destroy();
+			this._onPointMove = undefined;
 		}
-		if (this._pointUp) {
-			this._pointUp.destroy();
-			this._pointUp = undefined;
+		if (this._onPointUp) {
+			this._onPointUp.destroy();
+			this._onPointUp = undefined;
 		}
 
 		this.scene.unregister(this);

--- a/src/domain/entities/E.ts
+++ b/src/domain/entities/E.ts
@@ -200,11 +200,11 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	_hasTouchableChildren: boolean;
 
-	private _onUpdate: Trigger<void>;
-	private _onMessage: Trigger<MessageEvent>;
-	private _onPointDown: Trigger<PointDownEvent>;
-	private _onPointUp: Trigger<PointUpEvent>;
-	private _onPointMove: Trigger<PointMoveEvent>;
+	private _update: Trigger<void>;
+	private _message: Trigger<MessageEvent>;
+	private _pointDown: Trigger<PointDownEvent>;
+	private _pointUp: Trigger<PointUpEvent>;
+	private _pointMove: Trigger<PointMoveEvent>;
 	private _touchable: boolean;
 
 	/**
@@ -212,108 +212,52 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get onUpdate(): Trigger<void> {
-		if (!this._onUpdate) this._onUpdate = new ChainTrigger<void>(this.scene.onUpdate);
-		return this._onUpdate;
+		if (!this._update) this._update = new ChainTrigger<void>(this.scene.onUpdate);
+		return this._update;
 	}
-	// updateは代入する必要がないのでsetterを定義しない
-
-	/**
-	 * 時間経過イベント。本イベントの一度のfireにつき、常に1フレーム分の時間経過が起こる。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
-	get update(): Trigger<void> {
-		if (!this._onUpdate) this._onUpdate = new ChainTrigger<void>(this.scene.onUpdate);
-		return this._onUpdate;
-	}
+	// onUpdateは代入する必要がないのでsetterを定義しない
 
 	/**
 	 * このエンティティのmessageイベント。
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get onMessage(): Trigger<MessageEvent> {
-		if (!this._onMessage) this._onMessage = new ChainTrigger<MessageEvent>(this.scene.onMessage);
-		return this._onMessage;
+		if (!this._message) this._message = new ChainTrigger<MessageEvent>(this.scene.onMessage);
+		return this._message;
 	}
-	// messageは代入する必要がないのでsetterを定義しない
-
-	/**
-	 * このエンティティのmessageイベント。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
-	get message(): Trigger<MessageEvent> {
-		if (!this._onMessage) this._onMessage = new ChainTrigger<MessageEvent>(this.scene.onMessage);
-		return this._onMessage;
-	}
-	// messageは代入する必要がないのでsetterを定義しない
+	// onMessageは代入する必要がないのでsetterを定義しない
 
 	/**
 	 * このエンティティのpoint downイベント。
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get onPointDown(): Trigger<PointDownEvent> {
-		if (!this._onPointDown)
-			this._onPointDown = new ChainTrigger<PointDownEvent>(this.scene.onPointDownCapture, this._isTargetOperation, this);
-		return this._onPointDown;
+		if (!this._pointDown)
+			this._pointDown = new ChainTrigger<PointDownEvent>(this.scene.onPointDownCapture, this._isTargetOperation, this);
+		return this._pointDown;
 	}
-	// pointDownは代入する必要がないのでsetterを定義しない
-
-	/**
-	 * このエンティティのpoint downイベント。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
-	get pointDown(): Trigger<PointDownEvent> {
-		if (!this._onPointDown)
-			this._onPointDown = new ChainTrigger<PointDownEvent>(this.scene.onPointDownCapture, this._isTargetOperation, this);
-		return this._onPointDown;
-	}
-	// pointDownは代入する必要がないのでsetterを定義しない
+	// onPointDownは代入する必要がないのでsetterを定義しない
 
 	/**
 	 * このエンティティのpoint upイベント。
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get onPointUp(): Trigger<PointUpEvent> {
-		if (!this._onPointUp) this._onPointUp = new ChainTrigger<PointUpEvent>(this.scene.onPointUpCapture, this._isTargetOperation, this);
-		return this._onPointUp;
+		if (!this._pointUp) this._pointUp = new ChainTrigger<PointUpEvent>(this.scene.onPointUpCapture, this._isTargetOperation, this);
+		return this._pointUp;
 	}
-	// pointUpは代入する必要がないのでsetterを定義しない
-
-	/**
-	 * このエンティティのpoint upイベント。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
-	get pointUp(): Trigger<PointUpEvent> {
-		if (!this._onPointUp) this._onPointUp = new ChainTrigger<PointUpEvent>(this.scene.onPointUpCapture, this._isTargetOperation, this);
-		return this._onPointUp;
-	}
-	// pointUpは代入する必要がないのでsetterを定義しない
+	// onPointUpは代入する必要がないのでsetterを定義しない
 
 	/**
 	 * このエンティティのpoint moveイベント。
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get onPointMove(): Trigger<PointMoveEvent> {
-		if (!this._onPointMove)
-			this._onPointMove = new ChainTrigger<PointMoveEvent>(this.scene.onPointMoveCapture, this._isTargetOperation, this);
-		return this._onPointMove;
+		if (!this._pointMove)
+			this._pointMove = new ChainTrigger<PointMoveEvent>(this.scene.onPointMoveCapture, this._isTargetOperation, this);
+		return this._pointMove;
 	}
-	// pointMoveは代入する必要がないのでsetterを定義しない
-
-	/**
-	 * このエンティティのpoint moveイベント。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
-	get pointMove(): Trigger<PointMoveEvent> {
-		if (!this._onPointMove)
-			this._onPointMove = new ChainTrigger<PointMoveEvent>(this.scene.onPointMoveCapture, this._isTargetOperation, this);
-		return this._onPointMove;
-	}
-	// pointMoveは代入する必要がないのでsetterを定義しない
+	// onPointMoveは代入する必要がないのでsetterを定義しない
 
 	/**
 	 * プレイヤーにとって触れられるオブジェクトであるかを表す。
@@ -338,6 +282,63 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	}
 
 	/**
+	 * 時間経過イベント。本イベントの一度のfireにつき、常に1フレーム分の時間経過が起こる。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onUpdate` を利用すること。
+	 */
+	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
+	get update(): Trigger<void> {
+		if (!this._update) this._update = new ChainTrigger<void>(this.scene.onUpdate);
+		return this._update;
+	}
+	// updateは代入する必要がないのでsetterを定義しない
+
+	/**
+	 * このエンティティのmessageイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onMessage` を利用すること。
+	 */
+	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
+	get message(): Trigger<MessageEvent> {
+		if (!this._message) this._message = new ChainTrigger<MessageEvent>(this.scene.onMessage);
+		return this._message;
+	}
+	// messageは代入する必要がないのでsetterを定義しない
+
+	/**
+	 * このエンティティのpoint downイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPointDown` を利用すること。
+	 */
+	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
+	get pointDown(): Trigger<PointDownEvent> {
+		if (!this._pointDown)
+			this._pointDown = new ChainTrigger<PointDownEvent>(this.scene.onPointDownCapture, this._isTargetOperation, this);
+		return this._pointDown;
+	}
+	// pointDownは代入する必要がないのでsetterを定義しない
+
+	/**
+	 * このエンティティのpoint upイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPointUp` を利用すること。
+	 */
+	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
+	get pointUp(): Trigger<PointUpEvent> {
+		if (!this._pointUp) this._pointUp = new ChainTrigger<PointUpEvent>(this.scene.onPointUpCapture, this._isTargetOperation, this);
+		return this._pointUp;
+	}
+	// pointUpは代入する必要がないのでsetterを定義しない
+
+	/**
+	 * このエンティティのpoint moveイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPointMove` を利用すること。
+	 */
+	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
+	get pointMove(): Trigger<PointMoveEvent> {
+		if (!this._pointMove)
+			this._pointMove = new ChainTrigger<PointMoveEvent>(this.scene.onPointMoveCapture, this._isTargetOperation, this);
+		return this._pointMove;
+	}
+	// pointMoveは代入する必要がないのでsetterを定義しない
+
+	/**
 	 * 各種パラメータを指定して `E` のインスタンスを生成する。
 	 * @param param 初期化に用いるパラメータのオブジェクト
 	 */
@@ -348,11 +349,11 @@ export class E extends Object2D implements CommonArea, Destroyable {
 		this._touchable = false;
 		this.state = EntityStateFlags.None;
 		this._hasTouchableChildren = false;
-		this._onUpdate = undefined;
-		this._onMessage = undefined;
-		this._onPointDown = undefined;
-		this._onPointMove = undefined;
-		this._onPointUp = undefined;
+		this._update = undefined;
+		this._message = undefined;
+		this._pointDown = undefined;
+		this._pointMove = undefined;
+		this._pointUp = undefined;
 		this.tag = param.tag;
 		this.shaderProgram = param.shaderProgram;
 
@@ -532,25 +533,25 @@ export class E extends Object2D implements CommonArea, Destroyable {
 		}
 
 		// この解放はstringとforeachを使って書きたいが、minifyする時は.アクセスの方がいいのでやむを得ない
-		if (this._onUpdate) {
-			this._onUpdate.destroy();
-			this._onUpdate = undefined;
+		if (this._update) {
+			this._update.destroy();
+			this._update = undefined;
 		}
-		if (this._onMessage) {
-			this._onMessage.destroy();
-			this._onMessage = undefined;
+		if (this._message) {
+			this._message.destroy();
+			this._message = undefined;
 		}
-		if (this._onPointDown) {
-			this._onPointDown.destroy();
-			this._onPointDown = undefined;
+		if (this._pointDown) {
+			this._pointDown.destroy();
+			this._pointDown = undefined;
 		}
-		if (this._onPointMove) {
-			this._onPointMove.destroy();
-			this._onPointMove = undefined;
+		if (this._pointMove) {
+			this._pointMove.destroy();
+			this._pointMove = undefined;
 		}
-		if (this._onPointUp) {
-			this._onPointUp.destroy();
-			this._onPointUp = undefined;
+		if (this._pointUp) {
+			this._pointUp.destroy();
+			this._pointUp = undefined;
 		}
 
 		this.scene.unregister(this);

--- a/src/domain/entities/E.ts
+++ b/src/domain/entities/E.ts
@@ -200,11 +200,12 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	_hasTouchableChildren: boolean;
 
+	// TODO: ハンドラ側のrename作業が終わり次第、_onUpdateへ修正する
 	private _update: Trigger<void>;
-	private _message: Trigger<MessageEvent>;
-	private _pointDown: Trigger<PointDownEvent>;
-	private _pointUp: Trigger<PointUpEvent>;
-	private _pointMove: Trigger<PointMoveEvent>;
+	private _onMessage: Trigger<MessageEvent>;
+	private _onPointDown: Trigger<PointDownEvent>;
+	private _onPointUp: Trigger<PointUpEvent>;
+	private _onPointMove: Trigger<PointMoveEvent>;
 	private _touchable: boolean;
 
 	/**
@@ -222,8 +223,8 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get onMessage(): Trigger<MessageEvent> {
-		if (!this._message) this._message = new ChainTrigger<MessageEvent>(this.scene.onMessage);
-		return this._message;
+		if (!this._onMessage) this._onMessage = new ChainTrigger<MessageEvent>(this.scene.onMessage);
+		return this._onMessage;
 	}
 	// onMessageは代入する必要がないのでsetterを定義しない
 
@@ -232,9 +233,9 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get onPointDown(): Trigger<PointDownEvent> {
-		if (!this._pointDown)
-			this._pointDown = new ChainTrigger<PointDownEvent>(this.scene.onPointDownCapture, this._isTargetOperation, this);
-		return this._pointDown;
+		if (!this._onPointDown)
+			this._onPointDown = new ChainTrigger<PointDownEvent>(this.scene.onPointDownCapture, this._isTargetOperation, this);
+		return this._onPointDown;
 	}
 	// onPointDownは代入する必要がないのでsetterを定義しない
 
@@ -243,8 +244,8 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get onPointUp(): Trigger<PointUpEvent> {
-		if (!this._pointUp) this._pointUp = new ChainTrigger<PointUpEvent>(this.scene.onPointUpCapture, this._isTargetOperation, this);
-		return this._pointUp;
+		if (!this._onPointUp) this._onPointUp = new ChainTrigger<PointUpEvent>(this.scene.onPointUpCapture, this._isTargetOperation, this);
+		return this._onPointUp;
 	}
 	// onPointUpは代入する必要がないのでsetterを定義しない
 
@@ -253,9 +254,9 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get onPointMove(): Trigger<PointMoveEvent> {
-		if (!this._pointMove)
-			this._pointMove = new ChainTrigger<PointMoveEvent>(this.scene.onPointMoveCapture, this._isTargetOperation, this);
-		return this._pointMove;
+		if (!this._onPointMove)
+			this._onPointMove = new ChainTrigger<PointMoveEvent>(this.scene.onPointMoveCapture, this._isTargetOperation, this);
+		return this._onPointMove;
 	}
 	// onPointMoveは代入する必要がないのでsetterを定義しない
 
@@ -287,8 +288,7 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get update(): Trigger<void> {
-		if (!this._update) this._update = new ChainTrigger<void>(this.scene.onUpdate);
-		return this._update;
+		return this.onUpdate;
 	}
 	// updateは代入する必要がないのでsetterを定義しない
 
@@ -298,8 +298,7 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get message(): Trigger<MessageEvent> {
-		if (!this._message) this._message = new ChainTrigger<MessageEvent>(this.scene.onMessage);
-		return this._message;
+		return this.onMessage;
 	}
 	// messageは代入する必要がないのでsetterを定義しない
 
@@ -309,9 +308,7 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get pointDown(): Trigger<PointDownEvent> {
-		if (!this._pointDown)
-			this._pointDown = new ChainTrigger<PointDownEvent>(this.scene.onPointDownCapture, this._isTargetOperation, this);
-		return this._pointDown;
+		return this.onPointDown;
 	}
 	// pointDownは代入する必要がないのでsetterを定義しない
 
@@ -321,8 +318,7 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get pointUp(): Trigger<PointUpEvent> {
-		if (!this._pointUp) this._pointUp = new ChainTrigger<PointUpEvent>(this.scene.onPointUpCapture, this._isTargetOperation, this);
-		return this._pointUp;
+		return this.onPointUp;
 	}
 	// pointUpは代入する必要がないのでsetterを定義しない
 
@@ -332,9 +328,7 @@ export class E extends Object2D implements CommonArea, Destroyable {
 	 */
 	// Eの生成コスト低減を考慮し、参照された時のみ生成出来るようアクセサを使う
 	get pointMove(): Trigger<PointMoveEvent> {
-		if (!this._pointMove)
-			this._pointMove = new ChainTrigger<PointMoveEvent>(this.scene.onPointMoveCapture, this._isTargetOperation, this);
-		return this._pointMove;
+		return this.onPointMove;
 	}
 	// pointMoveは代入する必要がないのでsetterを定義しない
 
@@ -350,10 +344,10 @@ export class E extends Object2D implements CommonArea, Destroyable {
 		this.state = EntityStateFlags.None;
 		this._hasTouchableChildren = false;
 		this._update = undefined;
-		this._message = undefined;
-		this._pointDown = undefined;
-		this._pointMove = undefined;
-		this._pointUp = undefined;
+		this._onMessage = undefined;
+		this._onPointDown = undefined;
+		this._onPointMove = undefined;
+		this._onPointUp = undefined;
 		this.tag = param.tag;
 		this.shaderProgram = param.shaderProgram;
 
@@ -537,21 +531,21 @@ export class E extends Object2D implements CommonArea, Destroyable {
 			this._update.destroy();
 			this._update = undefined;
 		}
-		if (this._message) {
-			this._message.destroy();
-			this._message = undefined;
+		if (this._onMessage) {
+			this._onMessage.destroy();
+			this._onMessage = undefined;
 		}
-		if (this._pointDown) {
-			this._pointDown.destroy();
-			this._pointDown = undefined;
+		if (this._onPointDown) {
+			this._onPointDown.destroy();
+			this._onPointDown = undefined;
 		}
-		if (this._pointMove) {
-			this._pointMove.destroy();
-			this._pointMove = undefined;
+		if (this._onPointMove) {
+			this._onPointMove.destroy();
+			this._onPointMove = undefined;
 		}
-		if (this._pointUp) {
-			this._pointUp.destroy();
-			this._pointUp = undefined;
+		if (this._onPointUp) {
+			this._onPointUp.destroy();
+			this._onPointUp = undefined;
 		}
 
 		this.scene.unregister(this);

--- a/src/domain/entities/FrameSprite.ts
+++ b/src/domain/entities/FrameSprite.ts
@@ -106,6 +106,13 @@ export class FrameSprite extends Sprite {
 	 * アニメーション終了時にfireされるTrigger。
 	 * 本Triggerは loop: true の場合にのみfireされる。
 	 */
+	onFinish: Trigger<void>;
+
+	/**
+	 * アニメーション終了時にfireされるTrigger。
+	 * 本Triggerは loop: true の場合にのみfireされる。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	finished: Trigger<void>;
 
 	/**
@@ -148,7 +155,8 @@ export class FrameSprite extends Sprite {
 		this.interval = param.interval;
 		this._timer = undefined;
 		this.loop = param.loop != null ? param.loop : true;
-		this.finished = new Trigger<void>();
+		this.onFinish = new Trigger<void>();
+		this.finished = this.onFinish;
 		this._modifiedSelf();
 	}
 
@@ -161,7 +169,7 @@ export class FrameSprite extends Sprite {
 		if (this._timer) this._free();
 
 		this._timer = this.scene.createTimer(this.interval);
-		this._timer.elapsed.add(this._onElapsed, this);
+		this._timer.onElapsed.add(this._onElapsed, this);
 	}
 
 	/**
@@ -198,7 +206,7 @@ export class FrameSprite extends Sprite {
 				this.frameNumber = 0;
 			} else {
 				this.stop();
-				this.finished.fire();
+				this.onFinish.fire();
 			}
 		} else {
 			this.frameNumber++;
@@ -213,7 +221,7 @@ export class FrameSprite extends Sprite {
 	_free(): void {
 		if (!this._timer) return;
 
-		this._timer.elapsed.remove(this._onElapsed, this);
+		this._timer.onElapsed.remove(this._onElapsed, this);
 		if (this._timer.canDelete()) this.scene.deleteTimer(this._timer);
 
 		this._timer = undefined;

--- a/src/domain/entities/FrameSprite.ts
+++ b/src/domain/entities/FrameSprite.ts
@@ -111,7 +111,7 @@ export class FrameSprite extends Sprite {
 	/**
 	 * アニメーション終了時にfireされるTrigger。
 	 * 本Triggerは loop: true の場合にのみfireされる。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onFinish` を利用すること。
 	 */
 	finished: Trigger<void>;
 
@@ -169,7 +169,7 @@ export class FrameSprite extends Sprite {
 		if (this._timer) this._free();
 
 		this._timer = this.scene.createTimer(this.interval);
-		this._timer.onElapsed.add(this._onElapsed, this);
+		this._timer.onElapse.add(this._onElapsed, this);
 	}
 
 	/**
@@ -221,7 +221,7 @@ export class FrameSprite extends Sprite {
 	_free(): void {
 		if (!this._timer) return;
 
-		this._timer.onElapsed.remove(this._onElapsed, this);
+		this._timer.onElapse.remove(this._onElapsed, this);
 		if (this._timer.canDelete()) this.scene.deleteTimer(this._timer);
 
 		this._timer = undefined;

--- a/src/domain/entities/Sprite.ts
+++ b/src/domain/entities/Sprite.ts
@@ -133,7 +133,7 @@ export class Sprite extends E {
 	/**
 	 * @private
 	 */
-	_onUpdate(): void {
+	_onUpdated(): void {
 		this.modified();
 	}
 
@@ -141,8 +141,8 @@ export class Sprite extends E {
 	 * @private
 	 */
 	_onAnimatingStarted(): void {
-		if (!this.update.contains(this._onUpdate, this)) {
-			this.update.add(this._onUpdate, this);
+		if (!this.onUpdate.contains(this._onUpdated, this)) {
+			this.onUpdate.add(this._onUpdated, this);
 		}
 	}
 
@@ -151,7 +151,7 @@ export class Sprite extends E {
 	 */
 	_onAnimatingStopped(): void {
 		if (!this.destroyed()) {
-			this.update.remove(this._onUpdate, this);
+			this.onUpdate.remove(this._onUpdated, this);
 		}
 	}
 
@@ -194,8 +194,8 @@ export class Sprite extends E {
 			if (destroySurface) {
 				this._surface.destroy();
 			} else if (this._surface.isDynamic) {
-				this._surface.animatingStarted.remove(this._onAnimatingStarted, this);
-				this._surface.animatingStopped.remove(this._onAnimatingStopped, this);
+				this._surface.onAnimationStart.remove(this._onAnimatingStarted, this);
+				this._surface.onAnimationStop.remove(this._onAnimatingStopped, this);
 			}
 		}
 		this.src = undefined;

--- a/src/domain/entities/Sprite.ts
+++ b/src/domain/entities/Sprite.ts
@@ -133,7 +133,7 @@ export class Sprite extends E {
 	/**
 	 * @private
 	 */
-	_onUpdated(): void {
+	_onUpdate(): void {
 		this.modified();
 	}
 
@@ -141,8 +141,8 @@ export class Sprite extends E {
 	 * @private
 	 */
 	_onAnimatingStarted(): void {
-		if (!this.onUpdate.contains(this._onUpdated, this)) {
-			this.onUpdate.add(this._onUpdated, this);
+		if (!this.onUpdate.contains(this._onUpdate, this)) {
+			this.onUpdate.add(this._onUpdate, this);
 		}
 	}
 
@@ -151,7 +151,7 @@ export class Sprite extends E {
 	 */
 	_onAnimatingStopped(): void {
 		if (!this.destroyed()) {
-			this.onUpdate.remove(this._onUpdated, this);
+			this.onUpdate.remove(this._onUpdate, this);
 		}
 	}
 

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -23,21 +23,9 @@ export class AudioPlayer implements AudioPlayerLike {
 	onPlay: Trigger<AudioPlayerEvent>;
 
 	/**
-	 * `play()` が呼び出された時に通知される `Trigger` 。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	played: Trigger<AudioPlayerEvent>;
-
-	/**
 	 * `stop()` が呼び出された時に通知される `Trigger` 。
 	 */
 	onStop: Trigger<AudioPlayerEvent>;
-
-	/**
-	 * `stop()` が呼び出された時に通知される `Trigger` 。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	stopped: Trigger<AudioPlayerEvent>;
 
 	/**
 	 * 音量。
@@ -47,6 +35,18 @@ export class AudioPlayer implements AudioPlayerLike {
 	 * 音量を変更したい場合、  `changeVolume()` メソッドを用いること。
 	 */
 	volume: number;
+
+	/**
+	 * `play()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPlay` を利用すること。
+	 */
+	played: Trigger<AudioPlayerEvent>;
+
+	/**
+	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onStop` を利用すること。
+	 */
+	stopped: Trigger<AudioPlayerEvent>;
 
 	/**
 	 * ミュート中か否か。
@@ -64,8 +64,8 @@ export class AudioPlayer implements AudioPlayerLike {
 	 */
 	constructor(system: AudioSystemLike) {
 		this.onPlay = new Trigger<AudioPlayerEvent>();
-		this.played = this.onPlay;
 		this.onStop = new Trigger<AudioPlayerEvent>();
+		this.played = this.onPlay;
 		this.stopped = this.onStop;
 		this.currentAudio = undefined;
 		this.volume = system.volume;

--- a/src/implementations/AudioPlayer.ts
+++ b/src/implementations/AudioPlayer.ts
@@ -20,10 +20,22 @@ export class AudioPlayer implements AudioPlayerLike {
 	/**
 	 * `play()` が呼び出された時に通知される `Trigger` 。
 	 */
+	onPlay: Trigger<AudioPlayerEvent>;
+
+	/**
+	 * `play()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	played: Trigger<AudioPlayerEvent>;
 
 	/**
 	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 */
+	onStop: Trigger<AudioPlayerEvent>;
+
+	/**
+	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	stopped: Trigger<AudioPlayerEvent>;
 
@@ -51,8 +63,10 @@ export class AudioPlayer implements AudioPlayerLike {
 	 * `AudioPlayer` のインスタンスを生成する。
 	 */
 	constructor(system: AudioSystemLike) {
-		this.played = new Trigger<AudioPlayerEvent>();
-		this.stopped = new Trigger<AudioPlayerEvent>();
+		this.onPlay = new Trigger<AudioPlayerEvent>();
+		this.played = this.onPlay;
+		this.onStop = new Trigger<AudioPlayerEvent>();
+		this.stopped = this.onStop;
 		this.currentAudio = undefined;
 		this.volume = system.volume;
 		this._muted = system._muted;
@@ -62,12 +76,12 @@ export class AudioPlayer implements AudioPlayerLike {
 	/**
 	 * `AudioAsset` を再生する。
 	 *
-	 * 再生後、 `this.played` がfireされる。
+	 * 再生後、 `this.onPlay` がfireされる。
 	 * @param audio 再生するオーディオアセット
 	 */
 	play(audio: AudioAssetLike): void {
 		this.currentAudio = audio;
-		this.played.fire({
+		this.onPlay.fire({
 			player: this,
 			audio: audio
 		});
@@ -76,14 +90,14 @@ export class AudioPlayer implements AudioPlayerLike {
 	/**
 	 * 再生を停止する。
 	 *
-	 * 停止後、 `this.stopped` がfireされる。
-	 * 再生中でない場合、何もしない(`stopped` もfireされない)。
+	 * 停止後、 `this.onStop` がfireされる。
+	 * 再生中でない場合、何もしない(`onStop` もfireされない)。
 	 */
 	stop(): void {
 		var audio = this.currentAudio;
 		if (!audio) return;
 		this.currentAudio = undefined;
-		this.stopped.fire({
+		this.onStop.fire({
 			player: this,
 			audio: audio
 		});

--- a/src/implementations/AudioSystem.ts
+++ b/src/implementations/AudioSystem.ts
@@ -158,8 +158,8 @@ export class MusicAudioSystem extends AudioSystem {
 	get player(): AudioPlayerLike {
 		if (!this._player) {
 			this._player = this._resourceFactory.createAudioPlayer(this);
-			this._player.played.add(this._onPlayerPlayed, this);
-			this._player.stopped.add(this._onPlayerStopped, this);
+			this._player.onPlay.add(this._onPlayerPlayed, this);
+			this._player.onStop.add(this._onPlayerStopped, this);
 		}
 		return this._player;
 	}
@@ -192,8 +192,8 @@ export class MusicAudioSystem extends AudioSystem {
 	_reset(): void {
 		super._reset();
 		if (this._player) {
-			this._player.played.remove({ owner: this, func: this._onPlayerPlayed });
-			this._player.stopped.remove({ owner: this, func: this._onPlayerStopped });
+			this._player.onPlay.remove({ owner: this, func: this._onPlayerPlayed });
+			this._player.onStop.remove({ owner: this, func: this._onPlayerStopped });
 		}
 		this._player = undefined;
 	}
@@ -251,8 +251,8 @@ export class SoundAudioSystem extends AudioSystem {
 		var player = this._resourceFactory.createAudioPlayer(this);
 		if (player.canHandleStopped()) this.players.push(player);
 
-		player.played.add(this._onPlayerPlayed, this);
-		player.stopped.add(this._onPlayerStopped, this);
+		player.onPlay.add(this._onPlayerPlayed, this);
+		player.onStop.add(this._onPlayerStopped, this);
 
 		return player;
 	}
@@ -279,8 +279,8 @@ export class SoundAudioSystem extends AudioSystem {
 		super._reset();
 		for (var i = 0; i < this.players.length; ++i) {
 			var player = this.players[i];
-			player.played.remove({ owner: this, func: this._onPlayerPlayed });
-			player.stopped.remove({ owner: this, func: this._onPlayerStopped });
+			player.onPlay.remove({ owner: this, func: this._onPlayerPlayed });
+			player.onStop.remove({ owner: this, func: this._onPlayerStopped });
 		}
 		this.players = [];
 	}
@@ -323,7 +323,7 @@ export class SoundAudioSystem extends AudioSystem {
 		var index = this.players.indexOf(e.player);
 		if (index < 0) return;
 
-		e.player.stopped.remove({ owner: this, func: this._onPlayerStopped });
+		e.player.onStop.remove({ owner: this, func: this._onPlayerStopped });
 		this.players.splice(index, 1);
 		if (this._destroyRequestedAssets[e.audio.id]) {
 			delete this._destroyRequestedAssets[e.audio.id];

--- a/src/implementations/Surface.ts
+++ b/src/implementations/Surface.ts
@@ -37,22 +37,22 @@ export abstract class Surface implements SurfaceLike, CommonSize, Destroyable {
 	onAnimationStart: Trigger<void>;
 
 	/**
-	 * アニメーション再生開始イベント。
-	 * isDynamicが偽の時undefined。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	animatingStarted: Trigger<void>;
-
-	/**
 	 * アニメーション再生停止イベント。
 	 * isDynamicが偽の時undefined。
 	 */
 	onAnimationStop: Trigger<void>;
 
 	/**
+	 * アニメーション再生開始イベント。
+	 * isDynamicが偽の時undefined。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onAnimationStart` を利用すること。
+	 */
+	animatingStarted: Trigger<void>;
+
+	/**
 	 * アニメーション再生停止イベント。
 	 * isDynamicが偽の時undefined。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onAnimationStop` を利用すること。
 	 */
 	animatingStopped: Trigger<void>;
 
@@ -88,13 +88,13 @@ export abstract class Surface implements SurfaceLike, CommonSize, Destroyable {
 		this.isDynamic = isDynamic;
 		if (this.isDynamic) {
 			this.onAnimationStart = new Trigger<void>();
-			this.animatingStarted = this.onAnimationStart;
 			this.onAnimationStop = new Trigger<void>();
+			this.animatingStarted = this.onAnimationStart;
 			this.animatingStopped = this.onAnimationStop;
 		} else {
 			this.onAnimationStart = undefined;
-			this.animatingStarted = undefined;
 			this.onAnimationStop = undefined;
+			this.animatingStarted = undefined;
 			this.animatingStopped = undefined;
 		}
 	}

--- a/src/implementations/Surface.ts
+++ b/src/implementations/Surface.ts
@@ -34,11 +34,25 @@ export abstract class Surface implements SurfaceLike, CommonSize, Destroyable {
 	 * アニメーション再生開始イベント。
 	 * isDynamicが偽の時undefined。
 	 */
+	onAnimationStart: Trigger<void>;
+
+	/**
+	 * アニメーション再生開始イベント。
+	 * isDynamicが偽の時undefined。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	animatingStarted: Trigger<void>;
 
 	/**
 	 * アニメーション再生停止イベント。
 	 * isDynamicが偽の時undefined。
+	 */
+	onAnimationStop: Trigger<void>;
+
+	/**
+	 * アニメーション再生停止イベント。
+	 * isDynamicが偽の時undefined。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	animatingStopped: Trigger<void>;
 
@@ -73,10 +87,14 @@ export abstract class Surface implements SurfaceLike, CommonSize, Destroyable {
 		// this._destroyedは破棄時に一度だけ代入する特殊なフィールドなため、コンストラクタで初期値を代入しない
 		this.isDynamic = isDynamic;
 		if (this.isDynamic) {
-			this.animatingStarted = new Trigger<void>();
-			this.animatingStopped = new Trigger<void>();
+			this.onAnimationStart = new Trigger<void>();
+			this.animatingStarted = this.onAnimationStart;
+			this.onAnimationStop = new Trigger<void>();
+			this.animatingStopped = this.onAnimationStop;
 		} else {
+			this.onAnimationStart = undefined;
 			this.animatingStarted = undefined;
+			this.onAnimationStop = undefined;
 			this.animatingStopped = undefined;
 		}
 	}
@@ -96,11 +114,11 @@ export abstract class Surface implements SurfaceLike, CommonSize, Destroyable {
 	 * 以後、このSurfaceを利用することは出来なくなる。
 	 */
 	destroy(): void {
-		if (this.animatingStarted) {
-			this.animatingStarted.destroy();
+		if (this.onAnimationStart) {
+			this.onAnimationStart.destroy();
 		}
-		if (this.animatingStopped) {
-			this.animatingStopped.destroy();
+		if (this.onAnimationStop) {
+			this.onAnimationStop.destroy();
 		}
 		this._destroyed = true;
 	}

--- a/src/implementations/VideoPlayer.ts
+++ b/src/implementations/VideoPlayer.ts
@@ -20,21 +20,9 @@ export class VideoPlayer implements VideoPlayerLike {
 	onPlay: Trigger<VideoPlayerEvent>;
 
 	/**
-	 * `play()` が呼び出された時に通知される `Trigger` 。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	played: Trigger<VideoPlayerEvent>;
-
-	/**
 	 * `stop()` が呼び出された時に通知される `Trigger` 。
 	 */
 	onStop: Trigger<VideoPlayerEvent>;
-
-	/**
-	 * `stop()` が呼び出された時に通知される `Trigger` 。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	stopped: Trigger<VideoPlayerEvent>;
 
 	/**
 	 * 音量。
@@ -44,6 +32,18 @@ export class VideoPlayer implements VideoPlayerLike {
 	 * 音量を変更したい場合、  `changeVolume()` メソッドを用いること。
 	 */
 	volume: number;
+
+	/**
+	 * `play()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPlay` を利用すること。
+	 */
+	played: Trigger<VideoPlayerEvent>;
+
+	/**
+	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onStop` を利用すること。
+	 */
+	stopped: Trigger<VideoPlayerEvent>;
 
 	/**
 	 * @private
@@ -56,8 +56,8 @@ export class VideoPlayer implements VideoPlayerLike {
 	constructor(loop?: boolean) {
 		this._loop = !!loop;
 		this.onPlay = new Trigger<VideoPlayerEvent>();
-		this.played = this.onPlay;
 		this.onStop = new Trigger<VideoPlayerEvent>();
+		this.played = this.onPlay;
 		this.stopped = this.onStop;
 		this.currentVideo = undefined;
 		this.volume = 1.0;

--- a/src/implementations/VideoPlayer.ts
+++ b/src/implementations/VideoPlayer.ts
@@ -17,10 +17,22 @@ export class VideoPlayer implements VideoPlayerLike {
 	/**
 	 * `play()` が呼び出された時に通知される `Trigger` 。
 	 */
+	onPlay: Trigger<VideoPlayerEvent>;
+
+	/**
+	 * `play()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	played: Trigger<VideoPlayerEvent>;
 
 	/**
 	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 */
+	onStop: Trigger<VideoPlayerEvent>;
+
+	/**
+	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	stopped: Trigger<VideoPlayerEvent>;
 
@@ -43,8 +55,10 @@ export class VideoPlayer implements VideoPlayerLike {
 	 */
 	constructor(loop?: boolean) {
 		this._loop = !!loop;
-		this.played = new Trigger<VideoPlayerEvent>();
-		this.stopped = new Trigger<VideoPlayerEvent>();
+		this.onPlay = new Trigger<VideoPlayerEvent>();
+		this.played = this.onPlay;
+		this.onStop = new Trigger<VideoPlayerEvent>();
+		this.stopped = this.onStop;
 		this.currentVideo = undefined;
 		this.volume = 1.0;
 	}
@@ -52,31 +66,31 @@ export class VideoPlayer implements VideoPlayerLike {
 	/**
 	 * `VideoAsset` を再生する。
 	 *
-	 * 再生後、 `this.played` がfireされる。
+	 * 再生後、 `this.onPlay` がfireされる。
 	 * @param Video 再生するビデオアセット
 	 */
 	play(videoAsset: VideoAssetLike): void {
 		this.currentVideo = videoAsset;
-		this.played.fire({
+		this.onPlay.fire({
 			player: this,
 			video: videoAsset
 		});
-		videoAsset.asSurface().animatingStarted.fire();
+		videoAsset.asSurface().onAnimationStart.fire();
 	}
 
 	/**
 	 * 再生を停止する。
 	 *
 	 * 再生中でない場合、何もしない。
-	 * 停止後、 `this.stopped` がfireされる。
+	 * 停止後、 `this.onStop` がfireされる。
 	 */
 	stop(): void {
 		var videoAsset = this.currentVideo;
-		this.stopped.fire({
+		this.onStop.fire({
 			player: this,
 			video: videoAsset
 		});
-		videoAsset.asSurface().animatingStopped.fire();
+		videoAsset.asSurface().onAnimationStop.fire();
 	}
 
 	/**

--- a/src/interfaces/AudioPlayerLike.ts
+++ b/src/interfaces/AudioPlayerLike.ts
@@ -23,10 +23,22 @@ export interface AudioPlayerLike {
 	/**
 	 * `play()` が呼び出された時に通知される `Trigger` 。
 	 */
+	onPlay: Trigger<AudioPlayerEvent>;
+
+	/**
+	 * `play()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	played: Trigger<AudioPlayerEvent>;
 
 	/**
 	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 */
+	onStop: Trigger<AudioPlayerEvent>;
+
+	/**
+	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	stopped: Trigger<AudioPlayerEvent>;
 
@@ -47,7 +59,7 @@ export interface AudioPlayerLike {
 	/**
 	 * `AudioAsset` を再生する。
 	 *
-	 * 再生後、 `this.played` がfireされる。
+	 * 再生後、 `this.onPlay` がfireされる。
 	 * @param audio 再生するオーディオアセット
 	 */
 	play(audio: AudioAssetLike): void;
@@ -55,8 +67,8 @@ export interface AudioPlayerLike {
 	/**
 	 * 再生を停止する。
 	 *
-	 * 停止後、 `this.stopped` がfireされる。
-	 * 再生中でない場合、何もしない(`stopped` もfireされない)。
+	 * 停止後、 `this.onStop` がfireされる。
+	 * 再生中でない場合、何もしない(`onStop` もfireされない)。
 	 */
 	stop(): void;
 

--- a/src/interfaces/AudioPlayerLike.ts
+++ b/src/interfaces/AudioPlayerLike.ts
@@ -26,21 +26,9 @@ export interface AudioPlayerLike {
 	onPlay: Trigger<AudioPlayerEvent>;
 
 	/**
-	 * `play()` が呼び出された時に通知される `Trigger` 。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	played: Trigger<AudioPlayerEvent>;
-
-	/**
 	 * `stop()` が呼び出された時に通知される `Trigger` 。
 	 */
 	onStop: Trigger<AudioPlayerEvent>;
-
-	/**
-	 * `stop()` が呼び出された時に通知される `Trigger` 。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	stopped: Trigger<AudioPlayerEvent>;
 
 	/**
 	 * 音量。
@@ -50,6 +38,18 @@ export interface AudioPlayerLike {
 	 * 音量を変更したい場合、  `changeVolume()` メソッドを用いること。
 	 */
 	volume: number;
+
+	/**
+	 * `play()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPlay` を利用すること。
+	 */
+	played: Trigger<AudioPlayerEvent>;
+
+	/**
+	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onStop` を利用すること。
+	 */
+	stopped: Trigger<AudioPlayerEvent>;
 
 	/**
 	 * ミュート中か否か。

--- a/src/interfaces/SurfaceLike.ts
+++ b/src/interfaces/SurfaceLike.ts
@@ -32,22 +32,22 @@ export interface SurfaceLike extends CommonSize, Destroyable {
 	onAnimationStart: Trigger<void>;
 
 	/**
-	 * アニメーション再生開始イベント。
-	 * isDynamicが偽の時undefined。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	animatingStarted: Trigger<void>;
-
-	/**
 	 * アニメーション再生停止イベント。
 	 * isDynamicが偽の時undefined。
 	 */
 	onAnimationStop: Trigger<void>;
 
 	/**
+	 * アニメーション再生開始イベント。
+	 * isDynamicが偽の時undefined。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onAnimationStart` を利用すること。
+	 */
+	animatingStarted: Trigger<void>;
+
+	/**
 	 * アニメーション再生停止イベント。
 	 * isDynamicが偽の時undefined。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onAnimationStop` を利用すること。
 	 */
 	animatingStopped: Trigger<void>;
 

--- a/src/interfaces/SurfaceLike.ts
+++ b/src/interfaces/SurfaceLike.ts
@@ -29,11 +29,25 @@ export interface SurfaceLike extends CommonSize, Destroyable {
 	 * アニメーション再生開始イベント。
 	 * isDynamicが偽の時undefined。
 	 */
+	onAnimationStart: Trigger<void>;
+
+	/**
+	 * アニメーション再生開始イベント。
+	 * isDynamicが偽の時undefined。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	animatingStarted: Trigger<void>;
 
 	/**
 	 * アニメーション再生停止イベント。
 	 * isDynamicが偽の時undefined。
+	 */
+	onAnimationStop: Trigger<void>;
+
+	/**
+	 * アニメーション再生停止イベント。
+	 * isDynamicが偽の時undefined。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	animatingStopped: Trigger<void>;
 

--- a/src/interfaces/VideoPlayerLike.ts
+++ b/src/interfaces/VideoPlayerLike.ts
@@ -21,10 +21,22 @@ export interface VideoPlayerLike {
 	/**
 	 * `play()` が呼び出された時に通知される `Trigger` 。
 	 */
+	onPlay: Trigger<VideoPlayerEvent>;
+
+	/**
+	 * `play()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
+	 */
 	played: Trigger<VideoPlayerEvent>;
 
 	/**
 	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 */
+	onStop: Trigger<VideoPlayerEvent>;
+
+	/**
+	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	stopped: Trigger<VideoPlayerEvent>;
 
@@ -45,7 +57,7 @@ export interface VideoPlayerLike {
 	/**
 	 * `VideoAsset` を再生する。
 	 *
-	 * 再生後、 `this.played` がfireされる。
+	 * 再生後、 `this.onPlay` がfireされる。
 	 * @param Video 再生するビデオアセット
 	 */
 	play(videoAsset: VideoAssetLike): void;
@@ -54,7 +66,7 @@ export interface VideoPlayerLike {
 	 * 再生を停止する。
 	 *
 	 * 再生中でない場合、何もしない。
-	 * 停止後、 `this.stopped` がfireされる。
+	 * 停止後、 `this.onStop` がfireされる。
 	 */
 	stop(): void;
 

--- a/src/interfaces/VideoPlayerLike.ts
+++ b/src/interfaces/VideoPlayerLike.ts
@@ -24,21 +24,9 @@ export interface VideoPlayerLike {
 	onPlay: Trigger<VideoPlayerEvent>;
 
 	/**
-	 * `play()` が呼び出された時に通知される `Trigger` 。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	played: Trigger<VideoPlayerEvent>;
-
-	/**
 	 * `stop()` が呼び出された時に通知される `Trigger` 。
 	 */
 	onStop: Trigger<VideoPlayerEvent>;
-
-	/**
-	 * `stop()` が呼び出された時に通知される `Trigger` 。
-	 * @deprecated 非推奨である。将来的に削除される予定である。
-	 */
-	stopped: Trigger<VideoPlayerEvent>;
 
 	/**
 	 * 音量。
@@ -48,6 +36,18 @@ export interface VideoPlayerLike {
 	 * 音量を変更したい場合、  `changeVolume()` メソッドを用いること。
 	 */
 	volume: number;
+
+	/**
+	 * `play()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPlay` を利用すること。
+	 */
+	played: Trigger<VideoPlayerEvent>;
+
+	/**
+	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onStop` を利用すること。
+	 */
+	stopped: Trigger<VideoPlayerEvent>;
 
 	/**
 	 * @private


### PR DESCRIPTION
## このpull requestが解決する内容

Trigger を `on+動詞原型/名詞` の形式でリネームします。
元のTriggerは deprecated コメントを付与し alias として残します。

## 破壊的な変更を含んでいるか?

- Triggerの名前が on~に変更され、元のTriggerは deprecatedeとなります。

