### PR TITLE
V3 add audio stop all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### ゲーム開発者への影響
 
  * `g.AudioSystemManager#stopAll` を追加
-    * ゲーム開発者は、`g.game.audio.stopAll()` を使うことで、再生中のオーディオシステム群全てを停止することができます。
+    * ゲーム開発者は、`g.game.audio.stopAll()` を使うことで、全てのオーディオシステムを停止することができます。
 
 ## 3.0.0-beta.30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # ChangeLog
 
+## 3.0.0-beta.31
+
+機能追加
+ * `g.AudioSystemManager#stopAll` を追加
+
+### ゲーム開発者への影響
+
+ * `g.AudioSystemManager#stopAll` を追加
+    * ゲーム開発者は、`g.game.audio.stopAll()` を使うことで、再生中のオーディオシステム群全てを停止することができます。
+
 ## 3.0.0-beta.30
 
 その他変更

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.30",
+  "version": "3.0.0-beta.31",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/AudioSystemManager.ts
+++ b/src/AudioSystemManager.ts
@@ -73,4 +73,9 @@ export class AudioSystemManager {
 			resourceFactory: resourceFactory
 		});
 	}
+
+	stopAll(): void {
+		this.music.stopAll();
+		this.sound.stopAll();
+	}
 }


### PR DESCRIPTION
## このpull requestが解決する内容

`g.game.audio.stopAll()` の追加。
 - `AudioSystemManger` に 全てのオーディオシステムを停止させる `stopAll()` を追加します。


## 破壊的な変更を含んでいるか?

- なし

