### PR TITLE
add Game#onSceneChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog
 
+## Unreleased changes
+
+機能追加
+ * `g.Game#onSceneChange` を追加
+
+### ゲーム開発者への影響
+ * `g.Game#onSceneChange` を追加
+
 ## 3.0.0-beta.19
 
 不具合修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## Unreleased changes
+## 3.0.0-beta.21
 
 機能追加
  * `g.Game#onSceneChange` を追加

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.20",
+  "version": "3.0.0-beta.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.18",
+  "version": "3.0.0-beta.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.20",
+  "version": "3.0.0-beta.21",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -34,6 +34,8 @@ describe("test Game", () => {
 		expect(game.selfId).toBe("foo");
 		expect(game.playId).toBe(undefined);
 		expect(game.onSkipChange).not.toBe(undefined);
+		expect(game.onSceneChange).not.toBe(undefined);
+		expect(game._onSceneChange).not.toBe(undefined);
 		expect(game).toHaveProperty("_assetManager");
 		expect(game).toHaveProperty("_initialScene");
 	});
@@ -50,6 +52,8 @@ describe("test Game", () => {
 		expect(game.vars).toEqual({}); // vars も触らない
 		expect(game.playId).toBe(undefined);
 		expect(game.onSkipChange).toBe(undefined);
+		expect(game.onSceneChange).toBe(undefined);
+		expect(game._onSceneChange).toBe(undefined);
 	});
 
 	it("global assets", done => {
@@ -606,8 +610,12 @@ describe("test Game", () => {
 
 		let topIsLocal: LocalTickModeString = undefined;
 		let sceneChangedCount = 0;
-		game._onSceneChange.add(scene => {
+		let _sceneChangedCount = 0;
+		game.onSceneChange.add(() => {
 			sceneChangedCount++;
+		});
+		game._onSceneChange.add(scene => {
+			_sceneChangedCount++;
 			topIsLocal = scene.local;
 		});
 		game._onLoad.add(() => {
@@ -622,18 +630,21 @@ describe("test Game", () => {
 
 			scene.onLoad.add(() => {
 				expect(sceneChangedCount).toBe(2); // _initialScene と scene (いずれも loadingSceneなし) で 2
+				expect(_sceneChangedCount).toBe(2);
 				expect(topIsLocal).toBe("non-local");
 				expect(game.scenes).toEqual([game._initialScene, scene]);
 				expect(game._eventTriggerMap["point-down"]).toBe(scene.onPointDownCapture);
 
 				scene2.onLoad.add(() => {
 					expect(sceneChangedCount).toBe(4); // loadingScene が pop されて 1 増えたので 4
+					expect(_sceneChangedCount).toBe(4);
 					expect(topIsLocal).toBe("non-local");
 					expect(game.scenes).toEqual([game._initialScene, scene2]);
 					expect(game._eventTriggerMap["point-down"]).toBe(scene2.onPointDownCapture);
 
 					scene3.onLoad.add(() => {
 						expect(sceneChangedCount).toBe(6);
+						expect(_sceneChangedCount).toBe(6);
 						expect(topIsLocal).toBe("full-local");
 						expect(game.scenes).toEqual([game._initialScene, scene2, scene3]);
 						expect(game._eventTriggerMap["point-down"]).toBe(scene3.onPointDownCapture);
@@ -641,6 +652,7 @@ describe("test Game", () => {
 						game.popScene();
 						game._flushPostTickTasks();
 						expect(sceneChangedCount).toBe(7);
+						expect(_sceneChangedCount).toBe(7);
 						expect(topIsLocal).toBe("non-local");
 						expect(game.scenes).toEqual([game._initialScene, scene2]);
 						expect(game._eventTriggerMap["point-down"]).toBe(scene2.onPointDownCapture);
@@ -648,6 +660,7 @@ describe("test Game", () => {
 						game.popScene();
 						game._flushPostTickTasks();
 						expect(sceneChangedCount).toBe(8);
+						expect(_sceneChangedCount).toBe(8);
 						expect(topIsLocal).toBe("full-local");
 						expect(game.scenes).toEqual([game._initialScene]);
 						expect(game._eventTriggerMap["point-down"]).toBe(game._initialScene.onPointDownCapture);
@@ -656,6 +669,7 @@ describe("test Game", () => {
 					game.pushScene(scene3);
 					game._flushPostTickTasks();
 					expect(sceneChangedCount).toBe(5);
+					expect(_sceneChangedCount).toBe(5);
 					expect(topIsLocal).toBe("full-local");
 					expect(game.scenes).toEqual([game._initialScene, scene2, scene3, game._defaultLoadingScene]);
 					expect(game._eventTriggerMap["point-down"]).toBe(game._defaultLoadingScene.onPointDownCapture);
@@ -663,11 +677,13 @@ describe("test Game", () => {
 				game.replaceScene(scene2);
 				game._flushPostTickTasks();
 				expect(sceneChangedCount).toBe(3); // scene2とloadingSceneが乗るが、scene2はまだ_sceneStackTopChangeCountをfireしてない
+				expect(_sceneChangedCount).toBe(3);
 				expect(topIsLocal).toBe("full-local"); // loadingScene がトップなので local
 				expect(game.scenes).toEqual([game._initialScene, scene2, game._defaultLoadingScene]);
 				expect(game._eventTriggerMap["point-down"]).toBe(game._defaultLoadingScene.onPointDownCapture);
 			});
 			expect(sceneChangedCount).toBe(1); // _initialScene (loadingSceneなし) が push された分で 1
+			expect(_sceneChangedCount).toBe(1);
 			expect(topIsLocal).toBe("full-local");
 			expect(game.scenes).toEqual([game._initialScene]);
 			expect(game._eventTriggerMap["point-down"]).toBe(game._initialScene.onPointDownCapture);
@@ -808,6 +824,12 @@ describe("test Game", () => {
 				}
 			}
 		});
+		game.onSceneChange.add(() => {
+			//
+		});
+		game._onSceneChange.add(() => {
+			//
+		});
 		game.resourceFactory.scriptContents["/script/mainScene.js"] =
 			"module.exports = () => { const s = new g.Scene({game: g.game}); g.game.pushScene(s);}";
 		expect(game.age).toBe(0);
@@ -874,6 +896,8 @@ describe("test Game", () => {
 					offset: { x: 0, y: 0 }
 				})
 			).toBeNull();
+			expect(game.onSceneChange.length).toBe(0);
+			expect(game._onSceneChange.length).not.toBe(1);
 			done();
 		});
 		game._loadAndStart();

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -896,8 +896,9 @@ describe("test Game", () => {
 					offset: { x: 0, y: 0 }
 				})
 			).toBeNull();
+			// reset で Game#onSceneChange は removeAll() されるが、Game#_onSceneChange は removeAll() されないことを確認
 			expect(game.onSceneChange.length).toBe(0);
-			expect(game._onSceneChange.length).not.toBe(1);
+			expect(game._onSceneChange.length).not.toBe(0);
 			done();
 		});
 		game._loadAndStart();

--- a/src/engine/Game.ts
+++ b/src/engine/Game.ts
@@ -392,6 +392,12 @@ export class Game {
 	operationPluginManager: OperationPluginManager;
 
 	/**
+	 * `this.scenes` の変化時にfireされるTrigger。
+	 * このTriggerはアセットロード(Scene#onLoadのfire)を待たず、変化した時点で即fireされることに注意。
+	 */
+	onSceneChange: Trigger<Scene | undefined>;
+
+	/**
 	 * プレイヤーがゲームに参加したことを表すイベント。
 	 * @deprecated 非推奨である。将来的に削除される。代わりに `onJoin` を利用すること。
 	 */
@@ -476,8 +482,10 @@ export class Game {
 	_defaultLoadingScene: LoadingScene;
 
 	/**
-	 * `this.scenes` の変化時にfireされるTrigger。
-	 * このTriggerはアセットロード(Scene#onLoadのfire)を待たず、変化した時点で即fireされることに注意。
+	 * `this.onSceneChange` と同様に `this.scenes` の変化時にfireされるTrigger。
+	 * `this.onSceneChange` との相違点は以下の通りである。
+	 * * 内部でのみ使用される Trigger なので、ゲーム開発者が直接利用すべきではない
+	 * * Game#_reset() 時に removeAll() されない (登録内容がリセットされず、残っている)
 	 * @private
 	 */
 	_onSceneChange: Trigger<Scene | undefined>;
@@ -738,6 +746,7 @@ export class Game {
 		this._operationPluginOperated = this._onOperationPluginOperated;
 		this.operationPluginManager.onOperate.add(this._onOperationPluginOperated.fire, this._onOperationPluginOperated);
 
+		this.onSceneChange = new Trigger<Scene>();
 		this._onSceneChange = new Trigger<Scene>();
 		this._onSceneChange.add(this._handleSceneChanged, this);
 		this._sceneChanged = this._onSceneChange;
@@ -1203,6 +1212,7 @@ export class Game {
 		this.onSeed.removeAll();
 		this.onResized.removeAll();
 		this.onSkipChange.removeAll();
+		this.onSceneChange.removeAll();
 		this.handlerSet.removeAllEventFilters();
 
 		this.isSkipping = false;
@@ -1309,6 +1319,8 @@ export class Game {
 		this._eventTriggerMap = undefined;
 		this._initialScene = undefined;
 		this._defaultLoadingScene = undefined;
+		this.onSceneChange.destroy();
+		this.onSceneChange = undefined;
 		this._onSceneChange.destroy();
 		this._onSceneChange = undefined;
 		this._onLoad.destroy();
@@ -1488,7 +1500,10 @@ export class Game {
 		if (scene === this._initialScene)
 			throw ExceptionFactory.createAssertionError("Game#_doPopScene: invalid call; attempting to pop the initial scene");
 		if (!preserveCurrent) scene.destroy();
-		if (fireSceneChanged) this._onSceneChange.fire(this.scene());
+		if (fireSceneChanged) {
+			this.onSceneChange.fire(this.scene());
+			this._onSceneChange.fire(this.scene());
+		}
 	}
 
 	private _handleLoad(): void {
@@ -1515,8 +1530,9 @@ export class Game {
 			this._doPushScene(loadingScene, this._defaultLoadingScene);
 			loadingScene.reset(scene);
 		} else {
-			// 読み込み待ちのアセットがなければその場で(loadingSceneに任せず)ロード、SceneReadyを発生させてからLoadingSceneEndを起こす。
+			this.onSceneChange.fire(scene);
 			this._onSceneChange.fire(scene);
+			// 読み込み待ちのアセットがなければその場で(loadingSceneに任せず)ロード、SceneReadyを発生させてからLoadingSceneEndを起こす。
 			if (!scene._loaded) {
 				scene._load();
 				this._pushPostTickTask(scene._fireLoaded, scene);

--- a/src/engine/Game.ts
+++ b/src/engine/Game.ts
@@ -484,8 +484,7 @@ export class Game {
 	/**
 	 * `this.onSceneChange` と同様に `this.scenes` の変化時にfireされるTrigger。
 	 * `this.onSceneChange` との相違点は以下の通りである。
-	 * * 内部でのみ使用される Trigger なので、ゲーム開発者が直接利用すべきではない
-	 * * Game#_reset() 時に removeAll() されない (登録内容がリセットされず、残っている)
+	 * * `this.reset()` 時に removeAll() されない
 	 * @private
 	 */
 	_onSceneChange: Trigger<Scene | undefined>;
@@ -1496,13 +1495,14 @@ export class Game {
 	}
 
 	private _doPopScene(preserveCurrent: boolean, fireSceneChanged: boolean): void {
-		var scene = this.scenes.pop();
+		const scene = this.scenes.pop();
 		if (scene === this._initialScene)
 			throw ExceptionFactory.createAssertionError("Game#_doPopScene: invalid call; attempting to pop the initial scene");
 		if (!preserveCurrent) scene.destroy();
 		if (fireSceneChanged) {
-			this.onSceneChange.fire(this.scene());
-			this._onSceneChange.fire(this.scene());
+			const scene = this.scene();
+			this.onSceneChange.fire(scene);
+			this._onSceneChange.fire(scene);
 		}
 	}
 

--- a/src/engine/Game.ts
+++ b/src/engine/Game.ts
@@ -483,8 +483,7 @@ export class Game {
 
 	/**
 	 * `this.onSceneChange` と同様に `this.scenes` の変化時にfireされるTrigger。
-	 * `this.onSceneChange` との相違点は以下の通りである。
-	 * * `this.reset()` 時に removeAll() されない
+	 * `this.onSceneChange` との相違点は `this.reset()` 時に removeAll() されないことである。
 	 * @private
 	 */
 	_onSceneChange: Trigger<Scene | undefined>;
@@ -1500,9 +1499,9 @@ export class Game {
 			throw ExceptionFactory.createAssertionError("Game#_doPopScene: invalid call; attempting to pop the initial scene");
 		if (!preserveCurrent) scene.destroy();
 		if (fireSceneChanged) {
-			const scene = this.scene();
-			this.onSceneChange.fire(scene);
-			this._onSceneChange.fire(scene);
+			const nextScene = this.scene();
+			this.onSceneChange.fire(nextScene);
+			this._onSceneChange.fire(nextScene);
 		}
 	}
 


### PR DESCRIPTION
## このpull requestが解決する内容
- `Game#onSceneChange` を新たに追加
  - このトリガーは `Game#_onSceneChange`と同じくscene変更時にfireされるトリガーだが、これはユーザーが直接利用すべきものという相違点があるので、どちらのトリガーも共存する状態にしておく(deprecatedにもしない)。

<!-- Pull Requestの変更内容の概要を書いてください -->

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

