### PR TITLE
add BitmapFontGlyphInfo

### DIFF
--- a/spec/BitmapFontSpec.js
+++ b/spec/BitmapFontSpec.js
@@ -115,7 +115,7 @@ describe("test BitmapFont", function() {
 		expect(bmpFont.defaultGlyphHeight).toEqual(30);
 	});
 
-	it("初期化 - ParamterObject given glyphData", function() {
+	it("初期化 - ParamterObject given glyphInfo", function() {
 		var surface = new g.Surface(480, 480);
 		var map = {"37564": {"x": 0, "y": 1}};
 		var missingGlyph = {"x": 2, "y": 3};
@@ -130,30 +130,6 @@ describe("test BitmapFont", function() {
 		var bmpFont = new g.BitmapFont({
 			src: surface,
 			glyphInfo: glyphInfo
-		});
-		expect(bmpFont.surface).toEqual(surface);
-		expect(bmpFont.map).toEqual(map);
-		expect(bmpFont.missingGlyph).toEqual(missingGlyph);
-		expect(bmpFont.defaultGlyphWidth).toEqual(20);
-		expect(bmpFont.defaultGlyphHeight).toEqual(30);
-	});
-
-	it("初期化 - ParamterObject given glyphData(TextAsset)", function() {
-		var surface = new g.Surface(480, 480);
-		var map = {"37564": {"x": 0, "y": 1}};
-		var missingGlyph = {"x": 2, "y": 3};
-
-		var mockTextAsset = new g.TextAsset("mockId", "mockPath");
-		mockTextAsset.data = JSON.stringify({
-			"map": map,
-			"width": 20,
-			"height": 30,
-			"missingGlyph": missingGlyph
-		});
-
-		var bmpFont = new g.BitmapFont({
-			src: surface,
-			glyphInfo: mockTextAsset
 		});
 		expect(bmpFont.surface).toEqual(surface);
 		expect(bmpFont.map).toEqual(map);

--- a/spec/BitmapFontSpec.js
+++ b/spec/BitmapFontSpec.js
@@ -114,4 +114,51 @@ describe("test BitmapFont", function() {
 		expect(bmpFont.defaultGlyphWidth).toEqual(20);
 		expect(bmpFont.defaultGlyphHeight).toEqual(30);
 	});
+
+	it("初期化 - ParamterObject given glyphData", function() {
+		var surface = new g.Surface(480, 480);
+		var map = {"37564": {"x": 0, "y": 1}};
+		var missingGlyph = {"x": 2, "y": 3};
+
+		var glyphInfo = {
+			map: map,
+			width: 20,
+			height: 30,
+			missingGlyph: missingGlyph
+		};
+
+		var bmpFont = new g.BitmapFont({
+			src: surface,
+			glyphInfo: glyphInfo
+		});
+		expect(bmpFont.surface).toEqual(surface);
+		expect(bmpFont.map).toEqual(map);
+		expect(bmpFont.missingGlyph).toEqual(missingGlyph);
+		expect(bmpFont.defaultGlyphWidth).toEqual(20);
+		expect(bmpFont.defaultGlyphHeight).toEqual(30);
+	});
+
+	it("初期化 - ParamterObject given glyphData(TextAsset)", function() {
+		var surface = new g.Surface(480, 480);
+		var map = {"37564": {"x": 0, "y": 1}};
+		var missingGlyph = {"x": 2, "y": 3};
+
+		var mockTextAsset = new g.TextAsset("mockId", "mockPath");
+		mockTextAsset.data = JSON.stringify({
+			"map": map,
+			"width": 20,
+			"height": 30,
+			"missingGlyph": missingGlyph
+		});
+
+		var bmpFont = new g.BitmapFont({
+			src: surface,
+			glyphInfo: mockTextAsset
+		});
+		expect(bmpFont.surface).toEqual(surface);
+		expect(bmpFont.map).toEqual(map);
+		expect(bmpFont.missingGlyph).toEqual(missingGlyph);
+		expect(bmpFont.defaultGlyphWidth).toEqual(20);
+		expect(bmpFont.defaultGlyphHeight).toEqual(30);
+	});
 });

--- a/src/BitmapFont.ts
+++ b/src/BitmapFont.ts
@@ -1,4 +1,20 @@
 namespace g {
+
+	/**
+	 * BitmapFont のデータを格納したテキストアセット (JSON) を JSON.parse したオブジェクト
+	 */
+	export interface BitmapFontGlyphData {
+		map: {[key: string]: GlyphArea},
+		width: number,
+		height: number,
+		missingGlyph: GlyphArea
+	}
+
+	/**
+	 * BitmapFont の生成に必要なデータセット
+	 */
+	export type BitmapFontGlyphInfo = TextAsset | BitmapFontGlyphData;
+
 	/**
 	 * `BitmapFont` のコンストラクタに渡すことができるパラメータ。
 	 * 各メンバの詳細は `BitmapFont` の同名メンバの説明を参照すること。
@@ -10,19 +26,25 @@ namespace g {
 		src: Surface|Asset;
 
 		/**
+		 * BitmapFont の生成に必要なデータセット。
+		 * glyphInfo が与えられる場合、 BitmapFontParameterObject の map defaultGlyphWidth defaultGlyphHeight missingGlyph は参照されない。
+		 */
+		glyphInfo?: BitmapFontGlyphInfo;
+
+		/**
 		 * 各文字から画像上の位置・サイズなどを特定する情報。コードポイントから `GlyphArea` への写像。
 		 */
-		map: {[key: string]: GlyphArea};
+		map?: {[key: string]: GlyphArea};
 
 		/**
 		 * `map` で指定を省略した文字に使われる、デフォルトの文字の幅。
 		 */
-		defaultGlyphWidth: number;
+		defaultGlyphWidth?: number;
 
 		/**
 		 * `map` で指定を省略した文字に使われる、デフォルトの文字の高さ
 		 */
-		defaultGlyphHeight: number;
+		defaultGlyphHeight?: number;
 
 		/**
 		 * `map` に存在しないコードポイントの代わりに表示するべき文字の `GlyphArea` 。
@@ -49,11 +71,21 @@ namespace g {
 		constructor(param: BitmapFontParameterObject) {
 			super();
 			this.surface = Util.asSurface(param.src);
-			this.map = param.map;
-			this.defaultGlyphWidth = param.defaultGlyphWidth;
-			this.defaultGlyphHeight = param.defaultGlyphHeight;
-			this.missingGlyph = param.missingGlyph;
-			this.size = param.defaultGlyphHeight;
+
+			let glyphInfo: BitmapFontGlyphData;
+			if (param.glyphInfo) {
+				if ((param.glyphInfo as BitmapFontGlyphData).map) {
+					glyphInfo = param.glyphInfo as BitmapFontGlyphData;
+				} else {
+					glyphInfo = JSON.parse((param.glyphInfo as g.TextAsset).data);
+				}
+			}
+
+			this.map = glyphInfo ? glyphInfo.map : param.map;
+			this.defaultGlyphWidth = glyphInfo ? glyphInfo.width : param.defaultGlyphWidth;
+			this.defaultGlyphHeight = glyphInfo ? glyphInfo.height : param.defaultGlyphHeight;
+			this.missingGlyph = glyphInfo ? glyphInfo.missingGlyph : param.missingGlyph;
+			this.size = glyphInfo ? glyphInfo.height : param.defaultGlyphHeight;
 		}
 
 		/**

--- a/src/BitmapFont.ts
+++ b/src/BitmapFont.ts
@@ -3,17 +3,12 @@ namespace g {
 	/**
 	 * BitmapFont のデータを格納したテキストアセット (JSON) を JSON.parse したオブジェクト
 	 */
-	export interface BitmapFontGlyphData {
+	export interface BitmapFontGlyphInfo {
 		map: {[key: string]: GlyphArea},
 		width: number,
 		height: number,
 		missingGlyph: GlyphArea
 	}
-
-	/**
-	 * BitmapFont の生成に必要なデータセット
-	 */
-	export type BitmapFontGlyphInfo = TextAsset | BitmapFontGlyphData;
 
 	/**
 	 * `BitmapFont` のコンストラクタに渡すことができるパラメータ。
@@ -27,7 +22,7 @@ namespace g {
 
 		/**
 		 * BitmapFont の生成に必要なデータセット。
-		 * glyphInfo が与えられる場合、 BitmapFontParameterObject の map defaultGlyphWidth defaultGlyphHeight missingGlyph は参照されない。
+		 * glyphInfo が与えられる場合、 BitmapFontParameterObject の map, defaultGlyphWidth, defaultGlyphHeight, missingGlyph は参照されない。
 		 */
 		glyphInfo?: BitmapFontGlyphInfo;
 
@@ -72,20 +67,19 @@ namespace g {
 			super();
 			this.surface = Util.asSurface(param.src);
 
-			let glyphInfo: BitmapFontGlyphData;
 			if (param.glyphInfo) {
-				if ((param.glyphInfo as BitmapFontGlyphData).map) {
-					glyphInfo = param.glyphInfo as BitmapFontGlyphData;
-				} else {
-					glyphInfo = JSON.parse((param.glyphInfo as g.TextAsset).data);
-				}
+				this.map = param.glyphInfo.map;
+				this.defaultGlyphWidth = param.glyphInfo.width;
+				this.defaultGlyphHeight = param.glyphInfo.height;
+				this.missingGlyph = param.glyphInfo.missingGlyph;
+				this.size = param.glyphInfo.height;
+			} else {
+				this.map = param.map;
+				this.defaultGlyphWidth = param.defaultGlyphWidth;
+				this.defaultGlyphHeight = param.defaultGlyphHeight;
+				this.missingGlyph = param.missingGlyph;
+				this.size = param.defaultGlyphHeight;
 			}
-
-			this.map = glyphInfo ? glyphInfo.map : param.map;
-			this.defaultGlyphWidth = glyphInfo ? glyphInfo.width : param.defaultGlyphWidth;
-			this.defaultGlyphHeight = glyphInfo ? glyphInfo.height : param.defaultGlyphHeight;
-			this.missingGlyph = glyphInfo ? glyphInfo.missingGlyph : param.missingGlyph;
-			this.size = glyphInfo ? glyphInfo.height : param.defaultGlyphHeight;
 		}
 
 		/**


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
g.BitmapFont の利用を簡便にするため、 g.BitmapFontParameterObject に一括したデータを渡せる口を用意します。
g.TextAsset または その data プロパティを JSON.parse したオブジェクトを渡せる glyphInfo プロパティを新設します。


## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

