### PR TITLE
refactor: remove cyclic dependencies around SceneAssetHolder

### DIFF
--- a/src/AssetHolder.ts
+++ b/src/AssetHolder.ts
@@ -1,7 +1,5 @@
-import { Trigger } from "@akashic/trigger";
 import { ExceptionFactory } from "./commons/ExceptionFactory";
 import { AssetManager } from "./domain/AssetManager";
-import { Game } from "./Game";
 import { AssetLike } from "./interfaces/AssetLike";
 import { AssetLoadFailureInfo } from "./interfaces/AssetLoadFailureInfo";
 import { DynamicAssetConfiguration } from "./types/DynamicAssetConfiguration";

--- a/src/AssetHolder.ts
+++ b/src/AssetHolder.ts
@@ -1,0 +1,198 @@
+import { Trigger } from "@akashic/trigger";
+import { ExceptionFactory } from "./commons/ExceptionFactory";
+import { AssetManager } from "./domain/AssetManager";
+import { Game } from "./Game";
+import { AssetLike } from "./interfaces/AssetLike";
+import { AssetLoadFailureInfo } from "./interfaces/AssetLoadFailureInfo";
+import { DynamicAssetConfiguration } from "./types/DynamicAssetConfiguration";
+import { AssetLoadError } from "./types/errors";
+
+export interface DestroyedCheckable {
+	destroyed(): boolean;
+}
+
+export interface AssetHolderHandlerSet<UserData> {
+	/**
+	 * 各ハンドラの呼び出し時に this として利用される値。
+	 */
+	owner: DestroyedCheckable;
+
+	/**
+	 * アセットが一つ読み込まれるたびに呼び出されるハンドラ。
+	 * @param asset 読み込まれたアセット
+	 */
+	handleLoad: (asset: AssetLike) => void;
+
+	/**
+	 * アセットが一つ読み込み失敗するごとに呼び出されるハンドラ。
+	 * @param failureInfo 読み込み失敗情報
+	 */
+	handleLoadFailure: (failureInfo: AssetLoadFailureInfo) => void;
+
+	/**
+	 * 全アセットの読み込みを終えた時に呼び出されるハンドラ。
+	 * @param holder 読み込みを終えた AssetHolder
+	 * @param succeed 読み込みに成功した場合 true, リトライ不能のエラーで断念した時 false
+	 */
+	handleFinish: (holder: AssetHolder<UserData>, succeed: boolean) => void;
+}
+
+/**
+ * AssetHolder のコンストラクタに指定できるパラメータ。
+ * 通常、ゲーム開発者が利用する必要はない。
+ */
+export interface AssetHolderParameterObject<UserData> {
+	/**
+	 * アセットの読み込みに利用するアセットマネージャ。
+	 */
+	assetManager: AssetManager;
+
+	/**
+	 * 読み込むアセット。
+	 */
+	assetIds?: (string | DynamicAssetConfiguration)[];
+
+	/**
+	 * 読み込むアセット。
+	 */
+	assetPaths?: string[];
+
+	/**
+	 * このインスタンスの状態を通知するハンドラ群。
+	 */
+	handlerSet: AssetHolderHandlerSet<UserData>;
+
+	// /**
+	//  * `handler` を直接呼ぶか。
+	//  * 真である場合、 `handler` は読み込み完了後に直接呼び出される。
+	//  * でなければ次の `Game#tick()` 呼び出し時点まで遅延される。
+	//  * 省略された場合、偽。
+	//  */
+	// direct?: boolean;
+
+	/**
+	 * このインスタンスに紐づけるユーザ定義データ。
+	 */
+	userData: UserData | null;
+}
+
+/**
+ * シーンのアセットの読み込みと破棄を管理するクラス。
+ * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
+ */
+export class AssetHolder<UserData> {
+	/**
+	 * 読み込みを待つ残りのアセット数。
+	 * この値は参照のためにのみ公開される。この値を外部から書き換えてはならない。
+	 */
+	waitingAssetsCount: number;
+
+	/**
+	 * インスタンス生成時に与えられたユーザ定義データ。
+	 * この値は参照のためにのみ公開される。この値を外部から書き換えてはならない。
+	 */
+	userData: UserData | null;
+
+	/**
+	 * @private
+	 */
+	_handlerSet: AssetHolderHandlerSet<UserData>;
+
+	/**
+	 * @private
+	 */
+	_assetManager: AssetManager;
+
+	/**
+	 * @private
+	 */
+	_assetIds: (string | DynamicAssetConfiguration)[];
+
+	/**
+	 * @private
+	 */
+	_assets: AssetLike[];
+
+	/**
+	 * @private
+	 */
+	_requested: boolean;
+
+	constructor(param: AssetHolderParameterObject<UserData>) {
+		const assetManager = param.assetManager;
+		const assetIds = param.assetIds ? param.assetIds.concat() : [];
+		assetIds.push.apply(assetIds, assetManager.resolvePatternsToAssetIds(param.assetPaths || []));
+
+		this.waitingAssetsCount = assetIds.length;
+		this.userData = param.userData;
+		this._assetManager = assetManager;
+		this._assetIds = assetIds;
+		this._assets = [];
+		this._handlerSet = param.handlerSet;
+		this._requested = false;
+	}
+
+	request(): boolean {
+		if (this.waitingAssetsCount === 0) return false;
+		if (this._requested) return true;
+		this._requested = true;
+		this._assetManager.requestAssets(this._assetIds, this);
+		return true;
+	}
+
+	destroy(): void {
+		if (this._requested) {
+			this._assetManager.unrefAssets(this._assets);
+		}
+		this.waitingAssetsCount = 0;
+		this.userData = undefined;
+		this._handlerSet = undefined;
+		this._assetIds = undefined;
+		this._requested = false;
+	}
+
+	destroyed(): boolean {
+		return !this._handlerSet;
+	}
+
+	/**
+	 * @private
+	 */
+	_onAssetError(asset: AssetLike, error: AssetLoadError): void {
+		const hs = this._handlerSet;
+		if (this.destroyed() || hs.owner.destroyed()) return;
+		var failureInfo = {
+			asset: asset,
+			error: error,
+			cancelRetry: false
+		};
+
+		hs.handleLoadFailure.call(hs.owner, failureInfo);
+
+		if (error.retriable && !failureInfo.cancelRetry) {
+			this._assetManager.retryLoad(asset);
+		} else {
+			// game.json に定義されていればゲームを止める。それ以外 (DynamicAsset) では続行。
+			if (this._assetManager.configuration[asset.id]) {
+				hs.handleFinish.call(hs.owner, this, false);
+			}
+		}
+	}
+
+	/**
+	 * @private
+	 */
+	_onAssetLoad(asset: AssetLike): void {
+		const hs = this._handlerSet;
+		if (this.destroyed() || hs.owner.destroyed()) return;
+
+		hs.handleLoad.call(hs.owner, asset);
+		this._assets.push(asset);
+
+		--this.waitingAssetsCount;
+		if (this.waitingAssetsCount < 0) throw ExceptionFactory.createAssertionError("AssetHolder#_onAssetLoad: broken waitingAssetsCount");
+		if (this.waitingAssetsCount > 0) return;
+
+		hs.handleFinish.call(hs.owner, this, true);
+	}
+}

--- a/src/AssetHolder.ts
+++ b/src/AssetHolder.ts
@@ -62,14 +62,6 @@ export interface AssetHolderParameterObject<UserData> {
 	 */
 	handlerSet: AssetHolderHandlerSet<UserData>;
 
-	// /**
-	//  * `handler` を直接呼ぶか。
-	//  * 真である場合、 `handler` は読み込み完了後に直接呼び出される。
-	//  * でなければ次の `Game#tick()` 呼び出し時点まで遅延される。
-	//  * 省略された場合、偽。
-	//  */
-	// direct?: boolean;
-
 	/**
 	 * このインスタンスに紐づけるユーザ定義データ。
 	 */
@@ -190,8 +182,8 @@ export class AssetHolder<UserData> {
 		this._assets.push(asset);
 
 		--this.waitingAssetsCount;
-		if (this.waitingAssetsCount < 0) throw ExceptionFactory.createAssertionError("AssetHolder#_onAssetLoad: broken waitingAssetsCount");
 		if (this.waitingAssetsCount > 0) return;
+		if (this.waitingAssetsCount < 0) throw ExceptionFactory.createAssertionError("AssetHolder#_onAssetLoad: broken waitingAssetsCount");
 
 		hs.handleFinish.call(hs.owner, this, true);
 	}

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -1,7 +1,7 @@
 import { Trigger } from "@akashic/trigger";
+import { AssetHolder } from "./AssetHolder";
 import { ExceptionFactory } from "./commons/ExceptionFactory";
 import { AssetAccessor } from "./domain/AssetAccessor";
-import { AssetManager } from "./domain/AssetManager";
 import { Camera } from "./domain/Camera";
 import { Camera2D } from "./domain/Camera2D";
 import { E, PointDownEvent, PointMoveEvent, PointSource, PointUpEvent } from "./domain/entities/E";
@@ -16,10 +16,9 @@ import { AssetLike } from "./interfaces/AssetLike";
 import { AssetLoadFailureInfo } from "./interfaces/AssetLoadFailureInfo";
 import { CommonOffset } from "./types/commons";
 import { DynamicAssetConfiguration } from "./types/DynamicAssetConfiguration";
-import { AssetLoadError, StorageLoadError } from "./types/errors";
+import { StorageLoadError } from "./types/errors";
 import { LocalTickModeString } from "./types/LocalTickModeString";
 import { TickGenerationModeString } from "./types/TickGenerationModeString";
-import { AssetHolder } from "./AssetHolder";
 
 export type SceneRequestAssetHandler = () => void;
 

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -829,7 +829,10 @@ export class Scene implements StorageLoaderHandler {
 				handleLoadFailure: this._handleSceneAssetLoadFailure,
 				handleFinish: this._handleSceneAssetLoadFinish
 			},
-			userData: handler
+			userData: () => {
+				// 不要なクロージャは避けたいが生存チェックのため不可避
+				if (!this.destroyed()) handler();
+			}
 		});
 		this._assetHolders.push(holder);
 		holder.request();

--- a/src/__tests__/ESpec.ts
+++ b/src/__tests__/ESpec.ts
@@ -405,14 +405,14 @@ describe("test E", () => {
 
 		const scene2 = new Scene({ game: runtime.game });
 		runtime.game.pushScene(scene2);
-		runtime.game._flushSceneChangeRequests();
+		runtime.game._flushPostTickTasks();
 		estate = false;
 		runtime.game.tick(true);
 		runtime.game.tick(true);
 		runtime.game.tick(true);
 
 		runtime.game.popScene();
-		runtime.game._flushSceneChangeRequests();
+		runtime.game._flushPostTickTasks();
 		estate = true;
 		esuccess = false;
 		runtime.game.tick(true);
@@ -420,7 +420,7 @@ describe("test E", () => {
 
 		const scene3 = new Scene({ game: runtime.game });
 		runtime.game.replaceScene(scene3);
-		runtime.game._flushSceneChangeRequests();
+		runtime.game._flushPostTickTasks();
 		estate = false;
 
 		expect(scene3.onUpdate.length > 0).toBe(false);
@@ -462,21 +462,21 @@ describe("test E", () => {
 
 		const scene2 = new Scene({ game: runtime.game });
 		runtime.game.pushScene(scene2);
-		runtime.game._flushSceneChangeRequests();
+		runtime.game._flushPostTickTasks();
 		estate = false;
 		operationTick();
 		operationTick();
 		operationTick();
 
 		runtime.game.popScene();
-		runtime.game._flushSceneChangeRequests();
+		runtime.game._flushPostTickTasks();
 		estate = true;
 		esuccess = false;
 		operationTick();
 		expect(esuccess).toBe(true);
 
 		runtime.game.replaceScene(new Scene({ game: runtime.game }));
-		runtime.game._flushSceneChangeRequests();
+		runtime.game._flushPostTickTasks();
 		estate = false;
 
 		expect(runtime.scene.onPointDownCapture.destroyed()).toBe(true);
@@ -721,7 +721,7 @@ describe("test E", () => {
 		const game = new Game({ width: 320, height: 320, main: "" });
 		const scene = new Scene({ game: game, local: true });
 		game.pushScene(scene);
-		game._flushSceneChangeRequests();
+		game._flushPostTickTasks();
 
 		const e = new E({
 			scene: scene,

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -194,7 +194,7 @@ describe("test Game", () => {
 				game._loadAndStart();
 			});
 			game.pushScene(scene);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			expect(() => {
 				game._startLoadingGlobalAssets();
 			}).toThrowError("AssertionError");
@@ -209,11 +209,11 @@ describe("test Game", () => {
 			// game.scenes テストのため _loaded を待つ必要がある
 			const scene = new Scene({ game: game });
 			game.pushScene(scene);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			expect(game.scenes).toEqual([game._initialScene, scene]);
 			const scene2 = new Scene({ game: game });
 			game.pushScene(scene2);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			expect(game.scenes).toEqual([game._initialScene, scene, scene2]);
 			done();
 		});
@@ -230,10 +230,10 @@ describe("test Game", () => {
 			game.pushScene(scene);
 			game.pushScene(scene2);
 			game.popScene();
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			expect(game.scenes).toEqual([game._initialScene, scene]);
 			game.popScene();
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			expect(game.scenes).toEqual([game._initialScene]);
 			done();
 		});
@@ -253,7 +253,7 @@ describe("test Game", () => {
 			game.pushScene(scene2);
 			game.pushScene(scene3);
 			game.popScene(false, 2);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			expect(game.scenes).toEqual([game._initialScene, scene]);
 			expect(scene.destroyed()).toBe(false);
 			expect(scene2.destroyed()).toBe(true);
@@ -265,7 +265,7 @@ describe("test Game", () => {
 			game.pushScene(scene2Alpha);
 			game.pushScene(scene3Beta);
 			game.popScene(true, 3);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			expect(game.scenes).toEqual([game._initialScene]);
 			expect(scene.destroyed()).toBe(false);
 			expect(scene2Alpha.destroyed()).toBe(false);
@@ -284,7 +284,7 @@ describe("test Game", () => {
 			const scene2 = new Scene({ game: game });
 			game.pushScene(scene);
 			game.replaceScene(scene2);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			expect(game.scenes).toEqual([game._initialScene, scene2]);
 			done();
 		});
@@ -407,10 +407,10 @@ describe("test Game", () => {
 					}, 1);
 				});
 				game.pushScene(scene2);
-				game._flushSceneChangeRequests();
+				game._flushPostTickTasks();
 			});
 			game.pushScene(scene);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 		});
 		game._startLoadingGlobalAssets();
 	});
@@ -507,10 +507,10 @@ describe("test Game", () => {
 					}, 1);
 				});
 				game.pushScene(scene2);
-				game._flushSceneChangeRequests();
+				game._flushPostTickTasks();
 			});
 			game.pushScene(scene);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 		});
 		game._startLoadingGlobalAssets();
 	});
@@ -575,7 +575,7 @@ describe("test Game", () => {
 				done();
 			});
 			game.pushScene(scene);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 		});
 		game._startLoadingGlobalAssets();
 	});
@@ -640,14 +640,14 @@ describe("test Game", () => {
 						expect(game._eventTriggerMap["point-down"]).toBe(scene3.onPointDownCapture);
 
 						game.popScene();
-						game._flushSceneChangeRequests();
+						game._flushPostTickTasks();
 						expect(sceneChangedCount).toBe(7);
 						expect(topIsLocal).toBe("non-local");
 						expect(game.scenes).toEqual([game._initialScene, scene2]);
 						expect(game._eventTriggerMap["point-down"]).toBe(scene2.onPointDownCapture);
 
 						game.popScene();
-						game._flushSceneChangeRequests();
+						game._flushPostTickTasks();
 						expect(sceneChangedCount).toBe(8);
 						expect(topIsLocal).toBe("full-local");
 						expect(game.scenes).toEqual([game._initialScene]);
@@ -655,14 +655,14 @@ describe("test Game", () => {
 						done();
 					});
 					game.pushScene(scene3);
-					game._flushSceneChangeRequests();
+					game._flushPostTickTasks();
 					expect(sceneChangedCount).toBe(5);
 					expect(topIsLocal).toBe("full-local");
 					expect(game.scenes).toEqual([game._initialScene, scene2, scene3, game._defaultLoadingScene]);
 					expect(game._eventTriggerMap["point-down"]).toBe(game._defaultLoadingScene.onPointDownCapture);
 				});
 				game.replaceScene(scene2);
-				game._flushSceneChangeRequests();
+				game._flushPostTickTasks();
 				expect(sceneChangedCount).toBe(3); // scene2とloadingSceneが乗るが、scene2はまだ_sceneStackTopChangeCountをfireしてない
 				expect(topIsLocal).toBe("full-local"); // loadingScene がトップなので local
 				expect(game.scenes).toEqual([game._initialScene, scene2, game._defaultLoadingScene]);
@@ -673,7 +673,7 @@ describe("test Game", () => {
 			expect(game.scenes).toEqual([game._initialScene]);
 			expect(game._eventTriggerMap["point-down"]).toBe(game._initialScene.onPointDownCapture);
 			game.pushScene(scene);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 		});
 		game._startLoadingGlobalAssets();
 	});
@@ -683,10 +683,10 @@ describe("test Game", () => {
 		const scene = new Scene({ game: game });
 		const scene2 = new Scene({ game: game });
 		game.pushScene(scene);
-		game._flushSceneChangeRequests();
+		game._flushPostTickTasks();
 		expect(game.scene()).toBe(scene);
 		game.replaceScene(scene2);
-		game._flushSceneChangeRequests();
+		game._flushPostTickTasks();
 		expect(game.scene()).toBe(scene2);
 	});
 
@@ -731,7 +731,7 @@ describe("test Game", () => {
 			++count;
 		});
 		game.pushScene(scene);
-		game._flushSceneChangeRequests();
+		game._flushPostTickTasks();
 
 		game.classicTick();
 		expect(count).toBe(1);
@@ -771,7 +771,7 @@ describe("test Game", () => {
 				});
 			});
 			game.pushScene(scene);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			game.classicTick();
 		});
 		game._startLoadingGlobalAssets();
@@ -835,7 +835,7 @@ describe("test Game", () => {
 			game.pushScene(scene);
 			game.pushScene(scene2);
 			game.pushScene(scene3);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 
 			expect(game.handlerSet.modeHistry.length).toBe(3);
 			expect(game.handlerSet.modeHistry[0]).toEqual({
@@ -966,7 +966,7 @@ describe("test Game", () => {
 		game.renderers.push(r);
 		const scene = new Scene({ game: game });
 		game.pushScene(scene);
-		game._flushSceneChangeRequests();
+		game._flushPostTickTasks();
 		const e = new E({ scene: scene });
 		scene.append(e);
 		expect(e.state).toBe(0);

--- a/src/__tests__/ModuleSpec.ts
+++ b/src/__tests__/ModuleSpec.ts
@@ -389,14 +389,14 @@ describe("test Module", () => {
 				expect(mod.me).toBe("script-bar");
 
 				game.popScene();
-				game._flushSceneChangeRequests();
+				game._flushPostTickTasks();
 				expect(() => {
 					module.require("aNonGlobalAssetBar");
 				}).toThrowError("AssertionError");
 				done();
 			});
 			game.pushScene(scene);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 		});
 		game._startLoadingGlobalAssets();
 	});
@@ -461,14 +461,14 @@ describe("test Module", () => {
 				expect(mod.me).toBe("script-bar");
 
 				game.popScene();
-				game._flushSceneChangeRequests();
+				game._flushPostTickTasks();
 				expect(() => {
 					module.require("aNonGlobalAssetBar");
 				}).toThrowError("AssertionError");
 				done();
 			});
 			game.pushScene(scene);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 		});
 		game._startLoadingGlobalAssets();
 	});
@@ -533,14 +533,14 @@ describe("test Module", () => {
 				expect(mod.me).toBe("script-bar");
 
 				game.popScene();
-				game._flushSceneChangeRequests();
+				game._flushPostTickTasks();
 				expect(() => {
 					module.require("aNonGlobalAssetBar");
 				}).toThrowError("AssertionError");
 				done();
 			});
 			game.pushScene(scene);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 		});
 		game._startLoadingGlobalAssets();
 	});

--- a/src/__tests__/SceneSpec.ts
+++ b/src/__tests__/SceneSpec.ts
@@ -713,7 +713,7 @@ describe("test Scene", () => {
 						expect(zoo.destroyed()).toBe(false);
 
 						game.popScene();
-						game._flushSceneChangeRequests();
+						game._flushPostTickTasks();
 						expect(foo.destroyed()).toBe(true);
 						expect(dynamicImage.destroyed()).toBe(true);
 						expect(baa.destroyed()).toBe(true);
@@ -723,16 +723,16 @@ describe("test Scene", () => {
 				);
 
 				// Scene#requestAssets() のハンドラ呼び出しは Game#tick() に同期しており、実ロードの完了後に tick() が来るまで遅延される。
-				// テスト上は tick() を呼び出さないので、 _flushSceneChangeRequests() を呼び続けることで模擬する。
+				// テスト上は tick() を呼び出さないので、 _flushPostTickTasks() を呼び続けることで模擬する。
 				function flushUntilLoaded(): void {
 					if (loaded) return;
-					game._flushSceneChangeRequests();
+					game._flushPostTickTasks();
 					setTimeout(flushUntilLoaded, 10);
 				}
 				flushUntilLoaded();
 			});
 			game.pushScene(scene);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 		});
 		game._startLoadingGlobalAssets();
 	});
@@ -989,7 +989,7 @@ describe("test Scene", () => {
 		const nextStep = () => {
 			setTimeout(() => {
 				steps[++stepIndex]();
-				game._flushSceneChangeRequests();
+				game._flushPostTickTasks();
 			}, 0);
 		};
 
@@ -1063,7 +1063,7 @@ describe("test Scene", () => {
 		const nextStep = () => {
 			setTimeout(() => {
 				steps[++stepIndex]();
-				game._flushSceneChangeRequests();
+				game._flushPostTickTasks();
 			}, 0);
 		};
 
@@ -1125,7 +1125,7 @@ describe("test Scene", () => {
 		let success2 = false;
 		let state2 = false;
 		game.pushScene(scene2);
-		game._flushSceneChangeRequests();
+		game._flushPostTickTasks();
 		state1 = false;
 		const holder2 = scene2.setInterval(() => {
 			if (!state2) fail("fail2");
@@ -1247,7 +1247,7 @@ describe("test Scene", () => {
 
 		const scene2 = new Scene({ game: game });
 		game.pushScene(scene2);
-		game._flushSceneChangeRequests();
+		game._flushPostTickTasks();
 		scene2.setInterval(() => {
 			if (!state2) fail("fail2");
 		}, 50);
@@ -1260,13 +1260,13 @@ describe("test Scene", () => {
 		expect(scene2._timer._timers.length).toBe(1);
 
 		game.popScene();
-		game._flushSceneChangeRequests();
+		game._flushPostTickTasks();
 		expect(scene1._timer._timers.length).toBe(1);
 		expect(scene2._timer._timers).toBeUndefined();
 
 		const scene3 = new Scene({ game: game });
 		game.replaceScene(scene3);
-		game._flushSceneChangeRequests();
+		game._flushPostTickTasks();
 		expect(scene1._timer._timers).toBeUndefined();
 	});
 
@@ -1313,24 +1313,24 @@ describe("test Scene", () => {
 			const scene3 = new Scene({ game: game });
 
 			game.pushScene(scene1);
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			expect(scene1.isCurrentScene()).toBe(true);
 			expect(scene2.isCurrentScene()).toBe(false);
 			expect(scene3.isCurrentScene()).toBe(false);
 
 			scene1.gotoScene(scene2, true); // push scene2
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			expect(scene1.isCurrentScene()).toBe(false);
 			expect(scene2.isCurrentScene()).toBe(true);
 			expect(scene3.isCurrentScene()).toBe(false);
 
 			scene2.end();
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			expect(scene1.isCurrentScene()).toBe(true);
 			expect(scene3.isCurrentScene()).toBe(false);
 
 			scene1.gotoScene(scene3, false); // replace scene1 to scene3
-			game._flushSceneChangeRequests();
+			game._flushPostTickTasks();
 			expect(scene3.isCurrentScene()).toBe(true);
 			done();
 		});

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -631,21 +631,10 @@ export class Game extends g.Game {
 		return this.tick(advance);
 	}
 
-	_fireSceneReady(scene: g.Scene): void {
-		super._fireSceneReady(scene);
+	_pushPostTickTask<T>(fun: () => void, owner: any): void {
+		super._pushPostTickTask(fun, owner);
 		if (this.autoTickForInternalEvents) {
 			setTimeout(() => {
-				if (scene.destroyed()) return; // 同期的にsceneを破棄してしまうテストのためにチェック
-				this.classicTick();
-			}, 0);
-		}
-	}
-
-	_fireSceneLoaded(scene: g.Scene): void {
-		super._fireSceneLoaded(scene);
-		if (this.autoTickForInternalEvents) {
-			setTimeout(() => {
-				if (scene.destroyed()) return; // 同期的にsceneを破棄してしまうテストのためにチェック
 				this.classicTick();
 			}, 0);
 		}

--- a/src/__tests__/helpers/skeleton.ts
+++ b/src/__tests__/helpers/skeleton.ts
@@ -11,7 +11,7 @@ export function skeletonRuntime(gameConfiguration?: GameConfiguration): Runtime 
 	const game = new Game(gameConfiguration);
 	const scene = new Scene({ game });
 	game.pushScene(scene);
-	game._flushSceneChangeRequests();
+	game._flushPostTickTasks();
 	return {
 		game: game,
 		scene: scene

--- a/src/domain/LoadingScene.ts
+++ b/src/domain/LoadingScene.ts
@@ -135,7 +135,7 @@ export class LoadingScene extends Scene {
 		}
 
 		this.game.popScene(true);
-		this.game._fireSceneLoaded(this._targetScene);
+		this.game._pushPostTickTask(this._targetScene._fireLoaded, this._targetScene);
 		this._clearTargetScene();
 	}
 


### PR DESCRIPTION
## このpull requestが解決する内容

掲題どおり。 #184 を再考しました。 `Scene` と循環参照していて、  Scene.ts から分離できていなかった `SceneAssetHolder` を見直し、 `AssetHolder` として切り離します。

`SceneAssetHolder` はもともと `Scene` の一部で、 `Scene` の各種トリガーを直接 fire するという状態になっていました。これを改めるため、生成時にいくつかのハンドラを受け取り、それを呼び出すだけの形にします。

また `SceneAssetHolder` は、生成時に与える `direct: boolean` によって挙動を変えるものでしたが、この中で `Game` への依存を持っていました。新たにこの `direct` 相当の情報を持たせておくプロパティ `AssetHolder#userData` を追加し、 `userData` の内容には `AssetHolder` を関知させないことで依存を切り離します。

### Game#_sceneChangeRequests の見直し

関連して、  `Game` のシーン操作系メソッドとデータを整理しました。

- `SceneChangeType` の `FireReady`, `FireLoaded` を廃止し、新設の `Call` に一本化
- `Call` の操作を登録するメソッド  `Game#pushPostTickTask()` を追加
   - `AssetHolder` に渡したハンドラからはこれを呼び出すように
- `FireReady`, `FireLoaded` などの処理中の `scene.destroyed()` チェックを、 `Scene#_fireReady()` など `Scene` の内部に移行
   - #210 の [コメント](https://github.com/akashic-games/akashic-engine/pull/210#pullrequestreview-390697992) で書いていた生存判定の整理です

## 破壊的な変更を含んでいるか?

なし。


レビューのため分岐元の `enum-to-str` ブランチへの PR になっていますが、マージ時は `v3-proto` ブランチに入れます。
