### PR TITLE
Glyphをdeprecatedにする対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.9",
+  "version": "3.0.0-beta.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__tests__/BitmapFontSpec.ts
+++ b/src/__tests__/BitmapFontSpec.ts
@@ -97,6 +97,5 @@ describe("test BitmapFont", () => {
 		expect(obj.y).toBe(1);
 		expect(obj.width).toBe(20);
 		expect(obj.height).toBe(30);
-		expect(obj.renderingWidth(60)).toBe(40);
 	});
 });

--- a/src/__tests__/BitmapFontSpec.ts
+++ b/src/__tests__/BitmapFontSpec.ts
@@ -80,7 +80,7 @@ describe("test BitmapFont", () => {
 		expect(bmpFont.defaultGlyphHeight).toEqual(30);
 	});
 
-	it("can create GlyphLike Object by glyphForCharacter", () => {
+	it("can create Glyph by glyphForCharacter", () => {
 		const surface = new Surface(480, 480);
 		const map = { "11": { x: 0, y: 1 } };
 		const missingGlyph = { x: 2, y: 3 };
@@ -91,11 +91,11 @@ describe("test BitmapFont", () => {
 			defaultGlyphHeight: 30,
 			missingGlyph: missingGlyph
 		});
-		const obj = bmpFont.glyphForCharacter(11);
-		expect(obj.code).toBe(11);
-		expect(obj.x).toBe(0);
-		expect(obj.y).toBe(1);
-		expect(obj.width).toBe(20);
-		expect(obj.height).toBe(30);
+		const glyph = bmpFont.glyphForCharacter(11);
+		expect(glyph.code).toBe(11);
+		expect(glyph.x).toBe(0);
+		expect(glyph.y).toBe(1);
+		expect(glyph.width).toBe(20);
+		expect(glyph.height).toBe(30);
 	});
 });

--- a/src/__tests__/BitmapFontSpec.ts
+++ b/src/__tests__/BitmapFontSpec.ts
@@ -2,35 +2,6 @@ import { BitmapFont, Glyph, SurfaceUtil } from "..";
 import { skeletonRuntime, Surface } from "./helpers";
 
 describe("test BitmapFont", () => {
-	it("初期化 - Glyph", () => {
-		const code = 300;
-		const x = 2;
-		const y = 2;
-		const width = 10;
-		const height = 12;
-		const glyph = new Glyph(code, x, y, width, height);
-		expect(glyph.code).toBe(code);
-		expect(glyph.x).toBe(x);
-		expect(glyph.y).toBe(y);
-		expect(glyph.width).toBe(width);
-		expect(glyph.height).toBe(height);
-	});
-
-	it("Glyph#renderingWidth", () => {
-		const code = 300;
-		const x = 2;
-		const y = 2;
-		const width = 10;
-		const height = 12;
-		const glyph = new Glyph(code, x, y, width, height);
-
-		glyph.width = 0;
-		expect(glyph.renderingWidth(24)).toBe(0);
-		glyph.width = 10;
-		glyph.height = 0;
-		expect(glyph.renderingWidth(24)).toBe(0);
-	});
-
 	it("初期化 - BitmapFont", () => {
 		// deprecatedなコンストラクタの動作確認を行う
 		const surface = new Surface(480, 480);
@@ -107,5 +78,25 @@ describe("test BitmapFont", () => {
 		expect(bmpFont.missingGlyph).toEqual(missingGlyph);
 		expect(bmpFont.defaultGlyphWidth).toEqual(20);
 		expect(bmpFont.defaultGlyphHeight).toEqual(30);
+	});
+
+	it("can create GlyphLike Object by glyphForCharacter", () => {
+		const surface = new Surface(480, 480);
+		const map = { "11": { x: 0, y: 1 } };
+		const missingGlyph = { x: 2, y: 3 };
+		const bmpFont = new BitmapFont({
+			src: surface,
+			map: map,
+			defaultGlyphWidth: 20,
+			defaultGlyphHeight: 30,
+			missingGlyph: missingGlyph
+		});
+		const obj = bmpFont.glyphForCharacter(11);
+		expect(obj.code).toBe(11);
+		expect(obj.x).toBe(0);
+		expect(obj.y).toBe(1);
+		expect(obj.width).toBe(20);
+		expect(obj.height).toBe(30);
+		expect(obj.renderingWidth(60)).toBe(40);
 	});
 });

--- a/src/__tests__/SurfaceAtlasSetSpec.ts
+++ b/src/__tests__/SurfaceAtlasSetSpec.ts
@@ -3,7 +3,7 @@ import { skeletonRuntime, Surface } from "./helpers";
 
 describe("test SurfaceAtlasSet", () => {
 	let surfaceAtlasSet: SurfaceAtlasSet;
-	const createGlyphLike = (code: number, x: number, y: number, width: number, height: number): GlyphLike => {
+	const createGlyph = (code: number, x: number, y: number, width: number, height: number): GlyphLike => {
 		return {
 			code,
 			x,
@@ -66,12 +66,12 @@ describe("test SurfaceAtlasSet", () => {
 
 	describe("addGlyph", () => {
 		it("追加対象のSurfaceに空き領域がない場合、nullが返る", () => {
-			const glyph = createGlyphLike(300, 0, 0, 10, 10);
+			const glyph = createGlyph(300, 0, 0, 10, 10);
 			const ret = surfaceAtlasSet.addGlyph(glyph);
 			expect(ret).toBeNull();
 		});
 		it("正常にグリフが追加された場合、追加したSurfaceAtlasが返る", () => {
-			const glyph = createGlyphLike(300, 0, 0, 1, 1);
+			const glyph = createGlyph(300, 0, 0, 1, 1);
 			glyph.surface = new Surface(1, 1);
 
 			const atlas = new SurfaceAtlas(new Surface(100, 100));
@@ -95,7 +95,7 @@ describe("test SurfaceAtlasSet", () => {
 		});
 		it("SurfaceAtlasの保持数が最大値の場合、削除処理が呼ばれる。", () => {
 			spyOn(surfaceAtlasSet, "_removeLeastFrequentlyUsedAtlas").and.callFake(() => {
-				const glyph = createGlyphLike(300, 0, 0, 10, 10);
+				const glyph = createGlyph(300, 0, 0, 10, 10);
 				const atlas = new SurfaceAtlas(new Surface(10, 10));
 				return { surfaceAtlases: [atlas], glyphs: [[glyph]] };
 			});

--- a/src/__tests__/SurfaceAtlasSetSpec.ts
+++ b/src/__tests__/SurfaceAtlasSetSpec.ts
@@ -4,28 +4,19 @@ import { skeletonRuntime, Surface } from "./helpers";
 describe("test SurfaceAtlasSet", () => {
 	let surfaceAtlasSet: SurfaceAtlasSet;
 	const createGlyphLike = (code: number, x: number, y: number, width: number, height: number): GlyphLike => {
-		const surface: undefined = undefined;
-		const _atlas: null = null;
-		const obj = {
+		return {
 			code,
 			x,
 			y,
 			width,
 			height,
-			surface,
+			surface: undefined,
 			offsetX: 0,
 			offsetY: 0,
 			advanceWidth: width,
 			isSurfaceValid: false,
-			_atlas,
-			renderingWidth: (fontSize: number): number => {
-				if (!obj.width || !obj.height) {
-					return 0;
-				}
-				return (fontSize / obj.height) * obj.width;
-			}
+			_atlas: null
 		};
-		return obj;
 	};
 
 	it("初期化", () => {

--- a/src/__tests__/SurfaceAtlasSetSpec.ts
+++ b/src/__tests__/SurfaceAtlasSetSpec.ts
@@ -1,8 +1,32 @@
-import { Glyph, SurfaceAtlas, SurfaceAtlasSet, SurfaceAtlasSetParameterObject } from "..";
+import { GlyphLike, SurfaceAtlas, SurfaceAtlasSet, SurfaceAtlasSetParameterObject } from "..";
 import { skeletonRuntime, Surface } from "./helpers";
 
 describe("test SurfaceAtlasSet", () => {
 	let surfaceAtlasSet: SurfaceAtlasSet;
+	const createGlyphLike = (code: number, x: number, y: number, width: number, height: number): GlyphLike => {
+		const surface: undefined = undefined;
+		const _atlas: null = null;
+		const obj = {
+			code,
+			x,
+			y,
+			width,
+			height,
+			surface,
+			offsetX: 0,
+			offsetY: 0,
+			advanceWidth: width,
+			isSurfaceValid: false,
+			_atlas,
+			renderingWidth: (fontSize: number): number => {
+				if (!obj.width || !obj.height) {
+					return 0;
+				}
+				return (fontSize / obj.height) * obj.width;
+			}
+		};
+		return obj;
+	};
 
 	it("初期化", () => {
 		const runtime = skeletonRuntime();
@@ -51,12 +75,12 @@ describe("test SurfaceAtlasSet", () => {
 
 	describe("addGlyph", () => {
 		it("追加対象のSurfaceに空き領域がない場合、nullが返る", () => {
-			const glyph = new Glyph(300, 0, 0, 10, 10);
+			const glyph = createGlyphLike(300, 0, 0, 10, 10);
 			const ret = surfaceAtlasSet.addGlyph(glyph);
 			expect(ret).toBeNull();
 		});
 		it("正常にグリフが追加された場合、追加したSurfaceAtlasが返る", () => {
-			const glyph = new Glyph(300, 0, 0, 1, 1);
+			const glyph = createGlyphLike(300, 0, 0, 1, 1);
 			glyph.surface = new Surface(1, 1);
 
 			const atlas = new SurfaceAtlas(new Surface(100, 100));
@@ -80,7 +104,7 @@ describe("test SurfaceAtlasSet", () => {
 		});
 		it("SurfaceAtlasの保持数が最大値の場合、削除処理が呼ばれる。", () => {
 			spyOn(surfaceAtlasSet, "_removeLeastFrequentlyUsedAtlas").and.callFake(() => {
-				const glyph = new Glyph(300, 0, 0, 10, 10);
+				const glyph = createGlyphLike(300, 0, 0, 10, 10);
 				const atlas = new SurfaceAtlas(new Surface(10, 10));
 				return { surfaceAtlases: [atlas], glyphs: [[glyph]] };
 			});

--- a/src/commons/Glyph.ts
+++ b/src/commons/Glyph.ts
@@ -78,7 +78,7 @@ export class Glyph implements GlyphLike {
 	 */
 	isSurfaceValid: boolean;
 
-	_atlas: SurfaceAtlasLike;
+	_atlas: SurfaceAtlasLike | null;
 
 	/**
 	 * `Glyph` のインスタンスを生成する。

--- a/src/commons/Glyph.ts
+++ b/src/commons/Glyph.ts
@@ -4,6 +4,8 @@ import { SurfaceLike } from "../interfaces/SurfaceLike";
 
 /**
  * グリフ。
+ *
+ * @deprecated 非推奨である。将来的に削除される予定である。
  */
 export class Glyph implements GlyphLike {
 	/**
@@ -80,6 +82,7 @@ export class Glyph implements GlyphLike {
 
 	/**
 	 * `Glyph` のインスタンスを生成する。
+	 * @deprecated 非推奨である。将来的に削除される予定である。
 	 */
 	constructor(
 		code: number,

--- a/src/domain/BitmapFont.ts
+++ b/src/domain/BitmapFont.ts
@@ -79,8 +79,28 @@ export class BitmapFont extends Font {
 		var offsetY = g.offsetY || 0;
 		var advanceWidth = g.advanceWidth === undefined ? w : g.advanceWidth;
 		var surface = w === 0 || h === 0 ? undefined : this.surface;
+		var _atlas: null = null;
 
-		return new Glyph(code, g.x, g.y, w, h, offsetX, offsetY, advanceWidth, surface, true);
+		const obj = {
+			code,
+			x: g.x,
+			y: g.y,
+			width: w,
+			height: h,
+			surface,
+			offsetX,
+			offsetY,
+			advanceWidth,
+			isSurfaceValid: true,
+			_atlas,
+			renderingWidth: (fontSize: number): number => {
+				if (!obj.width || !obj.height) {
+					return 0;
+				}
+				return (fontSize / obj.height) * obj.width;
+			}
+		};
+		return obj;
 	}
 
 	/**

--- a/src/domain/BitmapFont.ts
+++ b/src/domain/BitmapFont.ts
@@ -1,4 +1,3 @@
-import { Glyph } from "../commons/Glyph";
 import { GlyphArea, GlyphLike } from "../interfaces/GlyphLike";
 import { ImageAssetLike } from "../interfaces/ImageAssetLike";
 import { SurfaceLike } from "../interfaces/SurfaceLike";

--- a/src/domain/BitmapFont.ts
+++ b/src/domain/BitmapFont.ts
@@ -78,9 +78,8 @@ export class BitmapFont extends Font {
 		var offsetY = g.offsetY || 0;
 		var advanceWidth = g.advanceWidth === undefined ? w : g.advanceWidth;
 		var surface = w === 0 || h === 0 ? undefined : this.surface;
-		var _atlas: null = null;
 
-		const obj = {
+		return {
 			code,
 			x: g.x,
 			y: g.y,
@@ -91,15 +90,8 @@ export class BitmapFont extends Font {
 			offsetY,
 			advanceWidth,
 			isSurfaceValid: true,
-			_atlas,
-			renderingWidth: (fontSize: number): number => {
-				if (!obj.width || !obj.height) {
-					return 0;
-				}
-				return (fontSize / obj.height) * obj.width;
-			}
+			_atlas: null
 		};
-		return obj;
 	}
 
 	/**

--- a/src/interfaces/GlyphLike.ts
+++ b/src/interfaces/GlyphLike.ts
@@ -88,12 +88,5 @@ export interface GlyphLike {
 	 */
 	isSurfaceValid: boolean;
 
-	_atlas: SurfaceAtlasLike;
-
-	/**
-	 * グリフの描画上の幅を求める。
-	 * 通常、ゲーム開発者がこのメソッドを呼び出す必要はない。
-	 * @param fontSize フォントサイズ
-	 */
-	renderingWidth(fontSize: number): number;
+	_atlas: SurfaceAtlasLike | null;
 }


### PR DESCRIPTION
## このpull requestが解決する内容
* g.Glyphをdeprecatedにして、g.Glyphを利用している箇所で代わりにg.GlyphLikeを利用するよう差し替えます。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

