### PR TITLE
Integrate PlayerInfoEvent props into PlayerInfoEvent#player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## Unreleased Changes
+
+仕様変更
+ * `PlayerInfoEvent#player` を追加、 `PlayerInfoEvent` の `playerId`, `playerName`, `userData` を削除
+   * 将来のために予約されている未使用の機能のため、ゲーム開発者に影響はありません。
+
 ## 3.0.0
 
 v3.0.0-beta.X の正式リリース版です。

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -263,21 +263,17 @@ export class TimestampEvent implements Event {
 
 /**
  * プレイヤー情報を表すイベント。
- * PointInfoEvent#playerNameによってプレイヤー名を、PlayerInfoEvent#userData によってユーザ情報を取得できる。
+ * PointInfoEvent#player.nameによってプレイヤー名を、PlayerInfoEvent#player.userDataによって送信者依存の追加データを取得できる。
  */
 export class PlayerInfoEvent implements Event {
 	type: "player-info" = "player-info";
 	eventFlags: number;
-	playerId: string;
-	playerName: string;
-	userData: any;
+	player: Player;
 
-	constructor(playerId: string, playerName: string, userData?: any, eventFlags?: number) {
+	constructor(player: Player, eventFlags?: number) {
 		// @ts-ignore TODO: eventFlags のデフォルト値の扱い
 		this.eventFlags = eventFlags;
-		this.playerId = playerId;
-		this.playerName = playerName;
-		this.userData = userData;
+		this.player = player;
 	}
 }
 

--- a/src/EventConverter.ts
+++ b/src/EventConverter.ts
@@ -100,7 +100,7 @@ export class EventConverter {
 					userData
 				};
 				// @ts-ignore
-				return new PlayerInfoEvent(playerId, playerName, userData, prio);
+				return new PlayerInfoEvent(this._playerTable[playerId]!, prio);
 
 			case pl.EventCode.Message:
 				local = pev[EventIndex.Message.Local];
@@ -190,13 +190,13 @@ export class EventConverter {
 				];
 			case "player-info":
 				let playerInfo = <PlayerInfoEvent>e;
-				playerId = preservePlayer ? playerInfo.playerId : this._playerId;
+				playerId = preservePlayer ? playerInfo.player.id : this._playerId;
 				return [
-					pl.EventCode.PlayerInfo, // 0: イベントコード
-					playerInfo.eventFlags, //   1: イベントフラグ値
-					playerId, //                2: プレイヤーID
-					playerInfo.playerName, //   3: プレイヤー名
-					playerInfo.userData //      4: ユーザデータ
+					pl.EventCode.PlayerInfo, //   0: イベントコード
+					playerInfo.eventFlags, //     1: イベントフラグ値
+					playerId, //                  2: プレイヤーID
+					playerInfo.player.name, //    3: プレイヤー名
+					playerInfo.player.userData // 4: ユーザデータ
 				];
 			case "point-down":
 				let pointDown = <PointDownEvent>e;
@@ -276,7 +276,7 @@ export class EventConverter {
 
 	makePlaylogOperationEvent(op: InternalOperationPluginOperation): pl.Event {
 		let playerId = this._playerId;
-		let eventFlags = op.priority != null ? (op.priority & pl.EventFlagsMask.Priority ): 0;
+		let eventFlags = op.priority != null ? op.priority & pl.EventFlagsMask.Priority : 0;
 		return [
 			pl.EventCode.Operation, // 0: イベントコード
 			eventFlags, //             1: イベントフラグ値

--- a/src/EventConverter.ts
+++ b/src/EventConverter.ts
@@ -93,14 +93,14 @@ export class EventConverter {
 			case pl.EventCode.PlayerInfo:
 				let playerName = pev[EventIndex.PlayerInfo.PlayerName];
 				let userData: any = pev[EventIndex.PlayerInfo.UserData];
-				// @ts-ignore
-				this._playerTable[playerId] = {
+				player = {
 					id: playerId,
 					name: playerName,
 					userData
 				};
 				// @ts-ignore
-				return new PlayerInfoEvent(this._playerTable[playerId]!, prio);
+				this._playerTable[playerId] = player;
+				return new PlayerInfoEvent(player, prio);
 
 			case pl.EventCode.Message:
 				local = pev[EventIndex.Message.Local];

--- a/src/__tests__/EventConvertSpec.ts
+++ b/src/__tests__/EventConvertSpec.ts
@@ -119,9 +119,12 @@ describe("EventConverter", () => {
 			EventPriority.System,
 			"dummyPlayerId",
 			"dummyName",
-			{ userData: "dummy" }
+			{ userDataProp: "dummy" }
 		];
-		const playerInfo = new PlayerInfoEvent("dummyPlayerId", "dummyName", { userData: "dummy" }, EventPriority.System);
+		const playerInfo = new PlayerInfoEvent(
+			{ id: "dummyPlayerId", name: "dummyName", userData: { userDataProp: "dummy" } },
+			EventPriority.System
+		);
 		const playerInfo2 = self.toGameEvent(pPlayerInfo);
 		expect(playerInfo).toEqual(playerInfo2);
 
@@ -130,7 +133,7 @@ describe("EventConverter", () => {
 		const pointDown = self.toGameEvent(pdown) as PointDownEvent;
 		expect(pointDown.player!.id).toBe("dummyPlayerId");
 		expect(pointDown.player!.name).toBe("dummyName");
-		expect(pointDown.player!.userData).toEqual({ userData: "dummy" });
+		expect(pointDown.player!.userData).toEqual({ userDataProp: "dummy" });
 
 		// JoinEvent 送信後にユーザデータが上書きされていないことを確認
 		const pjoin2: pl.JoinEvent = [pl.EventCode.Join, EventPriority.System, player.id, player.name!, sds];
@@ -139,6 +142,6 @@ describe("EventConverter", () => {
 		const pointDown2 = self.toGameEvent(pdown2) as PointDownEvent;
 		expect(pointDown2.player!.id).toBe("dummyPlayerId");
 		expect(pointDown2.player!.name).toBe("dummyName");
-		expect(pointDown2.player!.userData).toEqual({ userData: "dummy" });
+		expect(pointDown2.player!.userData).toEqual({ userDataProp: "dummy" });
 	});
 });

--- a/src/__tests__/EventSpec.ts
+++ b/src/__tests__/EventSpec.ts
@@ -91,14 +91,13 @@ describe("test Event", () => {
 	});
 
 	it("初期化 - PlayerInfo", () => {
-		const player = { id: "3", name: "p" };
-		const userData = { hoge: "foo" };
-		const playerInfoEvent = new PlayerInfoEvent(player.id, player.name, userData, 1);
+		const player = { id: "3", name: "p", userData: { hoge: "foo" } };
+		const playerInfoEvent = new PlayerInfoEvent(player, 1);
 		expect(playerInfoEvent.type).toBe("player-info");
 		expect(playerInfoEvent.eventFlags).toBe(1);
-		expect(playerInfoEvent.userData).toEqual(userData);
-		expect(playerInfoEvent.playerId).toBe(player.id);
-		expect(playerInfoEvent.playerName).toBe(player.name);
+		expect(playerInfoEvent.player.userData).toEqual(player.userData);
+		expect(playerInfoEvent.player.id).toBe(player.id);
+		expect(playerInfoEvent.player.name).toBe(player.name);
 	});
 
 	it("初期化 - Seed", () => {


### PR DESCRIPTION
## このpull requestが解決する内容

掲題どおり。

`JoinEvent` などと対称性を鑑み、 `playerId`, `playerName` などを `player: Player` に統合します。

## 破壊的な変更を含んでいるか?

あり。 `PlayerInfoEvent` のプロパティが変化します。
ただしこのリポジトリに閉じた変更であること、また将来拡張のための未使用の機能であるため、ゲーム開発者に影響はありません。
