### PR TITLE
Fix export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 3.0.0-beta.33
+
+不具合修正
+ * export 出来ていなかった `g.AssetLoadFailureInfo` を追加。
+
 ## 3.0.0-beta.32
 
 不具合修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0-beta.33
 
 不具合修正
- * export 出来ていなかった `g.AssetLoadFailureInfo` を追加。
+ * `g.AssetLoadFailureInfo` を export するように修正
 
 ## 3.0.0-beta.32
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.32",
+  "version": "3.0.0-beta.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0-beta.32",
+  "version": "3.0.0-beta.33",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -21,6 +21,7 @@ export * from "./entities/Pane";
 export * from "./entities/Sprite";
 export * from "./AssetAccessor";
 export * from "./AssetConfiguration";
+export * from "./AssetLoadFailureInfo";
 export * from "./AssetManager";
 export * from "./AssetManagerLoadHandler";
 export * from "./AudioSystemManager";


### PR DESCRIPTION
## このpull requestが解決する内容

export 対象の class / interface を確認し、export できていなかった `AssetLoadFailureInfo` を追加。

## 破壊的な変更を含んでいるか?

- なし
