### PR TITLE
Add GameParameterObject#mainFunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 3.0.0-beta.22
+
+機能追加
+ * `GameParameterObject#mainFunc` を追加
+
 ## 3.0.0-beta.21
 
 機能追加

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.21",
+  "version": "3.0.0-beta.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.21",
+  "version": "3.0.0-beta.22",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -173,6 +173,18 @@ describe("test Game", () => {
 		game._loadAndStart({ args: "arg-value" });
 	});
 
+	it("_loadAndStart - with mainFunc", done => {
+		const mainFunc = (g: any, args: any): void => {
+			expect(g).toBeDefined();
+			expect(g.Game).toBeDefined();
+			expect(g.Scene).toBeDefined();
+			expect(args).toEqual({ args: "arg-value" });
+			done();
+		};
+		const game = new Game({ width: 320, height: 320, main: "dummy" }, "/", undefined, undefined, mainFunc);
+		game._loadAndStart({ args: "arg-value" });
+	});
+
 	it("_loadAndStart - after loaded", done => {
 		const assets: { [id: string]: AssetConfiguration } = {
 			mainScene: {

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -615,11 +615,12 @@ export class Game extends g.Game {
 		configuration: g.GameConfiguration,
 		assetBase?: string,
 		selfId?: string,
-		operationPluginViewInfo?: g.OperationPluginViewInfo
+		operationPluginViewInfo?: g.OperationPluginViewInfo,
+		mainFunc?: g.GameMainFunction
 	) {
 		const resourceFactory = new ResourceFactory();
 		const handlerSet = new GameHandlerSet();
-		super({ engineModule: g, configuration, resourceFactory, handlerSet, assetBase, selfId, operationPluginViewInfo });
+		super({ engineModule: g, configuration, resourceFactory, handlerSet, assetBase, selfId, operationPluginViewInfo, mainFunc });
 		resourceFactory.init(this);
 		this.terminatedGame = false;
 		this.autoTickForInternalEvents = true;


### PR DESCRIPTION
## このpull requestが解決する内容
`GameParameterObject#mainFunc` を追加します。
指定された場合、与えられた値をエントリポイントとして評価します。

この変更により**コンテンツのエントリポイントはスクリプトアセットではならない**という制約が削除されます。

## sample
```javascript
new Game({
	...,
	configuration: {
		fps: 30,
		width: 800,
		height: 450,
		assets: {
			aco: {
				type: "image",
				path: "images/aco.png",
				width: 32,
				height: 48
			}
		}
	},
	mainFunc: function (g, args) {
		var scene = new g.Scene({
			game: g.game,
			assetIds: [
				"aco"
			]
		});
		scene.loaded.add(function () {
			var sprite = new g.Sprite({
				scene: scene,
				src: scene.assets["aco"],
				width: 32,
				height: 48
			});
			scene.append(sprite);
		});
		g.game.pushScene(scene);
	}
});
```

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

