### PR TITLE
Add PdiCommonUtil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## 3.0.0-beta.24
+
+その他変更
+ * `src/pdi-common-impls` に `PdiCommonUtil.ts` を追加
+    * `src/engine/PathUtil` の一部関数を `PdiCommonUtil.ts` へ移動
+
 ## 3.0.0-beta.23
 
 その他変更

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.22",
+  "version": "3.0.0-beta.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.23",
+  "version": "3.0.0-beta.24",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/__tests__/PathUtilSpec.ts
+++ b/src/__tests__/PathUtilSpec.ts
@@ -157,12 +157,6 @@ describe("test PathUtil", () => {
 		expect(paths).toEqual(["https://node_modules/node_modules"]);
 	});
 
-	it("addExtname", () => {
-		expect(PathUtil.addExtname("file", "ext")).toBe("file.ext");
-		expect(PathUtil.addExtname("http://example/file?query", "ext")).toBe("http://example/file.ext?query");
-		expect(PathUtil.addExtname("http://example/?query", "ext")).toBe("http://example/.ext?query");
-	});
-
 	it("splitPath", () => {
 		expect(PathUtil.splitPath("http://example.com/file.ext")).toEqual({
 			host: "http://example.com",

--- a/src/__tests__/PdiCommnUtilSpec.ts
+++ b/src/__tests__/PdiCommnUtilSpec.ts
@@ -1,0 +1,9 @@
+import { PdiCommonUtil } from "..";
+
+describe("test PdiCommonUtil", () => {
+	it("addExtname", () => {
+		expect(PdiCommonUtil.addExtname("file", "ext")).toBe("file.ext");
+		expect(PdiCommonUtil.addExtname("http://example/file?query", "ext")).toBe("http://example/file.ext?query");
+		expect(PdiCommonUtil.addExtname("http://example/?query", "ext")).toBe("http://example/.ext?query");
+	});
+});

--- a/src/engine/PathUtil.ts
+++ b/src/engine/PathUtil.ts
@@ -103,20 +103,6 @@ export module PathUtil {
 	}
 
 	/**
-	 * 与えられたパス文字列に与えられた拡張子を追加する。
-	 * @param path パス文字列
-	 * @param ext 追加する拡張子
-	 */
-	export function addExtname(path: string, ext: string): string {
-		var index = path.indexOf("?");
-		if (index === -1) {
-			return path + "." + ext;
-		}
-		// hoge?query => hoge.ext?query
-		return path.substring(0, index) + "." + ext + path.substring(index, path.length);
-	}
-
-	/**
 	 * 与えられたパス文字列からホストを切り出す。
 	 * @param path パス文字列
 	 */

--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -42,6 +42,7 @@ export * from "./pdi-common-impls/ExceptionFactory";
 export * from "./pdi-common-impls/Glyph";
 export * from "./pdi-common-impls/GlyphFactory";
 export * from "./pdi-common-impls/ImageAsset";
+export * from "./pdi-common-impls/PdiCommonUtil";
 export * from "./pdi-common-impls/Renderer";
 export * from "./pdi-common-impls/ResourceFactory";
 export * from "./pdi-common-impls/ScriptAsset";

--- a/src/pdi-common-impls/PdiCommonUtil.ts
+++ b/src/pdi-common-impls/PdiCommonUtil.ts
@@ -1,0 +1,18 @@
+/**
+ * pdi-browserから使用されるユーティリティ
+ */
+export module PdiCommonUtil {
+	/**
+	 * 与えられたパス文字列に与えられた拡張子を追加する。
+	 * @param path パス文字列
+	 * @param ext 追加する拡張子
+	 */
+	export function addExtname(path: string, ext: string): string {
+		var index = path.indexOf("?");
+		if (index === -1) {
+			return path + "." + ext;
+		}
+		// hoge?query => hoge.ext?query
+		return path.substring(0, index) + "." + ext + path.substring(index, path.length);
+	}
+}


### PR DESCRIPTION
## このpull requestが解決する内容

Pdi-browserで使用されているメソッドを`PdiCommonUtil.ts`にまとめます。

- `src/pdi-common-impls` に `PdiCommonUtil.ts` を追加。
  - `src/engine/PathUtil` の一部関数を `PdiCommonUtil.ts` へ移動。


**関連PR:** https://github.com/akashic-games/pdi-browser/pull/76

## 破壊的な変更を含んでいるか?

- なし
