### PR TITLE
Add RuntimeGame, InternalGame

### DIFF
--- a/index.runtime.d.ts
+++ b/index.runtime.d.ts
@@ -1,12 +1,12 @@
 // このファイルにある変数をエンジン開発者及びエンジンユーザは利用してはならない。
 // これらはゲーム開発者がスクリプトアセット内で `g.game` 等を利用する場合の型解決のために利用される。
-import { Game } from "./lib/Game";
+import { RuntimeGame } from "./lib/RuntimeGame";
 
 /**
  * スクリプトアセット内で参照可能な値。
  * スクリプトアセットを実行した `Game` を表す。
  */
-export const game: Game;
+export const game: RuntimeGame;
 
 /**
  * スクリプトアセット内で参照可能な値。
@@ -20,6 +20,6 @@ export const dirname: string;
  */
 export const filename: string;
 
-export * from "./lib";
+export * from "./lib/index.common";
 
 export as namespace g;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -22,6 +22,7 @@ import { RendererLike } from "./interfaces/RendererLike";
 import { ResourceFactoryLike } from "./interfaces/ResourceFactoryLike";
 import { ScriptAssetRuntimeValueBase } from "./interfaces/ScriptAssetRuntimeValue";
 import { SurfaceAtlasSetLike } from "./interfaces/SurfaceAtlasSetLike";
+import { InternalGame } from "./InternalGame";
 import { Scene, SceneAssetHolder, SceneLoadState } from "./Scene";
 import { CommonOffset, CommonSize } from "./types/commons";
 import { EventFilter } from "./types/EventFilter";
@@ -164,75 +165,12 @@ export interface GameParameterObject {
  *
  * 本クラスのインスタンスは暗黙に生成され、ゲーム開発者が生成することはない。
  * ゲーム開発者はg.gameによって本クラスのインスタンスを参照できる。
- *
- * 多くの機能を持つが、本クラスをゲーム開発者が利用するのは以下のようなケースである。
- * 1. Sceneの生成時、コンストラクタに引数として渡す
- * 2. Sceneに紐付かないイベント Game#join, Game#leave, Game#playerInfo, Game#seed を処理する
- * 3. 乱数を発生させるため、Game#randomにアクセスしRandomGeneratorを取得する
- * 4. ゲームのメタ情報を確認するため、Game#width, Game#height, Game#fpsにアクセスする
- * 5. グローバルアセットを取得するため、Game#assetsにアクセスする
- * 6. LoadingSceneを変更するため、Game#loadingSceneにゲーム開発者の定義したLoadingSceneを指定する
- * 7. スナップショット機能を作るため、Game#snapshotRequestにアクセスする
- * 8. 現在フォーカスされているCamera情報を得るため、Game#focusingCameraにアクセスする
- * 9. AudioSystemを直接制御するため、Game#audioにアクセスする
- * 10.Sceneのスタック情報を調べるため、Game#scenesにアクセスする
- * 11.操作プラグインを直接制御するため、Game#operationPluginManagerにアクセスする
  */
-export class Game {
-	/**
-	 * このコンテンツに関連付けられるエンティティ。(ローカルなエンティティを除く)
-	 */
-	db: { [idx: number]: E };
+export class Game implements InternalGame {
 	/**
 	 * このコンテンツを描画するためのオブジェクト群。
 	 */
 	renderers: RendererLike[];
-	/**
-	 * シーンのスタック。
-	 */
-	scenes: Scene[];
-	/**
-	 * このGameで利用可能な乱数生成機群。
-	 */
-	random: RandomGenerator;
-	/**
-	 * プレイヤーがゲームに参加したことを表すイベント。
-	 */
-	onJoin: Trigger<JoinEvent>;
-	/**
-	 * プレイヤーがゲームから離脱したことを表すイベント。
-	 */
-	onLeave: Trigger<LeaveEvent>;
-	/**
-	 * 新しいプレイヤー情報が発生したことを示すイベント。
-	 */
-	onPlayerInfo: Trigger<PlayerInfoEvent>;
-	/**
-	 * 新しい乱数シードが発生したことを示すイベント。
-	 */
-	onSeed: Trigger<SeedEvent>;
-	/**
-	 * このコンテンツの累計経過時間。
-	 * 通常は `this.scene().local` が偽である状態で `tick()` の呼ばれた回数だが、シーン切り替え時等 `tick()` が呼ばれた時以外で加算される事もある。
-	 */
-	age: number;
-	/**
-	 * フレーム辺りの時間経過間隔。初期値は30である。
-	 */
-	fps: number;
-	/**
-	 * ゲーム画面の幅。
-	 */
-	width: number;
-	/**
-	 * ゲーム画面の高さ。
-	 */
-	height: number;
-
-	/**
-	 * グローバルアセットのマップ。this._initialScene.assets のエイリアス。
-	 */
-	assets: { [key: string]: AssetLike };
 
 	/**
 	 * グローバルアセットが読み込み済みの場合真。でなければ偽。
@@ -240,207 +178,9 @@ export class Game {
 	isLoaded: boolean;
 
 	/**
-	 * アセットのロード中に表示するシーン。
-	 * ゲーム開発者はこの値を書き換えることでローディングシーンを変更してよい。
-	 */
-	loadingScene: LoadingScene;
-
-	/**
-	 * Assetの読み込みに使うベースパス。
-	 * ゲーム開発者が参照する必要はない。
-	 * 値はプラットフォーム由来のパス(絶対パス)とゲームごとの基準パス(相対パス)をつないだものになる。
-	 */
-	assetBase: string;
-
-	/**
-	 * このゲームを実行している「自分」のID。
-	 *
-	 * この値は、 `Game#join` で渡される `Player` のフィールド `id` と等価性を比較できる値である。
-	 * すなわちゲーム開発者は、join してきた`Player`の `id` とこの値を比較することで、
-	 * このゲームのインスタンスを実行している「自分」が参加者であるか否かを決定することができる。
-	 *
-	 * この値は必ずしも常に存在するとは限らないことに注意。存在しない場合、 `undefined` である。
-	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
-	 */
-	// ゲーム開発者がこのIDに付随する情報(名前など)を、ローカルエンティティでの表示や
-	// 干渉などで利用したい場合は、外部システムに問い合わせる必要がある。
-	selfId: string;
-
-	/**
-	 * 本ゲームで利用可能なオーディオシステム群。musicとsoundが登録されている。
-	 */
-	audio: AudioSystemManager;
-
-	/**
-	 * デフォルトで利用されるオーディオシステムのID。デフォルト値はsound。
-	 */
-	defaultAudioSystemId: "music" | "sound";
-
-	/**
-	 * スナップショット要求通知。
-	 * ゲーム開発者はこれをhandleして可能ならスナップショットを作成しGame#saveSnapshotを呼び出すべきである。
-	 */
-	// NOTE: このクラスはこのTriggerをfireしない。派生クラスがfireせねばならない。
-	onSnapshotRequest: Trigger<void>;
-
-	/**
-	 * 外部インターフェース。
-	 *
-	 * 実行環境によって、環境依存の値が設定される。
-	 * ゲーム開発者はこの値を用いる場合、各実行環境のドキュメントを参照すべきである。
-	 */
-	// このクラス自身は、初期値 `{}` を代入することを除き、この値を参照・設定しない。
-	external: any;
-
-	/**
-	 * 各種リソースのファクトリ。
-	 */
-	resourceFactory: ResourceFactoryLike;
-
-	/**
 	 * ハンドラセット。
 	 */
 	handlerSet: GameHandlerSet;
-
-	/**
-	 * ストレージ。
-	 */
-	storage: Storage;
-
-	/**
-	 * ゲーム開発者向けのコンテナ。
-	 *
-	 * この値はゲームエンジンのロジックからは使用されず、ゲーム開発者は任意の目的に使用してよい。
-	 */
-	vars: any;
-
-	/**
-	 * このゲームの各プレイを識別する値。
-	 *
-	 * このゲームに複数のプレイヤーがいる場合、すなわち `Game#join` が複数回fireされている場合、各プレイヤー間でこの値は同一である。
-	 * この値は、特に `game.external` で提供される外部APIに与えるなど、Akashic Engine外部とのやりとりで使われることを想定する値である。
-	 *
-	 * 実行中、この値が変化しないことは保証されない。ゲーム開発者はこの値を保持すべきではない。
-	 * また、この値に応じてゲームの処理や内部状態を変化させるべきではない。
-	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
-	 */
-	playId: string;
-
-	/**
-	 * ロードしている操作プラグインを保持するオブジェクト。
-	 */
-	operationPlugins: { [key: number]: OperationPlugin };
-
-	/**
-	 * 画面サイズの変更時にfireされるTrigger。
-	 */
-	onResized: Trigger<CommonSize>;
-
-	/**
-	 * スキップ状態の変化時にfireされるTrigger。
-	 *
-	 * スキップ状態に遷移する時に真、非スキップ状態に遷移する時に偽が与えられる。
-	 * この通知は、ゲーム開発者が「スキップ中の演出省略」などの最適化を行うために提供されている。
-	 *
-	 * この通知のfire頻度は、ゲームの実行状態などに依存して異なりうることに注意。
-	 * 例えば多人数プレイされている時、それぞれの環境でfireされ方が異なりうる。
-	 * ゲーム開発者は、この通知に起因する処理で、ゲームのグローバルな実行状態を変化させてはならない。
-	 */
-	onSkipChange: Trigger<boolean>;
-
-	/**
-	 * 直近の `update` の通知が、ローカルティックによるものか否か。
-	 *
-	 * ただし一度も `update` 通知が起きていない間は真である。
-	 * ローカルシーンおよびローカルティック補間シーン以外のシーンにおいては、常に偽。
-	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
-	 */
-	isLastTickLocal: boolean;
-
-	/**
-	 * 直近の `update` の通知時(の直前)に(タイムスタンプ待ちを省略する動作などの影響でエンジンが)省いたローカルティックの数。
-	 *
-	 * 一度も `update` 通知が起きていない間は `0` である。
-	 * ローカルティック補間シーンでない場合、常に `0` であることに注意。
-	 *
-	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
-	 */
-	lastOmittedLocalTickCount: number;
-
-	/**
-	 * 直近の `Scene#local` の値。
-	 *
-	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
-	 */
-	lastLocalTickMode: LocalTickMode | null;
-
-	/**
-	 * 直近の `Scene#tickGenerationMode` の値。
-	 *
-	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
-	 */
-	lastTickGenerationMode: TickGenerationMode | null;
-
-	/**
-	 * ゲーム全体で共有するサーフェスアトラス。
-	 */
-	surfaceAtlasSet: SurfaceAtlasSetLike;
-
-	/**
-	 * 操作プラグインの管理者。
-	 */
-	operationPluginManager: OperationPluginManager;
-
-	/**
-	 * プレイヤーがゲームに参加したことを表すイベント。
-	 * @deprecated 非推奨である。将来的に削除される。代わりに `onJoin` を利用すること。
-	 */
-	join: Trigger<JoinEvent>;
-
-	/**
-	 * プレイヤーがゲームから離脱したことを表すイベント。
-	 * @deprecated 非推奨である。将来的に削除される。代わりに `onLeave` を利用すること。
-	 */
-	leave: Trigger<LeaveEvent>;
-
-	/**
-	 * 新しいプレイヤー情報が発生したことを示すイベント。
-	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPlayerInfo` を利用すること。
-	 */
-	playerInfo: Trigger<PlayerInfoEvent>;
-
-	/**
-	 * 新しい乱数シードが発生したことを示すイベント。
-	 * @deprecated 非推奨である。将来的に削除される。代わりに `onSeed` を利用すること。
-	 */
-	seed: Trigger<SeedEvent>;
-
-	/**
-	 * スナップショット要求通知。
-	 * ゲーム開発者はこれをhandleして可能ならスナップショットを作成しGame#saveSnapshotを呼び出すべきである。
-	 * @deprecated 非推奨である。将来的に削除される。代わりに `onSnapshotRequest` を利用すること。
-	 */
-	// NOTE: このクラスはこのTriggerをfireしない。派生クラスがfireせねばならない。
-	snapshotRequest: Trigger<void>;
-
-	/**
-	 * 画面サイズの変更時にfireされるTrigger。
-	 * @deprecated 非推奨である。将来的に削除される。代わりに `onResized` を利用すること。
-	 */
-	resized: Trigger<CommonSize>;
-
-	/**
-	 * スキップ状態の変化時にfireされるTrigger。
-	 *
-	 * スキップ状態に遷移する時に真、非スキップ状態に遷移する時に偽が与えられる。
-	 * この通知は、ゲーム開発者が「スキップ中の演出省略」などの最適化を行うために提供されている。
-	 *
-	 * この通知のfire頻度は、ゲームの実行状態などに依存して異なりうることに注意。
-	 * 例えば多人数プレイされている時、それぞれの環境でfireされ方が異なりうる。
-	 * ゲーム開発者は、この通知に起因する処理で、ゲームのグローバルな実行状態を変化させてはならない。
-	 * @deprecated 非推奨である。将来的に削除される。代わりに `onSkipChange` を利用すること。
-	 */
-	skippingChanged: Trigger<boolean>;
 
 	/**
 	 * イベントとTriggerのマップ。
@@ -500,18 +240,6 @@ export class Game {
 	_mainParameter: GameMainParameterObject;
 
 	/**
-	 * アセットの管理者。
-	 * @private
-	 */
-	_assetManager: AssetManager;
-
-	/**
-	 * モジュールの管理者。
-	 * @private
-	 */
-	_moduleManager: ModuleManager;
-
-	/**
 	 * イベントコンバータ。
 	 * @private
 	 */
@@ -536,14 +264,6 @@ export class Game {
 	 */
 	_idx: number;
 
-	/**
-	 * このゲームに紐づくローカルなエンティティ (`E#local` が真のもの)
-	 * @private
-	 */
-	// ローカルエンティティは他のゲームインスタンス(他参加者・視聴者など)とは独立に生成される可能性がある。
-	// そのため `db` (`_idx`) 基準で `id` を与えてしまうと `id` の値がずれることがありうる。
-	// これを避けるため、 `db` からローカルエンティティ用のDBを独立させたものがこの値である。
-	_localDb: { [id: number]: E };
 	/**
 	 * ローカルエンティティ用の `this._idx` 。
 	 * @private
@@ -620,17 +340,57 @@ export class Game {
 	 */
 	_operationPluginOperated: Trigger<InternalOperationPluginOperation>;
 
+	// defined in RuntimeGame
+	scenes: Scene[];
+	random: RandomGenerator;
+	onJoin: Trigger<JoinEvent>;
+	onLeave: Trigger<LeaveEvent>;
+	onPlayerInfo: Trigger<PlayerInfoEvent>;
+	onSeed: Trigger<SeedEvent>;
+	age: number;
+	fps: number;
+	width: number;
+	height: number;
+	assets: { [key: string]: AssetLike };
+	loadingScene: LoadingScene;
+	selfId: string;
+	audio: AudioSystemManager;
+	defaultAudioSystemId: "music" | "sound";
+	onSnapshotRequest: Trigger<void>;
+	external: any;
+	resourceFactory: ResourceFactoryLike;
+	storage: Storage;
+	vars: any;
+	playId: string;
+	operationPlugins: { [key: number]: OperationPlugin };
+	onResized: Trigger<CommonSize>;
+	onSkipChange: Trigger<boolean>;
+	isLastTickLocal: boolean;
+	lastOmittedLocalTickCount: number;
+	lastLocalTickMode: LocalTickMode | null;
+	lastTickGenerationMode: TickGenerationMode | null;
+	surfaceAtlasSet: SurfaceAtlasSetLike;
+	operationPluginManager: OperationPluginManager;
+	join: Trigger<JoinEvent>;
+	leave: Trigger<LeaveEvent>;
+	playerInfo: Trigger<PlayerInfoEvent>;
+	seed: Trigger<SeedEvent>;
+	snapshotRequest: Trigger<void>;
+	resized: Trigger<CommonSize>;
+	skippingChanged: Trigger<boolean>;
+
+	// defined in InternalGame
+	db: { [idx: number]: E };
+	assetBase: string;
+	_localDb: { [id: number]: E };
+	_assetManager: AssetManager;
+	_moduleManager: ModuleManager;
+
 	/**
 	 * 実行待ちのシーン遷移要求。
 	 */
 	private _sceneChangeRequests: SceneChangeRequest[];
 
-	/**
-	 * 使用中のカメラ。
-	 *
-	 * `Game#draw()`, `Game#findPointSource()` のデフォルト値として使用される。
-	 * この値を変更した場合、変更を描画に反映するためには `Game#modified()` を呼び出す必要がある。
-	 */
 	// focusingCameraが変更されても古いカメラをtargetCamerasに持つエンティティのEntityStateFlags.Modifiedを取りこぼすことが無いように、変更時にはrenderを呼べるようアクセサを使う
 	get focusingCamera(): Camera {
 		return this._focusingCamera;
@@ -743,71 +503,6 @@ export class Game {
 	}
 
 	/**
-	 * シーンスタックへのシーンの追加と、そのシーンへの遷移を要求する。
-	 *
-	 * このメソッドは要求を行うだけである。呼び出し直後にはシーン遷移は行われていないことに注意。
-	 * 実際のシーン遷移は次のフレームまでに(次のupdateのfireまでに)行われる。
-	 * このメソッドの呼び出しにより、現在のシーンの `stateChanged` が引数 `SceneState.Deactive` でfireされる。
-	 * その後 `scene.stateChanged` が引数 `SceneState.Active` でfireされる。
-	 * @param scene 遷移後のシーン
-	 */
-	pushScene(scene: Scene): void {
-		this._sceneChangeRequests.push({
-			type: SceneChangeType.Push,
-			scene: scene
-		});
-	}
-
-	/**
-	 * 現在のシーンの置き換えを要求する。
-	 *
-	 * 現在のシーンをシーンスタックから取り除き、指定のシーンを追加することを要求する。
-	 * このメソッドは要求を行うだけである。呼び出し直後にはシーン遷移は行われていないことに注意。
-	 * 実際のシーン遷移は次のフレームまでに(次のupdateのfireまでに)行われる。
-	 * 引数 `preserveCurrent` が偽の場合、このメソッドの呼び出しにより現在のシーンは破棄される。
-	 * またその時 `stateChanged` が引数 `SceneState.Destroyed` でfireされる。
-	 * その後 `scene.stateChanged` が引数 `SceneState.Active` でfireされる。
-	 *
-	 * @param scene 遷移後のシーン
-	 * @param preserveCurrent 真の場合、現在のシーンを破棄しない(ゲーム開発者が明示的に破棄せねばならない)。省略された場合、偽
-	 */
-	replaceScene(scene: Scene, preserveCurrent?: boolean): void {
-		this._sceneChangeRequests.push({
-			type: SceneChangeType.Replace,
-			scene: scene,
-			preserveCurrent: preserveCurrent
-		});
-	}
-
-	/**
-	 * シーンスタックから現在のシーンを取り除くことを要求する
-	 *
-	 * このメソッドは要求を行うだけである。呼び出し直後にはシーン遷移は行われていないことに注意。
-	 * 実際のシーン遷移は次のフレームまでに(次のupdateのfireまでに)行われる。
-	 * 引数 `preserve` が偽の場合、このメソッドの呼び出しにより取り除かれたシーンは全て破棄される。
-	 * またその時 `stateChanged` が引数 `SceneState.Destroyed` でfireされる。
-	 * その後一つ前のシーンの `stateChanged` が引数 `SceneState.Active` でfireされる。
-	 * また、step数がスタックされているシーンの数以上の場合、例外が投げられる。
-	 *
-	 * @param preserve 真の場合、シーンを破棄しない(ゲーム開発者が明示的に破棄せねばならない)。省略された場合、偽
-	 * @param step 取り除くシーンの数。省略された場合、1
-	 */
-	popScene(preserve?: boolean, step: number = 1): void {
-		for (let i = 0; i < step; i++) {
-			this._sceneChangeRequests.push({ type: SceneChangeType.Pop, preserveCurrent: preserve });
-		}
-	}
-
-	/**
-	 * 現在のシーンを返す。
-	 * ない場合、 `undefined` を返す。
-	 */
-	scene(): Scene | undefined {
-		if (!this.scenes.length) return undefined;
-		return this.scenes[this.scenes.length - 1];
-	}
-
-	/**
 	 * この `Game` の時間経過とそれに伴う処理を行う。
 	 *
 	 * 現在の `Scene` に対して `Scene#update` をfireし、 `events` に設定されたイベントを処理する。
@@ -903,34 +598,91 @@ export class Game {
 		}
 	}
 
-	/**
-	 * その座標に反応する `PointSource` を返す。
-	 *
-	 * 戻り値は、対象が見つかった場合、 `target` に見つかった `E` を持つ `PointSource` である。
-	 * 対象が見つからなかった場合、 `undefined` である。
-	 *
-	 * 戻り値が `undefined` でない場合、その `target` プロパティは次を満たす:
-	 * - `E#touchable` が真である
-	 * - カメラ `camera` から可視である中で最も手前にある
-	 *
-	 * @param point 対象の座標
-	 * @param camera 対象のカメラ。指定しなければ `Game.focusingCamera` が使われる
-	 */
+	// defined in RuntimeGame
+	pushScene(scene: Scene): void {
+		this._sceneChangeRequests.push({
+			type: SceneChangeType.Push,
+			scene: scene
+		});
+	}
+
+	// defined in RuntimeGame
+	replaceScene(scene: Scene, preserveCurrent?: boolean): void {
+		this._sceneChangeRequests.push({
+			type: SceneChangeType.Replace,
+			scene: scene,
+			preserveCurrent: preserveCurrent
+		});
+	}
+
+	// defined in RuntimeGame
+	popScene(preserve?: boolean, step: number = 1): void {
+		for (let i = 0; i < step; i++) {
+			this._sceneChangeRequests.push({ type: SceneChangeType.Pop, preserveCurrent: preserve });
+		}
+	}
+
+	// defined in RuntimeGame
+	scene(): Scene | undefined {
+		if (!this.scenes.length) return undefined;
+		return this.scenes[this.scenes.length - 1];
+	}
+
+	// defined in RuntimeGame
 	findPointSource(point: CommonOffset, camera?: Camera): PointSource {
 		if (!camera) camera = this.focusingCamera;
 		return this.scene().findPointSourceByPoint(point, false, camera);
 	}
 
-	/**
-	 * このGameにエンティティを登録する。
-	 *
-	 * このメソッドは各エンティティに対して暗黙に呼び出される。ゲーム開発者がこのメソッドを明示的に利用する必要はない。
-	 * `e.id` が `undefined` である場合、このメソッドの呼び出し後、 `e.id` には `this` に一意の値が設定される。
-	 * `e.local` が偽である場合、このメソッドの呼び出し後、 `this.db[e.id] === e` が成立する。
-	 * `e.local` が真である場合、 `e.id` の値は不定である。
-	 *
-	 * @param e 登録するエンティティ
-	 */
+	// defined in RuntimeGame
+	raiseEvent(e: Event): void {
+		this.handlerSet.raiseEvent(this._eventConverter.toPlaylogEvent(e));
+	}
+
+	// defined in RuntimeGame
+	raiseTick(events?: Event[]): void {
+		if (events == null || !events.length) {
+			this.handlerSet.raiseTick();
+			return;
+		}
+		const plEvents: pl.Event[] = [];
+		for (let i = 0; i < events.length; i++) {
+			plEvents.push(this._eventConverter.toPlaylogEvent(events[i]));
+		}
+		this.handlerSet.raiseTick(plEvents);
+	}
+
+	// defined in RuntimeGame
+	addEventFilter(filter: EventFilter, handleEmpty?: boolean): void {
+		this.handlerSet.addEventFilter(filter, handleEmpty);
+	}
+
+	// defined in RuntimeGame
+	removeEventFilter(filter: EventFilter): void {
+		this.handlerSet.removeEventFilter(filter);
+	}
+
+	// defined in RuntimeGame
+	shouldSaveSnapshot(): boolean {
+		return this.handlerSet.shouldSaveSnapshot();
+	}
+
+	// defined in RuntimeGame
+	saveSnapshot(snapshot: any, timestamp?: number): void {
+		this.handlerSet.saveSnapshot(this.age, snapshot, this.random.serialize(), timestamp);
+	}
+
+	// defined in RuntimeGame
+	getCurrentTime(): number {
+		return this.handlerSet.getCurrentTime();
+	}
+
+	// defined in RuntimeGame
+	isActiveInstance(): boolean {
+		return this.handlerSet.getInstanceType() === "active";
+	}
+
+	// defined in InternalGame
 	register(e: E): void {
 		if (e.local) {
 			if (e.id === undefined) {
@@ -959,13 +711,7 @@ export class Game {
 		}
 	}
 
-	/**
-	 * このGameからエンティティの登録を削除する。
-	 *
-	 * このメソッドは各エンティティに対して暗黙に呼び出される。ゲーム開発者がこのメソッドを明示的に利用する必要はない。
-	 * このメソッドの呼び出し後、 `this.db[e.id]` は未定義である。
-	 * @param e 登録を削除するエンティティ
-	 */
+	// defined in InternalGame
 	unregister(e: E): void {
 		if (e.local) {
 			delete this._localDb[e.id];
@@ -974,144 +720,18 @@ export class Game {
 		}
 	}
 
-	/**
-	 * このゲームを終了する。
-	 *
-	 * エンジンに対して続行の断念を通知する。
-	 * このメソッドの呼び出し後、このクライアントの操作要求は送信されない。
-	 * またこのクライアントのゲーム実行は行われない(updateを含むイベントのfireはおきない)。
-	 */
+	// defined in InternalGame
 	terminateGame(): void {
 		this._isTerminated = true;
 		this._terminateGame();
 	}
 
-	/**
-	 * 画面更新が必要のフラグを設定する。
-	 */
+	// defined in InternalGame
 	modified(): void {
 		this._modified = true;
 	}
 
-	/**
-	 * イベントを発生させる。
-	 *
-	 * ゲーム開発者は、このメソッドを呼び出すことで、エンジンに指定のイベントを発生させることができる。
-	 *
-	 * @param e 発生させるイベント
-	 */
-	raiseEvent(e: Event): void {
-		this.handlerSet.raiseEvent(this._eventConverter.toPlaylogEvent(e));
-	}
-
-	/**
-	 * ティックを発生させる。
-	 *
-	 * ゲーム開発者は、このメソッドを呼び出すことで、エンジンに時間経過を要求することができる。
-	 * 現在のシーンのティック生成モード `Scene#tickGenerationMode` が `TickGenerationMode.Manual` でない場合、エラー。
-	 *
-	 * @param events そのティックで追加で発生させるイベント
-	 */
-	raiseTick(events?: Event[]): void {
-		if (events == null || !events.length) {
-			this.handlerSet.raiseTick();
-			return;
-		}
-		const plEvents: pl.Event[] = [];
-		for (let i = 0; i < events.length; i++) {
-			plEvents.push(this._eventConverter.toPlaylogEvent(events[i]));
-		}
-		this.handlerSet.raiseTick(plEvents);
-	}
-
-	/**
-	 * イベントフィルタを追加する。
-	 *
-	 * 一つ以上のイベントフィルタが存在する場合、このゲームで発生したイベントは、通常の処理の代わりにイベントフィルタに渡される。
-	 * エンジンは、イベントフィルタが戻り値として返したイベントを、まるでそのイベントが発生したかのように処理する。
-	 *
-	 * イベントフィルタはローカルイベントに対しても適用される。
-	 * イベントフィルタはローカルティック補間シーンやローカルシーンの間であっても適用される。
-	 * 複数のイベントフィルタが存在する場合、そのすべてが適用される。適用順は登録の順である。
-	 *
-	 * @param filter 追加するイベントフィルタ
-	 * @param handleEmpty イベントが存在しない場合でも定期的にフィルタを呼び出すか否か。省略された場合、偽。
-	 */
-	addEventFilter(filter: EventFilter, handleEmpty?: boolean): void {
-		this.handlerSet.addEventFilter(filter, handleEmpty);
-	}
-
-	/**
-	 * イベントフィルタを削除する。
-	 *
-	 * @param filter 削除するイベントフィルタ
-	 */
-	removeEventFilter(filter: EventFilter): void {
-		this.handlerSet.removeEventFilter(filter);
-	}
-
-	/**
-	 * このインスタンスにおいてスナップショットの保存を行うべきかを返す。
-	 *
-	 * スナップショット保存に対応するゲームであっても、
-	 * 必ずしもすべてのインスタンスにおいてスナップショット保存を行うべきとは限らない。
-	 * たとえば多人数プレイ時には、複数のクライアントで同一のゲームが実行される。
-	 * スナップショットを保存するのはそのうちの一つのインスタンスのみでよい。
-	 * 本メソッドはそのような場合に、自身がスナップショットを保存すべきかどうかを判定するために用いることができる。
-	 *
-	 * スナップショット保存に対応するゲームは、このメソッドが真を返す時にのみ `Game#saveSnapshot()` を呼び出すべきである。
-	 * 戻り値は、スナップショットの保存を行うべきであれば真、でなければ偽である。
-	 */
-	shouldSaveSnapshot(): boolean {
-		return this.handlerSet.shouldSaveSnapshot();
-	}
-
-	/**
-	 * スナップショットを保存する。
-	 *
-	 * 引数 `snapshot` の値は、スナップショット読み込み関数 (snapshot loader) に引数として渡されるものになる。
-	 * このメソッドを呼び出すゲームは必ずsnapshot loaderを実装しなければならない。
-	 * (snapshot loaderとは、idが "snapshotLoader" であるglobalなScriptAssetに定義された関数である。
-	 * 詳細はスナップショットについてのドキュメントを参照)
-	 *
-	 * このメソッドは `Game#shouldSaveSnapshot()` が真を返す `Game` に対してのみ呼び出されるべきである。
-	 * そうでない場合、このメソッドの動作は不定である。
-	 *
-	 * このメソッドを呼び出す推奨タイミングは、Trigger `Game#snapshotRequest` をhandleすることで得られる。
-	 * ゲームは、 `snapshotRequest` がfireされたとき (それが可能なタイミングであれば) スナップショットを
-	 * 生成してこのメソッドに渡すべきである。ゲーム開発者は推奨タイミング以外でもこのメソッドを呼び出すことができる。
-	 * ただしその頻度は推奨タイミングの発火頻度と同程度に抑えられるべきである。
-	 *
-	 * @param snapshot 保存するスナップショット。JSONとして妥当な値でなければならない。
-	 * @param timestamp 保存時の時刻。 `g.TimestampEvent` を利用するゲームの場合、それらと同じ基準の時間情報を与えなければならない。
-	 */
-	saveSnapshot(snapshot: any, timestamp?: number): void {
-		this.handlerSet.saveSnapshot(this.age, snapshot, this.random.serialize(), timestamp);
-	}
-
-	/**
-	 * 現在時刻を取得する。
-	 *
-	 * 値は1970-01-01T00:00:00Zからのミリ秒での経過時刻である。
-	 * `Date.now()` と異なり、この値は消化されたティックの数から算出される擬似的な時刻である。
-	 */
-	getCurrentTime(): number {
-		return this.handlerSet.getCurrentTime();
-	}
-
-	/**
-	 * このインスタンスがアクティブインスタンスであるかどうか返す。
-	 *
-	 * ゲーム開発者は、この値の真偽に起因する処理で、ゲームのローカルな実行状態を変更してはならず、
-	 * `raiseEvent()` などによって、グローバルな状態を更新する必要がある。
-	 */
-	isActiveInstance(): boolean {
-		return this.handlerSet.getInstanceType() === "active";
-	}
-
-	/**
-	 * @private
-	 */
+	// defined in InternalGame
 	_fireSceneReady(scene: Scene): void {
 		this._sceneChangeRequests.push({
 			type: SceneChangeType.FireReady,
@@ -1119,9 +739,7 @@ export class Game {
 		});
 	}
 
-	/**
-	 * @private
-	 */
+	// defined in InternalGame
 	_fireSceneLoaded(scene: Scene): void {
 		if (scene._loadingState < SceneLoadState.LoadedFired) {
 			this._sceneChangeRequests.push({
@@ -1131,9 +749,7 @@ export class Game {
 		}
 	}
 
-	/**
-	 * @private
-	 */
+	// defined in InternalGame
 	_callSceneAssetHolderHandler(assetHolder: SceneAssetHolder): void {
 		this._sceneChangeRequests.push({
 			type: SceneChangeType.CallAssetHolderHandler,

--- a/src/InternalGame.ts
+++ b/src/InternalGame.ts
@@ -1,0 +1,79 @@
+import { AssetManager } from "./domain/AssetManager";
+import { E } from "./domain/entities/E";
+import { ModuleManager } from "./domain/ModuleManager";
+import { RuntimeGame } from "./RuntimeGame";
+import { Scene, SceneAssetHolder } from "./Scene";
+
+/**
+ * akashic-engine 内部から参照可能な Game の型定義。
+ */
+export interface InternalGame extends RuntimeGame {
+	/**
+	 * このコンテンツに関連付けられるエンティティ。(ローカルなエンティティを除く)
+	 */
+	db: { [idx: number]: E };
+
+	/**
+	 * Assetの読み込みに使うベースパス。
+	 * ゲーム開発者が参照する必要はない。
+	 * 値はプラットフォーム由来のパス(絶対パス)とゲームごとの基準パス(相対パス)をつないだものになる。
+	 */
+	assetBase: string;
+
+	/**
+	 * このゲームに紐づくローカルなエンティティ (`E#local` が真のもの)
+	 */
+	// ローカルエンティティは他のゲームインスタンス(他参加者・視聴者など)とは独立に生成される可能性がある。
+	// そのため `db` (`_idx`) 基準で `id` を与えてしまうと `id` の値がずれることがありうる。
+	// これを避けるため、 `db` からローカルエンティティ用のDBを独立させたものがこの値である。
+	_localDb: { [id: number]: E };
+
+	/**
+	 * アセットの管理者。
+	 */
+	_assetManager: AssetManager;
+
+	/**
+	 * モジュールの管理者。
+	 */
+	_moduleManager: ModuleManager;
+
+	/**
+	 * 画面更新が必要のフラグを設定する。
+	 */
+	modified(): void;
+
+	/**
+	 * このGameにエンティティを登録する。
+	 *
+	 * このメソッドは各エンティティに対して暗黙に呼び出される。ゲーム開発者がこのメソッドを明示的に利用する必要はない。
+	 * `e.id` が `undefined` である場合、このメソッドの呼び出し後、 `e.id` には `this` に一意の値が設定される。
+	 * `e.local` が偽である場合、このメソッドの呼び出し後、 `this.db[e.id] === e` が成立する。
+	 * `e.local` が真である場合、 `e.id` の値は不定である。
+	 *
+	 * @param e 登録するエンティティ
+	 */
+	register(e: E): void;
+
+	/**
+	 * このGameからエンティティの登録を削除する。
+	 *
+	 * このメソッドは各エンティティに対して暗黙に呼び出される。ゲーム開発者がこのメソッドを明示的に利用する必要はない。
+	 * このメソッドの呼び出し後、 `this.db[e.id]` は未定義である。
+	 * @param e 登録を削除するエンティティ
+	 */
+	unregister(e: E): void;
+
+	/**
+	 * このゲームを終了する。
+	 *
+	 * エンジンに対して続行の断念を通知する。
+	 * このメソッドの呼び出し後、このクライアントの操作要求は送信されない。
+	 * またこのクライアントのゲーム実行は行われない(updateを含むイベントのfireはおきない)。
+	 */
+	terminateGame(): void;
+
+	_callSceneAssetHolderHandler(assetHolder: SceneAssetHolder): void;
+	_fireSceneReady(scene: Scene): void;
+	_fireSceneLoaded(scene: Scene): void;
+}

--- a/src/RuntimeGame.ts
+++ b/src/RuntimeGame.ts
@@ -1,0 +1,446 @@
+import { Trigger } from "@akashic/trigger";
+import { AudioSystemManager } from "./domain/AudioSystemManager";
+import { Camera } from "./domain/Camera";
+import { PointSource } from "./domain/entities/E";
+import { Event, JoinEvent, LeaveEvent, PlayerInfoEvent, SeedEvent } from "./domain/Event";
+import { LoadingScene } from "./domain/LoadingScene";
+import { OperationPluginManager } from "./domain/OperationPluginManager";
+import { RandomGenerator } from "./domain/RandomGenerator";
+import { Storage } from "./domain/Storage";
+import { AssetLike } from "./interfaces/AssetLike";
+import { ResourceFactoryLike } from "./interfaces/ResourceFactoryLike";
+import { SurfaceAtlasSetLike } from "./interfaces/SurfaceAtlasSetLike";
+import { Scene } from "./Scene";
+import { CommonOffset, CommonSize } from "./types/commons";
+import { EventFilter } from "./types/EventFilter";
+import { LocalTickMode } from "./types/LocalTickMode";
+import { OperationPlugin } from "./types/OperationPlugin";
+import { TickGenerationMode } from "./types/TickGenerationMode";
+
+/**
+ * コンテンツそのものを表すクラス。
+ *
+ * 本クラスのインスタンスは暗黙に生成され、ゲーム開発者が生成することはない。
+ * ゲーム開発者はg.gameによって本クラスのインスタンスを参照できる。
+ *
+ * 多くの機能を持つが、本クラスをゲーム開発者が利用するのは以下のようなケースである。
+ * 1. Sceneの生成時、コンストラクタに引数として渡す
+ * 2. Sceneに紐付かないイベント Game#join, Game#leave, Game#playerInfo, Game#seed を処理する
+ * 3. 乱数を発生させるため、Game#randomにアクセスしRandomGeneratorを取得する
+ * 4. ゲームのメタ情報を確認するため、Game#width, Game#height, Game#fpsにアクセスする
+ * 5. グローバルアセットを取得するため、Game#assetsにアクセスする
+ * 6. LoadingSceneを変更するため、Game#loadingSceneにゲーム開発者の定義したLoadingSceneを指定する
+ * 7. スナップショット機能を作るため、Game#snapshotRequestにアクセスする
+ * 8. 現在フォーカスされているCamera情報を得るため、Game#focusingCameraにアクセスする
+ * 9. AudioSystemを直接制御するため、Game#audioにアクセスする
+ * 10.Sceneのスタック情報を調べるため、Game#scenesにアクセスする
+ * 11.操作プラグインを直接制御するため、Game#operationPluginManagerにアクセスする
+ */
+export interface RuntimeGame {
+	/**
+	 * シーンのスタック。
+	 */
+	scenes: Scene[];
+
+	/**
+	 * このGameで利用可能な乱数生成機群。
+	 */
+	random: RandomGenerator;
+
+	/**
+	 * プレイヤーがゲームに参加したことを表すイベント。
+	 */
+	onJoin: Trigger<JoinEvent>;
+
+	/**
+	 * プレイヤーがゲームから離脱したことを表すイベント。
+	 */
+	onLeave: Trigger<LeaveEvent>;
+
+	/**
+	 * 新しいプレイヤー情報が発生したことを示すイベント。
+	 */
+	onPlayerInfo: Trigger<PlayerInfoEvent>;
+
+	/**
+	 * 新しい乱数シードが発生したことを示すイベント。
+	 */
+	onSeed: Trigger<SeedEvent>;
+
+	/**
+	 * このコンテンツの累計経過時間。
+	 * 通常は `this.scene().local` が偽である状態で `tick()` の呼ばれた回数だが、シーン切り替え時等 `tick()` が呼ばれた時以外で加算される事もある。
+	 */
+	age: number;
+
+	/**
+	 * フレーム辺りの時間経過間隔。初期値は30である。
+	 */
+	fps: number;
+
+	/**
+	 * ゲーム画面の幅。
+	 */
+	width: number;
+
+	/**
+	 * ゲーム画面の高さ。
+	 */
+	height: number;
+
+	/**
+	 * グローバルアセットのマップ。this._initialScene.assets のエイリアス。
+	 */
+	assets: { [key: string]: AssetLike };
+
+	/**
+	 * アセットのロード中に表示するシーン。
+	 * ゲーム開発者はこの値を書き換えることでローディングシーンを変更してよい。
+	 */
+	loadingScene: LoadingScene;
+
+	/**
+	 * このゲームを実行している「自分」のID。
+	 *
+	 * この値は、 `Game#join` で渡される `Player` のフィールド `id` と等価性を比較できる値である。
+	 * すなわちゲーム開発者は、join してきた`Player`の `id` とこの値を比較することで、
+	 * このゲームのインスタンスを実行している「自分」が参加者であるか否かを決定することができる。
+	 *
+	 * この値は必ずしも常に存在するとは限らないことに注意。存在しない場合、 `undefined` である。
+	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
+	 */
+	// ゲーム開発者がこのIDに付随する情報(名前など)を、ローカルエンティティでの表示や
+	// 干渉などで利用したい場合は、外部システムに問い合わせる必要がある。
+	selfId: string;
+
+	/**
+	 * 本ゲームで利用可能なオーディオシステム群。musicとsoundが登録されている。
+	 */
+	audio: AudioSystemManager;
+
+	/**
+	 * デフォルトで利用されるオーディオシステムのID。デフォルト値はsound。
+	 */
+	defaultAudioSystemId: "music" | "sound";
+
+	/**
+	 * スナップショット要求通知。
+	 * ゲーム開発者はこれをhandleして可能ならスナップショットを作成しGame#saveSnapshotを呼び出すべきである。
+	 */
+	onSnapshotRequest: Trigger<void>;
+
+	/**
+	 * 外部インターフェース。
+	 *
+	 * 実行環境によって、環境依存の値が設定される。
+	 * ゲーム開発者はこの値を用いる場合、各実行環境のドキュメントを参照すべきである。
+	 */
+	// このクラス自身は、初期値 `{}` を代入することを除き、この値を参照・設定しない。
+	external: any;
+
+	/**
+	 * この `Game` が用いる、リソースのファクトリ
+	 */
+	resourceFactory: ResourceFactoryLike;
+
+	/**
+	 * ストレージ。
+	 */
+	storage: Storage;
+
+	/**
+	 * ゲーム開発者向けのコンテナ。
+	 *
+	 * この値はゲームエンジンのロジックからは使用されず、ゲーム開発者は任意の目的に使用してよい。
+	 */
+	vars: any;
+
+	/**
+	 * このゲームの各プレイを識別する値。
+	 *
+	 * このゲームに複数のプレイヤーがいる場合、すなわち `Game#join` が複数回fireされている場合、各プレイヤー間でこの値は同一である。
+	 * この値は、特に `game.external` で提供される外部APIに与えるなど、Akashic Engine外部とのやりとりで使われることを想定する値である。
+	 *
+	 * 実行中、この値が変化しないことは保証されない。ゲーム開発者はこの値を保持すべきではない。
+	 * また、この値に応じてゲームの処理や内部状態を変化させるべきではない。
+	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
+	 */
+	playId: string;
+
+	/**
+	 * ロードしている操作プラグインを保持するオブジェクト。
+	 */
+	operationPlugins: { [key: number]: OperationPlugin };
+
+	/**
+	 * 画面サイズの変更時にfireされるTrigger。
+	 */
+	onResized: Trigger<CommonSize>;
+
+	/**
+	 * スキップ状態の変化時にfireされるTrigger。
+	 *
+	 * スキップ状態に遷移する時に真、非スキップ状態に遷移する時に偽が与えられる。
+	 * この通知は、ゲーム開発者が「スキップ中の演出省略」などの最適化を行うために提供されている。
+	 *
+	 * この通知のfire頻度は、ゲームの実行状態などに依存して異なりうることに注意。
+	 * 例えば多人数プレイされている時、それぞれの環境でfireされ方が異なりうる。
+	 * ゲーム開発者は、この通知に起因する処理で、ゲームのグローバルな実行状態を変化させてはならない。
+	 */
+	onSkipChange: Trigger<boolean>;
+
+	/**
+	 * 直近の `update` の通知が、ローカルティックによるものか否か。
+	 *
+	 * ただし一度も `update` 通知が起きていない間は真である。
+	 * ローカルシーンおよびローカルティック補間シーン以外のシーンにおいては、常に偽。
+	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
+	 */
+	isLastTickLocal: boolean;
+
+	/**
+	 * 直近の `update` の通知時(の直前)に(タイムスタンプ待ちを省略する動作などの影響でエンジンが)省いたローカルティックの数。
+	 *
+	 * 一度も `update` 通知が起きていない間は `0` である。
+	 * ローカルティック補間シーンでない場合、常に `0` であることに注意。
+	 *
+	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
+	 */
+	lastOmittedLocalTickCount: number;
+
+	/**
+	 * 直近の `Scene#local` の値。
+	 *
+	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
+	 */
+	lastLocalTickMode: LocalTickMode | null;
+
+	/**
+	 * 直近の `Scene#tickGenerationMode` の値。
+	 *
+	 * この値は参照のためにのみ公開されている。ゲーム開発者はこの値を変更すべきではない。
+	 */
+	lastTickGenerationMode: TickGenerationMode | null;
+
+	/**
+	 * ゲーム全体で共有するサーフェスアトラス。
+	 */
+	surfaceAtlasSet: SurfaceAtlasSetLike;
+
+	/**
+	 * 操作プラグインの管理者。
+	 */
+	operationPluginManager: OperationPluginManager;
+
+	/**
+	 * プレイヤーがゲームに参加したことを表すイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onJoin` を利用すること。
+	 */
+	join: Trigger<JoinEvent>;
+
+	/**
+	 * プレイヤーがゲームから離脱したことを表すイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onLeave` を利用すること。
+	 */
+	leave: Trigger<LeaveEvent>;
+
+	/**
+	 * 新しいプレイヤー情報が発生したことを示すイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onPlayerInfo` を利用すること。
+	 */
+	playerInfo: Trigger<PlayerInfoEvent>;
+
+	/**
+	 * 新しい乱数シードが発生したことを示すイベント。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onSeed` を利用すること。
+	 */
+	seed: Trigger<SeedEvent>;
+
+	/**
+	 * スナップショット要求通知。
+	 * ゲーム開発者はこれをhandleして可能ならスナップショットを作成しGame#saveSnapshotを呼び出すべきである。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onSnapshotRequest` を利用すること。
+	 */
+	snapshotRequest: Trigger<void>;
+
+	/**
+	 * 画面サイズの変更時にfireされるTrigger。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onResized` を利用すること。
+	 */
+	resized: Trigger<CommonSize>;
+
+	/**
+	 * スキップ状態の変化時にfireされるTrigger。
+	 *
+	 * スキップ状態に遷移する時に真、非スキップ状態に遷移する時に偽が与えられる。
+	 * この通知は、ゲーム開発者が「スキップ中の演出省略」などの最適化を行うために提供されている。
+	 *
+	 * この通知のfire頻度は、ゲームの実行状態などに依存して異なりうることに注意。
+	 * 例えば多人数プレイされている時、それぞれの環境でfireされ方が異なりうる。
+	 * ゲーム開発者は、この通知に起因する処理で、ゲームのグローバルな実行状態を変化させてはならない。
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `onSkipChange` を利用すること。
+	 */
+	skippingChanged: Trigger<boolean>;
+
+	/**
+	 * 使用中のカメラ。
+	 *
+	 * `Game#draw()`, `Game#findPointSource()` のデフォルト値として使用される。
+	 * この値を変更した場合、変更を描画に反映するためには `Game#modified()` を呼び出す必要がある。
+	 */
+	focusingCamera: Camera;
+
+	/**
+	 * シーンスタックへのシーンの追加と、そのシーンへの遷移を要求する。
+	 *
+	 * このメソッドは要求を行うだけである。呼び出し直後にはシーン遷移は行われていないことに注意。
+	 * 実際のシーン遷移は次のフレームまでに(次のupdateのfireまでに)行われる。
+	 * このメソッドの呼び出しにより、現在のシーンの `stateChanged` が引数 `SceneState.Deactive` でfireされる。
+	 * その後 `scene.stateChanged` が引数 `SceneState.Active` でfireされる。
+	 * @param scene 遷移後のシーン
+	 */
+	pushScene(scene: Scene): void;
+
+	/**
+	 * 現在のシーンの置き換えを要求する。
+	 *
+	 * 現在のシーンをシーンスタックから取り除き、指定のシーンを追加することを要求する。
+	 * このメソッドは要求を行うだけである。呼び出し直後にはシーン遷移は行われていないことに注意。
+	 * 実際のシーン遷移は次のフレームまでに(次のupdateのfireまでに)行われる。
+	 * 引数 `preserveCurrent` が偽の場合、このメソッドの呼び出しにより現在のシーンは破棄される。
+	 * またその時 `stateChanged` が引数 `SceneState.Destroyed` でfireされる。
+	 * その後 `scene.stateChanged` が引数 `SceneState.Active` でfireされる。
+	 *
+	 * @param scene 遷移後のシーン
+	 * @param preserveCurrent 真の場合、現在のシーンを破棄しない(ゲーム開発者が明示的に破棄せねばならない)。省略された場合、偽
+	 */
+	replaceScene(scene: Scene, preserveCurrent?: boolean): void;
+
+	/**
+	 * シーンスタックから現在のシーンを取り除くことを要求する
+	 *
+	 * このメソッドは要求を行うだけである。呼び出し直後にはシーン遷移は行われていないことに注意。
+	 * 実際のシーン遷移は次のフレームまでに(次のupdateのfireまでに)行われる。
+	 * 引数 `preserve` が偽の場合、このメソッドの呼び出しにより取り除かれたシーンは全て破棄される。
+	 * またその時 `stateChanged` が引数 `SceneState.Destroyed` でfireされる。
+	 * その後一つ前のシーンの `stateChanged` が引数 `SceneState.Active` でfireされる。
+	 * また、step数がスタックされているシーンの数以上の場合、例外が投げられる。
+	 *
+	 * @param preserve 真の場合、シーンを破棄しない(ゲーム開発者が明示的に破棄せねばならない)。省略された場合、偽
+	 * @param step 取り除くシーンの数。省略された場合、1
+	 */
+	popScene(preserve?: boolean, step?: number): void;
+
+	/**
+	 * 現在のシーンを返す。
+	 * ない場合、 `undefined` を返す。
+	 */
+	scene(): Scene | undefined;
+
+	/**
+	 * その座標に反応する `PointSource` を返す。
+	 *
+	 * 戻り値は、対象が見つかった場合、 `target` に見つかった `E` を持つ `PointSource` である。
+	 * 対象が見つからなかった場合、 `undefined` である。
+	 *
+	 * 戻り値が `undefined` でない場合、その `target` プロパティは次を満たす:
+	 * - `E#touchable` が真である
+	 * - カメラ `camera` から可視である中で最も手前にある
+	 *
+	 * @param point 対象の座標
+	 * @param camera 対象のカメラ。指定しなければ `Game.focusingCamera` が使われる
+	 */
+	findPointSource(point: CommonOffset, camera?: Camera): PointSource;
+
+	/**
+	 * イベントを発生させる。
+	 *
+	 * ゲーム開発者は、このメソッドを呼び出すことで、エンジンに指定のイベントを発生させることができる。
+	 *
+	 * @param e 発生させるイベント
+	 */
+	raiseEvent(e: Event): void;
+
+	/**
+	 * ティックを発生させる。
+	 *
+	 * ゲーム開発者は、このメソッドを呼び出すことで、エンジンに時間経過を要求することができる。
+	 * 現在のシーンのティック生成モード `Scene#tickGenerationMode` が `TickGenerationMode.Manual` でない場合、エラー。
+	 *
+	 * @param events そのティックで追加で発生させるイベント
+	 */
+	raiseTick(events?: Event[]): void;
+
+	/**
+	 * イベントフィルタを追加する。
+	 *
+	 * 一つ以上のイベントフィルタが存在する場合、このゲームで発生したイベントは、通常の処理の代わりにイベントフィルタに渡される。
+	 * エンジンは、イベントフィルタが戻り値として返したイベントを、まるでそのイベントが発生したかのように処理する。
+	 *
+	 * イベントフィルタはローカルイベントに対しても適用される。
+	 * イベントフィルタはローカルティック補間シーンやローカルシーンの間であっても適用される。
+	 * 複数のイベントフィルタが存在する場合、そのすべてが適用される。適用順は登録の順である。
+	 *
+	 * @param filter 追加するイベントフィルタ
+	 * @param handleEmpty イベントが存在しない場合でも定期的にフィルタを呼び出すか否か。省略された場合、偽。
+	 */
+	addEventFilter(filter: EventFilter, handleEmpty?: boolean): void;
+
+	/**
+	 * イベントフィルタを削除する。
+	 *
+	 * @param filter 削除するイベントフィルタ
+	 */
+	removeEventFilter(filter: EventFilter): void;
+
+	/**
+	 * このインスタンスにおいてスナップショットの保存を行うべきかを返す。
+	 *
+	 * スナップショット保存に対応するゲームであっても、
+	 * 必ずしもすべてのインスタンスにおいてスナップショット保存を行うべきとは限らない。
+	 * たとえば多人数プレイ時には、複数のクライアントで同一のゲームが実行される。
+	 * スナップショットを保存するのはそのうちの一つのインスタンスのみでよい。
+	 * 本メソッドはそのような場合に、自身がスナップショットを保存すべきかどうかを判定するために用いることができる。
+	 *
+	 * スナップショット保存に対応するゲームは、このメソッドが真を返す時にのみ `Game#saveSnapshot()` を呼び出すべきである。
+	 * 戻り値は、スナップショットの保存を行うべきであれば真、でなければ偽である。
+	 */
+	shouldSaveSnapshot(): boolean;
+
+	/**
+	 * スナップショットを保存する。
+	 *
+	 * 引数 `snapshot` の値は、スナップショット読み込み関数 (snapshot loader) に引数として渡されるものになる。
+	 * このメソッドを呼び出すゲームは必ずsnapshot loaderを実装しなければならない。
+	 * (snapshot loaderとは、idが "snapshotLoader" であるglobalなScriptAssetに定義された関数である。
+	 * 詳細はスナップショットについてのドキュメントを参照)
+	 *
+	 * このメソッドは `Game#shouldSaveSnapshot()` が真を返す `Game` に対してのみ呼び出されるべきである。
+	 * そうでない場合、このメソッドの動作は不定である。
+	 *
+	 * このメソッドを呼び出す推奨タイミングは、Trigger `Game#snapshotRequest` をhandleすることで得られる。
+	 * ゲームは、 `snapshotRequest` がfireされたとき (それが可能なタイミングであれば) スナップショットを
+	 * 生成してこのメソッドに渡すべきである。ゲーム開発者は推奨タイミング以外でもこのメソッドを呼び出すことができる。
+	 * ただしその頻度は推奨タイミングの発火頻度と同程度に抑えられるべきである。
+	 *
+	 * @param snapshot 保存するスナップショット。JSONとして妥当な値でなければならない。
+	 * @param timestamp 保存時の時刻。 `g.TimestampEvent` を利用するゲームの場合、それらと同じ基準の時間情報を与えなければならない。
+	 */
+	saveSnapshot(snapshot: any, timestamp?: number): void;
+
+	/**
+	 * 現在時刻を取得する。
+	 *
+	 * 値は1970-01-01T00:00:00Zからのミリ秒での経過時刻である。
+	 * `Date.now()` と異なり、この値は消化されたティックの数から算出される擬似的な時刻である。
+	 */
+	getCurrentTime(): number;
+
+	/**
+	 * このインスタンスがアクティブインスタンスであるかどうか返す。
+	 *
+	 * ゲーム開発者は、この値の真偽に起因する処理で、ゲームのローカルな実行状態を変更してはならず、
+	 * `raiseEvent()` などによって、グローバルな状態を更新する必要がある。
+	 */
+	isActiveInstance(): boolean;
+}

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -10,9 +10,10 @@ import { Matrix } from "./domain/Matrix";
 import { StorageLoader, StorageLoaderHandler, StorageReadKey, StorageValueStore, StorageValueStoreSerialization } from "./domain/Storage";
 import { Timer } from "./domain/Timer";
 import { TimerIdentifier, TimerManager } from "./domain/TimerManager";
-import { Game } from "./Game";
 import { AssetLike } from "./interfaces/AssetLike";
 import { AssetLoadFailureInfo } from "./interfaces/AssetLoadFailureInfo";
+import { InternalGame } from "./InternalGame";
+import { RuntimeGame } from "./RuntimeGame";
 import { CommonOffset } from "./types/commons";
 import { DynamicAssetConfiguration } from "./types/DynamicAssetConfiguration";
 import { AssetLoadError, StorageLoadError } from "./types/errors";
@@ -211,7 +212,7 @@ export interface SceneParameterObject {
 	/**
 	 * このシーンの属するゲーム。
 	 */
-	game: Game;
+	game: RuntimeGame;
 
 	/**
 	 * このシーンで用いるアセットIDの配列。
@@ -348,7 +349,7 @@ export class Scene implements StorageLoaderHandler {
 	/**
 	 * このシーンの属するゲーム。
 	 */
-	game: Game;
+	game: InternalGame;
 
 	/**
 	 * このシーンのローカルティック消化ポリシー。
@@ -655,7 +656,7 @@ export class Scene implements StorageLoaderHandler {
 		}
 
 		this.name = param.name;
-		this.game = game;
+		this.game = game as InternalGame;
 		this.local = local;
 		this.tickGenerationMode = tickGenerationMode;
 
@@ -664,7 +665,7 @@ export class Scene implements StorageLoaderHandler {
 		this._onReady = new Trigger<Scene>();
 		this._ready = this._onReady;
 		this.assets = {};
-		this.asset = new AssetAccessor(game._assetManager);
+		this.asset = new AssetAccessor(this.game._assetManager);
 
 		this._loaded = false;
 		this._prefetchRequested = false;

--- a/src/__tests__/SceneSpec.ts
+++ b/src/__tests__/SceneSpec.ts
@@ -878,7 +878,7 @@ describe("test Scene", () => {
 	it("modified", () => {
 		const scene = new Scene({ game: game });
 		scene.modified();
-		expect(scene.game._modified).toEqual(true);
+		expect((scene.game as Game)._modified).toEqual(true);
 	});
 
 	it("state", done => {

--- a/src/domain/DefaultLoadingScene.ts
+++ b/src/domain/DefaultLoadingScene.ts
@@ -1,6 +1,7 @@
-import { Game } from "../Game";
 import { AssetLike } from "../interfaces/AssetLike";
 import { RendererLike } from "../interfaces/RendererLike";
+import { InternalGame } from "../InternalGame";
+import { RuntimeGame } from "../RuntimeGame";
 import { Scene } from "../Scene";
 import { Camera } from "./Camera";
 import { Camera2D } from "./Camera2D";
@@ -17,7 +18,7 @@ export interface DefaultLoadingSceneParameterObject {
 	/**
 	 * このシーンが属する `Game` 。
 	 */
-	game: Game;
+	game: RuntimeGame;
 	style?: "default" | "compact";
 }
 
@@ -92,7 +93,7 @@ export class DefaultLoadingScene extends LoadingScene {
 	 * @param param 初期化に用いるパラメータのオブジェクト
 	 */
 	constructor(param: DefaultLoadingSceneParameterObject) {
-		super({ game: param.game, name: "akashic:default-loading-scene" });
+		super({ game: param.game as InternalGame, name: "akashic:default-loading-scene" });
 		if (param.style === "compact") {
 			this._barWidth = this.game.width / 4;
 			this._barHeight = 5;

--- a/src/domain/DynamicFont.ts
+++ b/src/domain/DynamicFont.ts
@@ -1,9 +1,9 @@
 import { SurfaceAtlasSet } from "../commons/SurfaceAtlasSet";
-import { Game } from "../Game";
 import { GlyphFactoryLike } from "../interfaces/GlyphFactoryLike";
 import { GlyphArea, GlyphLike } from "../interfaces/GlyphLike";
 import { ResourceFactoryLike } from "../interfaces/ResourceFactoryLike";
 import { SurfaceAtlasSetHint, SurfaceAtlasSetLike } from "../interfaces/SurfaceAtlasSetLike";
+import { RuntimeGame } from "../RuntimeGame";
 import { FontFamily } from "../types/FontFamily";
 import { FontWeight } from "../types/FontWeight";
 import { BitmapFont } from "./BitmapFont";
@@ -21,7 +21,7 @@ export interface DynamicFontParameterObject {
 	/**
 	 * ゲームインスタンス。
 	 */
-	game: Game;
+	game: RuntimeGame;
 
 	/**
 	 * フォントファミリ。

--- a/src/domain/NinePatchSurfaceEffector.ts
+++ b/src/domain/NinePatchSurfaceEffector.ts
@@ -1,5 +1,6 @@
-import { Game } from "../Game";
 import { SurfaceLike } from "../interfaces/SurfaceLike";
+import { InternalGame } from "../InternalGame";
+import { RuntimeGame } from "../RuntimeGame";
 import { CommonRect } from "../types/commons";
 import { SurfaceEffector } from "./SurfaceEffector";
 import { SurfaceUtil } from "./SurfaceUtil";
@@ -15,7 +16,7 @@ import { SurfaceUtil } from "./SurfaceUtil";
  * @deprecated 非推奨である。将来的に削除される予定である。
  */
 export class NinePatchSurfaceEffector implements SurfaceEffector {
-	game: Game;
+	game: InternalGame;
 	borderWidth: CommonRect;
 
 	/**
@@ -34,8 +35,8 @@ export class NinePatchSurfaceEffector implements SurfaceEffector {
 	 * @param game このインスタンスが属する `Game`
 	 * @param borderWidth 上下左右の「拡大しない」領域の大きさ。すべて同じ値なら数値一つを渡すことができる。省略された場合、 `4`
 	 */
-	constructor(game: Game, borderWidth: CommonRect | number = 4) {
-		this.game = game;
+	constructor(game: RuntimeGame, borderWidth: CommonRect | number = 4) {
+		this.game = game as InternalGame;
 		if (typeof borderWidth === "number") {
 			this.borderWidth = {
 				top: borderWidth,

--- a/src/domain/OperationPluginManager.ts
+++ b/src/domain/OperationPluginManager.ts
@@ -1,5 +1,6 @@
 import { Trigger } from "@akashic/trigger";
-import { Game } from "../Game";
+import { InternalGame } from "../InternalGame";
+import { RuntimeGame } from "../RuntimeGame";
 import { OperationPlugin } from "../types/OperationPlugin";
 import { InternalOperationPluginInfo } from "../types/OperationPluginInfo";
 import { InternalOperationPluginOperation, OperationPluginOperation } from "../types/OperationPluginOperation";
@@ -57,16 +58,16 @@ export class OperationPluginManager {
 	 */
 	plugins: { [key: number]: OperationPlugin };
 
-	private _game: Game;
+	private _game: InternalGame;
 	private _viewInfo: OperationPluginViewInfo;
 	private _infos: InternalOperationPluginInfo[];
 	private _initialized: boolean;
 
-	constructor(game: Game, viewInfo: OperationPluginViewInfo, infos: InternalOperationPluginInfo[]) {
+	constructor(game: RuntimeGame, viewInfo: OperationPluginViewInfo, infos: InternalOperationPluginInfo[]) {
 		this.onOperate = new Trigger<InternalOperationPluginOperation>();
 		this.operated = this.onOperate;
 		this.plugins = {};
-		this._game = game;
+		this._game = game as InternalGame;
 		this._viewInfo = viewInfo;
 		this._infos = infos;
 		this._initialized = false;

--- a/src/domain/entities/E.ts
+++ b/src/domain/entities/E.ts
@@ -9,9 +9,9 @@ import {
 	PointUpEventBase
 } from "../../domain/Event";
 import { Matrix, PlainMatrix } from "../../domain/Matrix";
-import { Game } from "../../Game";
 import { RendererLike } from "../../interfaces/RendererLike";
 import { ShaderProgramLike } from "../../interfaces/ShaderProgramLike";
+import { RuntimeGame } from "../../RuntimeGame";
 import { Scene } from "../../Scene";
 import { CommonArea, CommonOffset, CommonRect } from "../../types/commons";
 import { EntityStateFlags } from "../../types/EntityStateFlags";
@@ -437,7 +437,7 @@ export class E extends Object2D implements CommonArea {
 	/**
 	 * このエンティティが属する `Game` を返す。
 	 */
-	game(): Game {
+	game(): RuntimeGame {
 		return this.scene.game;
 	}
 

--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -1,7 +1,6 @@
 export * from "@akashic/trigger";
 
 export * from "./Scene";
-export * from "./Game";
 
 export * from "./commons/ExceptionFactory";
 export * from "./commons/Glyph";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
 export * from "./index.common";
+export * from "./RuntimeGame";
+
+// NOTE: 以下の型定義はコンテンツから参照する必要がない
 export * from "./Game";
-export * from "./GameHandlerSet"; // NOTE: コンテンツから参照する必要はない
+export * from "./GameHandlerSet";
+export * from "./InternalGame";


### PR DESCRIPTION
## このpull requestが解決する内容
`g.Game` の型定義を `InternalGame` と `RuntimeGame` に分割します。

* InternalGame
  * akashic-engine 内部から参照可能な g.Game の型定義
  * ゲームコンテンツから `g.game` を受け取る場合は明示的なダウンキャストが必要
* RuntimeGame
  * ゲームコンテンツから参照可能な g.Game の型定義

## リポジトリ関係図

![POv1heCm34JtEON5FZa2GlfV-lhRzWHMS6b4Ogh4wOPozqAAr8RkF3CQp-kIO9GSlBgX7N4WQ734T7LM4m-EgO5P0JWMYXUq1AVCuWBzOQ3A_zykHhy7rcDAK8cp9IQbeBXW7ksXKqdGQrvlbJxeGsrHR_9XDNGVtPtYYbrH_1ONvaN1fpQcXQytTc8XbjUBdvna2lls1bNEG](https://user-images.githubusercontent.com/16933898/77605305-e8fdb380-6f57-11ea-8176-6a2bee9bc3ad.png)


## 破壊的な変更を含んでいるか?
- 部分的に **あり**
  - ゲームコンテンツ内で `g.Game` の private property にアクセスしている場合、その箇所を any などで型解決する必要があります。

