### PR TITLE
内部でしか使われていない変数・メソッドに @ignore を付与する対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # ChangeLog
 
 ## Unreleased changes
-* 内部でしか使われていない変数・メソッドに @private を付与
+* 内部でしか使われていない変数・メソッドに @ignore を付与
 
 ## 3.0.0-beta.25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## Unreleased changes
+* 内部でしか使われていない変数・メソッドに @private を付与
+
 ## 3.0.0-beta.25
 
 仕様変更

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.24",
+  "version": "3.0.0-beta.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/engine/AssetManager.ts
+++ b/src/engine/AssetManager.ts
@@ -435,7 +435,7 @@ export class AssetManager implements AssetLoadHandler {
 	}
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_normalize(configuration: any, audioSystemConfMap: AudioSystemConfigurationMap): any {
 		var ret: { [key: string]: AssetConfiguration } = {};
@@ -533,7 +533,7 @@ export class AssetManager implements AssetLoadHandler {
 	}
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_releaseAsset(assetId: string): void {
 		const asset = this._assets[assetId] || (this._loadings[assetId] && this._loadings[assetId].asset);

--- a/src/engine/AssetManager.ts
+++ b/src/engine/AssetManager.ts
@@ -25,9 +25,24 @@ export interface AssetManagerParameterGameLike {
 }
 
 class AssetLoadingInfo {
+	/**
+	 * @private
+	 */
 	asset: OneOfAssetLike;
+
+	/**
+	 * @private
+	 */
 	handlers: AssetManagerLoadHandler[];
+
+	/**
+	 * @private
+	 */
 	errorCount: number;
+
+	/**
+	 * @private
+	 */
 	loading: boolean;
 
 	constructor(asset: OneOfAssetLike, handler: AssetManagerLoadHandler) {
@@ -431,6 +446,9 @@ export class AssetManager implements AssetLoadHandler {
 		return ret;
 	}
 
+	/**
+	 * @private
+	 */
 	_normalize(configuration: any, audioSystemConfMap: AudioSystemConfigurationMap): any {
 		var ret: { [key: string]: AssetConfiguration } = {};
 		if (!(configuration instanceof Object)) throw ExceptionFactory.createAssertionError("AssetManager#_normalize: invalid arguments.");
@@ -526,6 +544,9 @@ export class AssetManager implements AssetLoadHandler {
 		}
 	}
 
+	/**
+	 * @private
+	 */
 	_releaseAsset(assetId: string): void {
 		const asset = this._assets[assetId] || (this._loadings[assetId] && this._loadings[assetId].asset);
 		let path: string | null = null;

--- a/src/engine/AssetManager.ts
+++ b/src/engine/AssetManager.ts
@@ -24,25 +24,13 @@ export interface AssetManagerParameterGameLike {
 	defaultAudioSystemId: "music" | "sound";
 }
 
+/**
+ * @ignore
+ */
 class AssetLoadingInfo {
-	/**
-	 * @private
-	 */
 	asset: OneOfAssetLike;
-
-	/**
-	 * @private
-	 */
 	handlers: AssetManagerLoadHandler[];
-
-	/**
-	 * @private
-	 */
 	errorCount: number;
-
-	/**
-	 * @private
-	 */
 	loading: boolean;
 
 	constructor(asset: OneOfAssetLike, handler: AssetManagerLoadHandler) {

--- a/src/engine/AssetManagerLoadHandler.ts
+++ b/src/engine/AssetManagerLoadHandler.ts
@@ -8,7 +8,7 @@ import { AssetLoadError } from "../pdi-types/errors";
 export interface AssetManagerLoadHandler {
 	/**
 	 * 読み込失敗の通知を受ける関数。
-	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
+	 * @ignore
 	 * @param asset 読み込みに失敗したアセット
 	 * @param error 失敗の内容を表すエラー
 	 * @param retryCallback 読み込みの再試行を行うコールバック関数。`AssetManager#retryLoad()` が設定される。
@@ -17,7 +17,7 @@ export interface AssetManagerLoadHandler {
 
 	/**
 	 * 読み込み完了の通知を受ける関数。
-	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
+	 * @ignore
 	 * @param asset 読み込みが完了したアセット
 	 */
 	_onAssetLoad(asset: AssetLike): void;

--- a/src/engine/AssetManagerLoadHandler.ts
+++ b/src/engine/AssetManagerLoadHandler.ts
@@ -8,6 +8,7 @@ import { AssetLoadError } from "../pdi-types/errors";
 export interface AssetManagerLoadHandler {
 	/**
 	 * 読み込失敗の通知を受ける関数。
+	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
 	 * @param asset 読み込みに失敗したアセット
 	 * @param error 失敗の内容を表すエラー
 	 * @param retryCallback 読み込みの再試行を行うコールバック関数。`AssetManager#retryLoad()` が設定される。
@@ -16,6 +17,7 @@ export interface AssetManagerLoadHandler {
 
 	/**
 	 * 読み込み完了の通知を受ける関数。
+	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
 	 * @param asset 読み込みが完了したアセット
 	 */
 	_onAssetLoad(asset: AssetLike): void;

--- a/src/engine/DefaultLoadingScene.ts
+++ b/src/engine/DefaultLoadingScene.ts
@@ -26,7 +26,6 @@ export interface DefaultLoadingSceneParameterObject {
 /**
  * カメラのtransformを戻すエンティティ。
  * LoadingSceneのインジケータがカメラの影響を受けないようにするための内部エンティティ。
- * @ignore
  */
 class CameraCancellingE extends E {
 	_canceller: Object2D;

--- a/src/engine/DefaultLoadingScene.ts
+++ b/src/engine/DefaultLoadingScene.ts
@@ -26,11 +26,9 @@ export interface DefaultLoadingSceneParameterObject {
 /**
  * カメラのtransformを戻すエンティティ。
  * LoadingSceneのインジケータがカメラの影響を受けないようにするための内部エンティティ。
+ * @ignore
  */
 class CameraCancellingE extends E {
-	/**
-	 * @private
-	 */
 	_canceller: Object2D;
 
 	constructor(param: EParameterObject) {
@@ -38,9 +36,6 @@ class CameraCancellingE extends E {
 		this._canceller = new Object2D();
 	}
 
-	/**
-	 * @private
-	 */
 	renderSelf(renderer: RendererLike, camera?: Camera): boolean {
 		if (!this.children) return false;
 

--- a/src/engine/DefaultLoadingScene.ts
+++ b/src/engine/DefaultLoadingScene.ts
@@ -38,6 +38,9 @@ class CameraCancellingE extends E {
 		this._canceller = new Object2D();
 	}
 
+	/**
+	 * @private
+	 */
 	renderSelf(renderer: RendererLike, camera?: Camera): boolean {
 		if (!this.children) return false;
 

--- a/src/engine/EventConverter.ts
+++ b/src/engine/EventConverter.ts
@@ -8,21 +8,13 @@ import { InternalOperationPluginOperation } from "./OperationPluginOperation";
 import { Player } from "./Player";
 import { StorageValueStore } from "./Storage";
 
+/**
+ * @ignore
+ */
 // TODO: Game を意識しないインターフェース を検討する
 interface EventConverterParameterObejctGameLike {
-	/**
-	 * @private
-	 */
 	db: { [idx: number]: E };
-
-	/**
-	 * @private
-	 */
 	_localDb: { [id: number]: E };
-
-	/**
-	 * @private
-	 */
 	_decodeOperationPluginOperation: (code: number, op: (number | string)[]) => any;
 }
 

--- a/src/engine/EventConverter.ts
+++ b/src/engine/EventConverter.ts
@@ -10,8 +10,19 @@ import { StorageValueStore } from "./Storage";
 
 // TODO: Game を意識しないインターフェース を検討する
 interface EventConverterParameterObejctGameLike {
+	/**
+	 * @private
+	 */
 	db: { [idx: number]: E };
+
+	/**
+	 * @private
+	 */
 	_localDb: { [id: number]: E };
+
+	/**
+	 * @private
+	 */
 	_decodeOperationPluginOperation: (code: number, op: (number | string)[]) => any;
 }
 
@@ -24,8 +35,19 @@ export interface EventConverterParameterObejct {
  * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
  */
 export class EventConverter {
+	/**
+	 * @private
+	 */
 	_game: EventConverterParameterObejctGameLike;
+
+	/**
+	 * @private
+	 */
 	_playerId: string;
+
+	/**
+	 * @private
+	 */
 	_playerTable: { [key: string]: Player };
 
 	constructor(param: EventConverterParameterObejct) {

--- a/src/engine/EventConverter.ts
+++ b/src/engine/EventConverter.ts
@@ -28,17 +28,17 @@ export interface EventConverterParameterObejct {
  */
 export class EventConverter {
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_game: EventConverterParameterObejctGameLike;
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_playerId: string;
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_playerTable: { [key: string]: Player };
 

--- a/src/engine/EventConverter.ts
+++ b/src/engine/EventConverter.ts
@@ -25,21 +25,11 @@ export interface EventConverterParameterObejct {
 
 /**
  * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
+ * @ignore
  */
 export class EventConverter {
-	/**
-	 * @ignore
-	 */
 	_game: EventConverterParameterObejctGameLike;
-
-	/**
-	 * @ignore
-	 */
 	_playerId: string;
-
-	/**
-	 * @ignore
-	 */
 	_playerTable: { [key: string]: Player };
 
 	constructor(param: EventConverterParameterObejct) {

--- a/src/engine/Game.ts
+++ b/src/engine/Game.ts
@@ -580,7 +580,7 @@ export class Game {
 
 	/**
 	 * エントリポイントの関数。
-	 * @private
+	 * @ignore
 	 */
 	_mainFunc: GameMainFunction | undefined;
 
@@ -1223,8 +1223,7 @@ export class Game {
 	}
 
 	/**
-	 * @private
-	 * NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明
+	 * @ignore
 	 */
 	_pushPostTickTask(fun: () => void, owner: any): void {
 		this._postTickTasks.push({
@@ -1520,7 +1519,7 @@ export class Game {
 	}
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_handleOperationPluginOperated(op: InternalOperationPluginOperation): void {
 		const pev = this._eventConverter.makePlaylogOperationEvent(op);
@@ -1528,7 +1527,7 @@ export class Game {
 	}
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_handleSceneChanged(scene?: Scene): void {
 		this._updateEventTriggers(scene);
@@ -1594,7 +1593,7 @@ export class Game {
 	}
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_handleSkipChange(isSkipping: boolean): void {
 		this.isSkipping = isSkipping;

--- a/src/engine/Game.ts
+++ b/src/engine/Game.ts
@@ -67,12 +67,14 @@ type PostTickTask = PostTickPopSceneTask | PostTickPushSceneTask | PostTickRepla
 interface PostTickPushSceneTask {
 	/**
 	 * 遷移の種類。
+	 * @private
 	 */
 	type: PostTickTaskType.PushScene;
 
 	/**
 	 * 遷移先になるシーン。
 	 * `type` が `Push` または `Replace` の時のみ存在。
+	 * @private
 	 */
 	scene: Scene;
 }
@@ -80,18 +82,21 @@ interface PostTickPushSceneTask {
 interface PostTickReplaceSceneTask {
 	/**
 	 * 遷移の種類。
+	 * @private
 	 */
 	type: PostTickTaskType.ReplaceScene;
 
 	/**
 	 * 遷移先になるシーン。
 	 * `type` が `Push` または `Replace` の時のみ存在。
+	 * @private
 	 */
 	scene: Scene;
 
 	/**
 	 * 現在のシーンを破棄するか否か。
 	 * `type` が `PopScene` または `Replace` の時のみ存在。
+	 * @private
 	 */
 	preserveCurrent: boolean;
 }
@@ -99,12 +104,14 @@ interface PostTickReplaceSceneTask {
 interface PostTickPopSceneTask {
 	/**
 	 * 遷移の種類。
+	 * @private
 	 */
 	type: PostTickTaskType.PopScene;
 
 	/**
 	 * 現在のシーンを破棄するか否か。
 	 * `type` が `PopScene` または `Replace` の時のみ存在。
+	 * @private
 	 */
 	preserveCurrent: boolean;
 }
@@ -112,18 +119,21 @@ interface PostTickPopSceneTask {
 interface PostTickCallFunctionTask {
 	/**
 	 * 遷移の種類。
+	 * @private
 	 */
 	type: PostTickTaskType.Call;
 
 	/**
 	 * 呼び出す関数。
 	 * `type` が `Call` の時のみ存在。
+	 * @private
 	 */
 	fun: Function;
 
 	/**
 	 * `fun` の `this` として使う値。
 	 * `type` が `Call` の時のみ存在。
+	 * @private
 	 */
 	owner: any;
 }
@@ -568,6 +578,7 @@ export class Game {
 
 	/**
 	 * エントリポイントの関数。
+	 * @private
 	 */
 	_mainFunc: GameMainFunction | undefined;
 
@@ -1209,6 +1220,10 @@ export class Game {
 		return this.handlerSet.getInstanceType() === "active";
 	}
 
+	/**
+	 * @private
+	 * NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明
+	 */
 	_pushPostTickTask(fun: () => void, owner: any): void {
 		this._postTickTasks.push({
 			type: PostTickTaskType.Call,
@@ -1502,11 +1517,17 @@ export class Game {
 		this._onLoad.fire(this);
 	}
 
+	/**
+	 * @private
+	 */
 	_handleOperationPluginOperated(op: InternalOperationPluginOperation): void {
 		const pev = this._eventConverter.makePlaylogOperationEvent(op);
 		this.handlerSet.raiseEvent(pev);
 	}
 
+	/**
+	 * @private
+	 */
 	_handleSceneChanged(scene?: Scene): void {
 		this._updateEventTriggers(scene);
 		const local = scene ? scene.local : "full-local";
@@ -1570,6 +1591,9 @@ export class Game {
 		} while (this._postTickTasks.length > 0); // flush中に追加される限りflushを続行する
 	}
 
+	/**
+	 * @private
+	 */
 	_handleSkipChange(isSkipping: boolean): void {
 		this.isSkipping = isSkipping;
 	}

--- a/src/engine/Game.ts
+++ b/src/engine/Game.ts
@@ -64,76 +64,78 @@ const enum PostTickTaskType {
  */
 type PostTickTask = PostTickPopSceneTask | PostTickPushSceneTask | PostTickReplaceSceneTask | PostTickCallFunctionTask;
 
+/**
+ * @ignore
+ */
 interface PostTickPushSceneTask {
 	/**
 	 * 遷移の種類。
-	 * @private
 	 */
 	type: PostTickTaskType.PushScene;
 
 	/**
 	 * 遷移先になるシーン。
 	 * `type` が `Push` または `Replace` の時のみ存在。
-	 * @private
 	 */
 	scene: Scene;
 }
 
+/**
+ * @ignore
+ */
 interface PostTickReplaceSceneTask {
 	/**
 	 * 遷移の種類。
-	 * @private
 	 */
 	type: PostTickTaskType.ReplaceScene;
 
 	/**
 	 * 遷移先になるシーン。
 	 * `type` が `Push` または `Replace` の時のみ存在。
-	 * @private
 	 */
 	scene: Scene;
 
 	/**
 	 * 現在のシーンを破棄するか否か。
 	 * `type` が `PopScene` または `Replace` の時のみ存在。
-	 * @private
 	 */
 	preserveCurrent: boolean;
 }
 
+/**
+ * @ignore
+ */
 interface PostTickPopSceneTask {
 	/**
 	 * 遷移の種類。
-	 * @private
 	 */
 	type: PostTickTaskType.PopScene;
 
 	/**
 	 * 現在のシーンを破棄するか否か。
 	 * `type` が `PopScene` または `Replace` の時のみ存在。
-	 * @private
 	 */
 	preserveCurrent: boolean;
 }
 
+/**
+ * @ignore
+ */
 interface PostTickCallFunctionTask {
 	/**
 	 * 遷移の種類。
-	 * @private
 	 */
 	type: PostTickTaskType.Call;
 
 	/**
 	 * 呼び出す関数。
 	 * `type` が `Call` の時のみ存在。
-	 * @private
 	 */
 	fun: Function;
 
 	/**
 	 * `fun` の `this` として使う値。
 	 * `type` が `Call` の時のみ存在。
-	 * @private
 	 */
 	owner: any;
 }

--- a/src/engine/ModuleManager.ts
+++ b/src/engine/ModuleManager.ts
@@ -46,6 +46,8 @@ export class ModuleManager {
 	 * node.jsのrequireに限りなく近いモデルでrequireする。
 	 * ただしアセットIDで該当すればそちらを優先する。また node.js のコアモジュールには対応していない。
 	 * 通常、ゲーム開発者が利用するのは `Module#require()` であり、このメソッドはその内部実装を提供する。
+	 *
+	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
 	 * @param path requireのパス。相対パスと、Asset識別名を利用することが出来る。
 	 *              なお、./xxx.json のようにjsonを指定する場合、そのAssetはTextAssetである必要がある。
 	 *              その他の形式である場合、そのAssetはScriptAssetである必要がある。
@@ -154,6 +156,7 @@ export class ModuleManager {
 	 * 見つかった場合そのアセットを、そうでない場合 `undefined` を返す。
 	 * 通常、ゲーム開発者がファイルパスを扱うことはなく、このメソッドを呼び出す必要はない。
 	 *
+	 * @private
 	 * @param resolvedPath パス文字列
 	 * @param liveAssetPathTable パス文字列のプロパティに対応するアセットを格納したオブジェクト
 	 */
@@ -170,6 +173,7 @@ export class ModuleManager {
 	 * ディレクトリ内に package.json が存在する場合、package.json 自体もアセットとして
 	 * `liveAssetPathTable` から参照可能でなければならないことに注意。
 	 *
+	 * @private
 	 * @param resolvedPath パス文字列
 	 * @param liveAssetPathTable パス文字列のプロパティに対応するアセットを格納したオブジェクト
 	 */

--- a/src/engine/ModuleManager.ts
+++ b/src/engine/ModuleManager.ts
@@ -47,7 +47,7 @@ export class ModuleManager {
 	 * ただしアセットIDで該当すればそちらを優先する。また node.js のコアモジュールには対応していない。
 	 * 通常、ゲーム開発者が利用するのは `Module#require()` であり、このメソッドはその内部実装を提供する。
 	 *
-	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
+	 * @ignore
 	 * @param path requireのパス。相対パスと、Asset識別名を利用することが出来る。
 	 *              なお、./xxx.json のようにjsonを指定する場合、そのAssetはTextAssetである必要がある。
 	 *              その他の形式である場合、そのAssetはScriptAssetである必要がある。
@@ -156,7 +156,7 @@ export class ModuleManager {
 	 * 見つかった場合そのアセットを、そうでない場合 `undefined` を返す。
 	 * 通常、ゲーム開発者がファイルパスを扱うことはなく、このメソッドを呼び出す必要はない。
 	 *
-	 * @private
+	 * @ignore
 	 * @param resolvedPath パス文字列
 	 * @param liveAssetPathTable パス文字列のプロパティに対応するアセットを格納したオブジェクト
 	 */
@@ -173,7 +173,7 @@ export class ModuleManager {
 	 * ディレクトリ内に package.json が存在する場合、package.json 自体もアセットとして
 	 * `liveAssetPathTable` から参照可能でなければならないことに注意。
 	 *
-	 * @private
+	 * @ignore
 	 * @param resolvedPath パス文字列
 	 * @param liveAssetPathTable パス文字列のプロパティに対応するアセットを格納したオブジェクト
 	 */

--- a/src/engine/OperationPluginManager.ts
+++ b/src/engine/OperationPluginManager.ts
@@ -21,6 +21,9 @@ class OperationHandler {
 		this._handlerOwner = owner;
 	}
 
+	/**
+	 * @private
+	 */
 	onOperation(op: OperationPluginOperation | (number | string)[]): void {
 		var iop: InternalOperationPluginOperation;
 		if (op instanceof Array) {

--- a/src/engine/OperationPluginManager.ts
+++ b/src/engine/OperationPluginManager.ts
@@ -9,6 +9,7 @@ import { OperationPluginViewInfo } from "./OperationPluginViewInfo";
 /**
  * 操作プラグインからの通知をハンドルするクラス。
  * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
+ * @ignore
  */
 class OperationHandler {
 	private _code: number;
@@ -21,9 +22,6 @@ class OperationHandler {
 		this._handlerOwner = owner;
 	}
 
-	/**
-	 * @private
-	 */
 	onOperation(op: OperationPluginOperation | (number | string)[]): void {
 		var iop: InternalOperationPluginOperation;
 		if (op instanceof Array) {

--- a/src/engine/PointEventResolver.ts
+++ b/src/engine/PointEventResolver.ts
@@ -44,15 +44,10 @@ export interface PointEventResolverParameterObject {
  * Down -> Move -> Up の流れを保証する機能も持つ。
  *
  * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
+ * @ignore
  */
 export class PointEventResolver {
-	/**
-	 * @ignore
-	 */
 	_sourceResolver: PointSourceResolver;
-	/**
-	 * @ignore
-	 */
 	_playerId: string;
 
 	// g.Eと関連した座標データ

--- a/src/engine/PointEventResolver.ts
+++ b/src/engine/PointEventResolver.ts
@@ -6,10 +6,29 @@ import { PointSource } from "./entities/E";
 import { EventPriority } from "./EventPriority";
 
 interface PointEventHolder {
+	/**
+	 * @private
+	 */
 	targetId?: number;
+
+	/**
+	 * @private
+	 */
 	local?: boolean;
+
+	/**
+	 * @private
+	 */
 	point: CommonOffset;
+
+	/**
+	 * @private
+	 */
 	start: CommonOffset;
+
+	/**
+	 * @private
+	 */
 	prev: CommonOffset;
 	// TODO: タイムスタンプのようなものを入れて一定時間後にクリアする仕組みが必要かもしれない。
 	//       pointUpをトリガに解放するので、pointUpを取り逃すとリークする(mapに溜まったままになってしまう)
@@ -43,7 +62,13 @@ export interface PointEventResolverParameterObject {
  * 本クラスのインスタンスをゲーム開発者が直接生成することはなく、ゲーム開発者が利用する必要もない。
  */
 export class PointEventResolver {
+	/**
+	 * @private
+	 */
 	_sourceResolver: PointSourceResolver;
+	/**
+	 * @private
+	 */
 	_playerId: string;
 
 	// g.Eと関連した座標データ

--- a/src/engine/PointEventResolver.ts
+++ b/src/engine/PointEventResolver.ts
@@ -5,30 +5,14 @@ import { Camera } from "./Camera";
 import { PointSource } from "./entities/E";
 import { EventPriority } from "./EventPriority";
 
+/**
+ * @ignore
+ */
 interface PointEventHolder {
-	/**
-	 * @private
-	 */
 	targetId?: number;
-
-	/**
-	 * @private
-	 */
 	local?: boolean;
-
-	/**
-	 * @private
-	 */
 	point: CommonOffset;
-
-	/**
-	 * @private
-	 */
 	start: CommonOffset;
-
-	/**
-	 * @private
-	 */
 	prev: CommonOffset;
 	// TODO: タイムスタンプのようなものを入れて一定時間後にクリアする仕組みが必要かもしれない。
 	//       pointUpをトリガに解放するので、pointUpを取り逃すとリークする(mapに溜まったままになってしまう)

--- a/src/engine/PointEventResolver.ts
+++ b/src/engine/PointEventResolver.ts
@@ -47,11 +47,11 @@ export interface PointEventResolverParameterObject {
  */
 export class PointEventResolver {
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_sourceResolver: PointSourceResolver;
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_playerId: string;
 

--- a/src/engine/RequireCachedValue.ts
+++ b/src/engine/RequireCachedValue.ts
@@ -1,6 +1,9 @@
 import { RequireCacheable } from "./RequireCacheable";
 
 export class RequireCachedValue implements RequireCacheable {
+	/**
+	 * @private
+	 */
 	_value: any;
 
 	constructor(value: any) {

--- a/src/engine/RequireCachedValue.ts
+++ b/src/engine/RequireCachedValue.ts
@@ -2,7 +2,7 @@ import { RequireCacheable } from "./RequireCacheable";
 
 export class RequireCachedValue implements RequireCacheable {
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_value: any;
 

--- a/src/engine/TimerManager.ts
+++ b/src/engine/TimerManager.ts
@@ -71,10 +71,29 @@ export class TimerIdentifier {
  * ゲーム開発者が本クラスを利用する事はない。
  */
 export class TimerManager {
+	/**
+	 * @private
+	 */
 	_timers: Timer[];
+
+	/**
+	 * @private
+	 */
 	_trigger: Trigger<void>;
+
+	/**
+	 * @private
+	 */
 	_identifiers: TimerIdentifier[];
+
+	/**
+	 * @private
+	 */
 	_fps: number;
+
+	/**
+	 * @private
+	 */
 	_registered: boolean;
 
 	constructor(trigger: Trigger<void>, fps: number) {

--- a/src/engine/TimerManager.ts
+++ b/src/engine/TimerManager.ts
@@ -72,27 +72,27 @@ export class TimerIdentifier {
  */
 export class TimerManager {
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_timers: Timer[];
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_trigger: Trigger<void>;
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_identifiers: TimerIdentifier[];
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_fps: number;
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_registered: boolean;
 

--- a/src/engine/TimerManager.ts
+++ b/src/engine/TimerManager.ts
@@ -9,27 +9,27 @@ import { Timer } from "./Timer";
  */
 export class TimerIdentifier {
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_timer: Timer;
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_handler: () => void;
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_handlerOwner: any;
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_fired: ((c: TimerIdentifier) => void) | undefined;
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_firedOwner: any;
 

--- a/src/engine/Xorshift.ts
+++ b/src/engine/Xorshift.ts
@@ -112,8 +112,23 @@ export class Xorshift {
  */
 
 export interface XorshiftSerialization {
+	/**
+	 * @private
+	 */
 	_state0U: number;
+
+	/**
+	 * @private
+	 */
 	_state0L: number;
+
+	/**
+	 * @private
+	 */
 	_state1U: number;
+
+	/**
+	 * @private
+	 */
 	_state1L: number;
 }

--- a/src/engine/Xorshift.ts
+++ b/src/engine/Xorshift.ts
@@ -113,22 +113,22 @@ export class Xorshift {
 
 export interface XorshiftSerialization {
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_state0U: number;
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_state0L: number;
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_state1U: number;
 
 	/**
-	 * @private
+	 * @ignore
 	 */
 	_state1L: number;
 }

--- a/src/pdi-common-impls/Glyph.ts
+++ b/src/pdi-common-impls/Glyph.ts
@@ -78,6 +78,10 @@ export class Glyph implements GlyphLike {
 	 */
 	isSurfaceValid: boolean;
 
+	/**
+	 * @private
+	 * NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明
+	 */
 	_atlas: SurfaceAtlasLike | null;
 
 	/**

--- a/src/pdi-common-impls/Glyph.ts
+++ b/src/pdi-common-impls/Glyph.ts
@@ -79,8 +79,7 @@ export class Glyph implements GlyphLike {
 	isSurfaceValid: boolean;
 
 	/**
-	 * @private
-	 * NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明
+	 * @ignore
 	 */
 	_atlas: SurfaceAtlasLike | null;
 

--- a/src/pdi-common-impls/Renderer.ts
+++ b/src/pdi-common-impls/Renderer.ts
@@ -84,6 +84,7 @@ export abstract class Renderer implements RendererLike {
 	 * 引数は CanvasRenderingContext2D#getImageData() と同様である。
 	 * 本メソッドの呼び出しは `Renderer#end()` から `Renderer#begin()` の間でなければならない。
 	 * NOTE: 実行環境によっては戻り値が `null` または `undefined` となりえることに注意。
+	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
 	 */
 	abstract _getImageData(sx: number, sy: number, sw: number, sh: number): ImageData;
 
@@ -91,6 +92,7 @@ export abstract class Renderer implements RendererLike {
 	 * 本Rendererの描画内容を上書きする。
 	 * 引数は CanvasRenderingContext2D#putImageData() と同様である。
 	 * 本メソッドの呼び出しは `Renderer#end()` から `Renderer#begin()` の間でなければならない。
+	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
 	 */
 	abstract _putImageData(
 		imageData: ImageData,

--- a/src/pdi-common-impls/Renderer.ts
+++ b/src/pdi-common-impls/Renderer.ts
@@ -84,7 +84,7 @@ export abstract class Renderer implements RendererLike {
 	 * 引数は CanvasRenderingContext2D#getImageData() と同様である。
 	 * 本メソッドの呼び出しは `Renderer#end()` から `Renderer#begin()` の間でなければならない。
 	 * NOTE: 実行環境によっては戻り値が `null` または `undefined` となりえることに注意。
-	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
+	 * @ignore
 	 */
 	abstract _getImageData(sx: number, sy: number, sw: number, sh: number): ImageData;
 
@@ -92,7 +92,7 @@ export abstract class Renderer implements RendererLike {
 	 * 本Rendererの描画内容を上書きする。
 	 * 引数は CanvasRenderingContext2D#putImageData() と同様である。
 	 * 本メソッドの呼び出しは `Renderer#end()` から `Renderer#begin()` の間でなければならない。
-	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
+	 * @ignore
 	 */
 	abstract _putImageData(
 		imageData: ImageData,

--- a/src/pdi-types/AssetLike.ts
+++ b/src/pdi-types/AssetLike.ts
@@ -9,7 +9,7 @@ import { AssetLoadError } from "./errors";
 export interface AssetLoadHandler {
 	/**
 	 * 読み込失敗の通知を受ける関数。
-	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
+	 * @ignore
 	 * @param asset 読み込みに失敗したアセット
 	 * @param error 失敗の内容を表すエラー
 	 */
@@ -17,7 +17,7 @@ export interface AssetLoadHandler {
 
 	/**
 	 * 読み込み完了の通知を受ける関数。
-	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
+	 * @ignore
 	 * @param asset 読み込みが完了したアセット
 	 */
 	_onAssetLoad(asset: AssetLike): void;

--- a/src/pdi-types/AssetLike.ts
+++ b/src/pdi-types/AssetLike.ts
@@ -9,6 +9,7 @@ import { AssetLoadError } from "./errors";
 export interface AssetLoadHandler {
 	/**
 	 * 読み込失敗の通知を受ける関数。
+	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
 	 * @param asset 読み込みに失敗したアセット
 	 * @param error 失敗の内容を表すエラー
 	 */
@@ -16,6 +17,7 @@ export interface AssetLoadHandler {
 
 	/**
 	 * 読み込み完了の通知を受ける関数。
+	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
 	 * @param asset 読み込みが完了したアセット
 	 */
 	_onAssetLoad(asset: AssetLike): void;

--- a/src/pdi-types/AudioAssetLike.ts
+++ b/src/pdi-types/AudioAssetLike.ts
@@ -19,7 +19,7 @@ export interface AudioAssetLike extends AssetLike {
 	hint: AudioAssetHint;
 
 	/**
-	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
+	 * @ignore
 	 */
 	_system: AudioSystemLike;
 

--- a/src/pdi-types/AudioAssetLike.ts
+++ b/src/pdi-types/AudioAssetLike.ts
@@ -17,6 +17,10 @@ export interface AudioAssetLike extends AssetLike {
 	duration: number;
 	loop: boolean;
 	hint: AudioAssetHint;
+
+	/**
+	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
+	 */
 	_system: AudioSystemLike;
 
 	play(): AudioPlayerLike;

--- a/src/pdi-types/GlyphLike.ts
+++ b/src/pdi-types/GlyphLike.ts
@@ -89,8 +89,7 @@ export interface GlyphLike {
 	isSurfaceValid: boolean;
 
 	/**
-	 * @private
-	 * NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明
+	 * @ignore
 	 */
 	_atlas: SurfaceAtlasLike | null;
 }

--- a/src/pdi-types/GlyphLike.ts
+++ b/src/pdi-types/GlyphLike.ts
@@ -88,5 +88,9 @@ export interface GlyphLike {
 	 */
 	isSurfaceValid: boolean;
 
+	/**
+	 * @private
+	 * NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明
+	 */
 	_atlas: SurfaceAtlasLike | null;
 }

--- a/src/pdi-types/RendererLike.ts
+++ b/src/pdi-types/RendererLike.ts
@@ -81,7 +81,7 @@ export interface RendererLike {
 	 * 引数は CanvasRenderingContext2D#getImageData() と同様である。
 	 * 本メソッドの呼び出しは `Renderer#end()` から `Renderer#begin()` の間でなければならない。
 	 * NOTE: 実行環境によっては戻り値が `null` または `undefined` となりえることに注意。
-	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
+	 * @ignore
 	 */
 	_getImageData(sx: number, sy: number, sw: number, sh: number): ImageData;
 
@@ -89,7 +89,7 @@ export interface RendererLike {
 	 * 本Rendererの描画内容を上書きする。
 	 * 引数は CanvasRenderingContext2D#putImageData() と同様である。
 	 * 本メソッドの呼び出しは `Renderer#end()` から `Renderer#begin()` の間でなければならない。
-	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
+	 * @ignore
 	 */
 	_putImageData(
 		imageData: ImageData,

--- a/src/pdi-types/RendererLike.ts
+++ b/src/pdi-types/RendererLike.ts
@@ -81,6 +81,7 @@ export interface RendererLike {
 	 * 引数は CanvasRenderingContext2D#getImageData() と同様である。
 	 * 本メソッドの呼び出しは `Renderer#end()` から `Renderer#begin()` の間でなければならない。
 	 * NOTE: 実行環境によっては戻り値が `null` または `undefined` となりえることに注意。
+	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
 	 */
 	_getImageData(sx: number, sy: number, sw: number, sh: number): ImageData;
 
@@ -88,6 +89,7 @@ export interface RendererLike {
 	 * 本Rendererの描画内容を上書きする。
 	 * 引数は CanvasRenderingContext2D#putImageData() と同様である。
 	 * 本メソッドの呼び出しは `Renderer#end()` から `Renderer#begin()` の間でなければならない。
+	 * @private (NOTE: 接頭辞に_は付いているが、他クラスから参照されているので @private していいか不明)
 	 */
 	_putImageData(
 		imageData: ImageData,


### PR DESCRIPTION
## このpull requestが解決する内容
* docとして出力させないために以下のような変数やメソッドに対して`@ignore`を付与しました
  * 接頭辞に`_`が付いているが、`@private`が抜けているもの
  * exportされてないclassやinterface

<!-- Pull Requestの変更内容の概要を書いてください -->

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

## 見ていただきたいところ
* `@ignore`を付ける所に間違いはないか？
* たとえ接頭辞に`_`がなくてもコメントに`ゲーム開発者は(参照|利用)する必要がない`と記載されている変数やメソッドにも`@ignore`を付与すべきか？
  * その場合、接頭辞に`_`を付けてリネームすべきか？