### PR TITLE
deprecated RandomGenerator#get()

### DIFF
--- a/src/__tests__/ModuleSpec.ts
+++ b/src/__tests__/ModuleSpec.ts
@@ -256,7 +256,7 @@ describe("test Module", () => {
 		"/script/cache1.js":
 			"module.exports = { v1: require('randomnumber'), v2: require('randomnumber'), cache2: require('./cache2.js') };",
 		"/script/cache2.js": "module.exports = { v1: require('randomnumber'), v2: require('randomnumber') };",
-		"/node_modules/randomnumber/index.js": "module.exports = g.game.random.get(0, 1000000);"
+		"/node_modules/randomnumber/index.js": "module.exports = g.game.random.generate();"
 	};
 
 	it("初期化", done => {

--- a/src/__tests__/XorshiftRandomGeneratorSpec.ts
+++ b/src/__tests__/XorshiftRandomGeneratorSpec.ts
@@ -20,26 +20,26 @@ describe("test XorshiftRandomGenerator", () => {
 
 		const generator = new XorshiftRandomGenerator(42);
 
-		for (let i = 0; i < 10; ++i) generator.get(0, 10000);
+		for (let i = 0; i < 10; ++i) generator.generate();
 
 		const copy1 = XorshiftRandomGenerator.deserialize(generator.serialize());
-		expect(copy1.get(0, 10000)).toBe(generator.get(0, 10000));
-		expect(copy1.get(0, 10000)).toBe(generator.get(0, 10000));
-		expect(copy1.get(0, 10000)).toBe(generator.get(0, 10000));
-		expect(copy1.get(0, 10000)).toBe(generator.get(0, 10000));
+		expect(copy1.generate()).toBe(generator.generate());
+		expect(copy1.generate()).toBe(generator.generate());
+		expect(copy1.generate()).toBe(generator.generate());
+		expect(copy1.generate()).toBe(generator.generate());
 
 		const copy2 = XorshiftRandomGenerator.deserialize(copy1.serialize());
-		expect(copy2.get(0, 10000)).toBe(generator.get(0, 10000));
-		expect(copy2.get(0, 10000)).toBe(generator.get(0, 10000));
-		expect(copy2.get(0, 10000)).toBe(generator.get(0, 10000));
-		expect(copy2.get(0, 10000)).toBe(generator.get(0, 10000));
+		expect(copy2.generate()).toBe(generator.generate());
+		expect(copy2.generate()).toBe(generator.generate());
+		expect(copy2.generate()).toBe(generator.generate());
+		expect(copy2.generate()).toBe(generator.generate());
 
 		const ser = generator.serialize();
 		const copy3 = XorshiftRandomGenerator.deserialize(JSON.parse(JSON.stringify(ser)));
-		expect(copy3.get(0, 10000)).toBe(generator.get(0, 10000));
-		expect(copy3.get(0, 10000)).toBe(generator.get(0, 10000));
-		expect(copy3.get(0, 10000)).toBe(generator.get(0, 10000));
-		expect(copy3.get(0, 10000)).toBe(generator.get(0, 10000));
+		expect(copy3.generate()).toBe(generator.generate());
+		expect(copy3.generate()).toBe(generator.generate());
+		expect(copy3.generate()).toBe(generator.generate());
+		expect(copy3.generate()).toBe(generator.generate());
 	});
 
 	it("is distribution within expectation", () => {
@@ -55,7 +55,8 @@ describe("test XorshiftRandomGenerator", () => {
 		testCases.forEach(testCase => {
 			const resultMap: number[] = [];
 			for (let i = 0; i < 10000; i++) {
-				resultMap.push(generator.get(testCase[0], testCase[1]));
+				const value = Math.floor(generator.generate() * (testCase[1] - testCase[0] + 1) + testCase[0]);
+				resultMap.push(value);
 			}
 			let sum = 0;
 			resultMap.forEach(v => {
@@ -85,7 +86,8 @@ describe("test XorshiftRandomGenerator", () => {
 				const generator = new XorshiftRandomGenerator(seed);
 				const resultMap = new Array(testCase[1] - testCase[0] + 1);
 				for (let i = 0; i < cycle; i++) {
-					const num = generator.get(testCase[0], testCase[1]) + (0 - testCase[0]);
+					const value = Math.floor(generator.generate() * (testCase[1] - testCase[0] + 1) + testCase[0]);
+					const num = value + (0 - testCase[0]);
 					if (!resultMap[num]) resultMap[num] = 0;
 					++resultMap[num];
 				}

--- a/src/domain/RandomGenerator.ts
+++ b/src/domain/RandomGenerator.ts
@@ -12,6 +12,9 @@ export abstract class RandomGenerator {
 		this.seed = seed;
 	}
 
+	/**
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `RandomGenerator#generate()` を利用すること。
+	 */
 	abstract get(min: number, max: number): number;
 
 	abstract generate(): number;

--- a/src/domain/XorshiftRandomGenerator.ts
+++ b/src/domain/XorshiftRandomGenerator.ts
@@ -25,6 +25,9 @@ export class XorshiftRandomGenerator extends RandomGenerator {
 		}
 	}
 
+	/**
+	 * @deprecated 非推奨である。将来的に削除される。代わりに `XorshiftRandomGenerator#generate()` を利用すること。
+	 */
 	get(min: number, max: number): number {
 		return this._xorshift.nextInt(min, max + 1);
 	}


### PR DESCRIPTION
## このpull requestが解決する内容

- `g.RandomGenerator#get()`を非推奨とします。
  `RandomGenerator`を継承している `XorshiftRandomGenerator#get()` も非推奨へ。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

