### PR TITLE
Add Game#resolvePointEvent(), Don't render when Game#modified() has not been called

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.14",
+  "version": "3.0.0-beta.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.14",
+  "version": "3.0.0-beta.15",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -894,12 +894,12 @@ export class Game {
 	 */
 	resolvePointEvent(e: PlatformPointEvent): pl.Event | null {
 		switch (e.type) {
-		case PlatformPointType.Down:
-			return this._pointEventResolver.pointDown(e);
-		case PlatformPointType.Move:
-			return this._pointEventResolver.pointMove(e);
-		case PlatformPointType.Up:
-			return this._pointEventResolver.pointUp(e);
+			case PlatformPointType.Down:
+				return this._pointEventResolver.pointDown(e);
+			case PlatformPointType.Move:
+				return this._pointEventResolver.pointMove(e);
+			case PlatformPointType.Up:
+				return this._pointEventResolver.pointUp(e);
 		}
 	}
 

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -850,10 +850,13 @@ export class Game {
 	 * このGameを描画する。
 	 *
 	 * このゲームに紐づけられた `Renderer` (`this.renderers` に含まれるすべての `Renderer` で、この `Game` の描画を行う。
+	 * 描画内容に変更がない場合、描画処理がスキップされる点に注意。強制的に描画をする場合は `this.modified()` を呼ぶこと。
 	 * このメソッドは暗黙に呼び出される。ゲーム開発者がこのメソッドを利用する必要はない。
 	 */
 	render(): void {
-		var scene = this.scene();
+		if (!this._modified) return;
+
+		const scene = this.scene();
 		if (!scene) return;
 
 		const camera = this.focusingCamera;
@@ -870,7 +873,7 @@ export class Game {
 				camera._applyTransformToRenderer(renderer);
 			}
 
-			var children = scene.children;
+			const children = scene.children;
 			for (let j = 0; j < children.length; ++j) children[j].render(renderer, camera);
 
 			if (camera) {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -31,6 +31,7 @@ import { LocalTickMode } from "./types/LocalTickMode";
 import { OperationPlugin } from "./types/OperationPlugin";
 import { InternalOperationPluginOperation } from "./types/OperationPluginOperation";
 import { OperationPluginViewInfo } from "./types/OperationPluginViewInfo";
+import { PlatformPointEvent, PlatformPointType } from "./types/PlatformPointEvent";
 import { TickGenerationMode } from "./types/TickGenerationMode";
 
 /**
@@ -880,6 +881,23 @@ export class Game {
 			renderer.end();
 		}
 		this._modified = false;
+	}
+
+	/**
+	 * 対象のポイントイベントのターゲットエンティティ(`PointTarget#target`)を解決し、それを補完した playlog.Event を返す。
+	 * Down -> Move -> Up とは異なる順番で呼び出された場合 `null` を返す。
+	 * このメソッドは暗黙に呼び出される。ゲーム開発者がこのメソッドを利用する必要はない。
+	 * @param e プラットフォームのポイントイベント
+	 */
+	resolvePointEvent(e: PlatformPointEvent): pl.Event | null {
+		switch (e.type) {
+		case PlatformPointType.Down:
+			return this._pointEventResolver.pointDown(e);
+		case PlatformPointType.Move:
+			return this._pointEventResolver.pointMove(e);
+		case PlatformPointType.Up:
+			return this._pointEventResolver.pointUp(e);
+		}
 	}
 
 	/**

--- a/src/domain/PointEventResolver.ts
+++ b/src/domain/PointEventResolver.ts
@@ -81,7 +81,7 @@ export class PointEventResolver {
 		return ret;
 	}
 
-	pointMove(e: PlatformPointEvent): pl.PointMoveEvent {
+	pointMove(e: PlatformPointEvent): pl.PointMoveEvent | null {
 		const holder = this._pointEventMap[e.identifier];
 		if (!holder) return null;
 		var prev = { x: 0, y: 0 };
@@ -104,7 +104,7 @@ export class PointEventResolver {
 		return ret;
 	}
 
-	pointUp(e: PlatformPointEvent): pl.PointUpEvent {
+	pointUp(e: PlatformPointEvent): pl.PointUpEvent | null {
 		const holder = this._pointEventMap[e.identifier];
 		if (!holder) return null;
 		const prev = { x: 0, y: 0 };


### PR DESCRIPTION
## このpull requestが解決する内容
* `g.Game#resolvePointEvent()` を追加
* **[breaking]** 描画内容に変更がない場合は `g.Game#render()` で描画をスキップするように

## 破壊的な変更を含んでいるか?
* **あり**

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

