### PR TITLE
feat: support to resolve external module path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 機能追加
  * `g.Module#_resolvePath()` を追加
-   * ゲーム開発者は、 `require.resolve()` を利用することで game.json からみた相対パスを取得することができます。
+   * ゲーム開発者は、 `require.resolve()` を利用することで game.json をルートとする絶対パスを取得することができます。
+ * パス形式でのアセットの取得時に、パスにモジュール名が含まれていたら絶対パスへと読み替えるように変更
 
 仕様変更
  * `PlayerInfoEvent#player` を追加、 `PlayerInfoEvent` の `playerId`, `playerName`, `userData` を削除

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## Unreleased Changes
+## 3.0.1
 
 機能追加
  * `g.Module#_resolvePath()` を追加

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -629,6 +629,8 @@ export class AssetManager implements AssetLoadHandler {
 	 * @private
 	 */
 	_replaceModulePathToAbsolute(accessorPath: string): string {
+		if (accessorPath[0] === "/") return accessorPath;
+
 		for (const moduleName in this._moduleMainScripts) {
 			if (!this._moduleMainScripts.hasOwnProperty(moduleName)) continue;
 			if (accessorPath.lastIndexOf(moduleName, 0) === 0) {

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -629,7 +629,12 @@ export class AssetManager implements AssetLoadHandler {
 	 * @private
 	 */
 	_replaceModulePathToAbsolute(accessorPath: string): string {
-		if (accessorPath[0] === "/") return accessorPath;
+		if (
+			accessorPath[0] === "/" ||
+			accessorPath[0] === "*" // パスに `**/*` が指定された場合
+		) {
+			return accessorPath;
+		}
 
 		for (const moduleName in this._moduleMainScripts) {
 			if (!this._moduleMainScripts.hasOwnProperty(moduleName)) continue;

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -289,7 +289,10 @@ export class AssetManager implements AssetLoadHandler {
 		const ret: string[] = [];
 		for (let i = 0; i < patternOrFilters.length; ++i) {
 			const patternOrFilter = patternOrFilters[i];
-			const filter = typeof patternOrFilter === "string" ? patternToFilter(patternOrFilter) : patternOrFilter;
+			const filter =
+				typeof patternOrFilter === "string"
+					? patternToFilter(this._replaceAccessorPathToAbsolute(patternOrFilter))
+					: patternOrFilter;
 			for (let j = 0; j < vpaths.length; ++j) {
 				const vpath = vpaths[j];
 				const accessorPath = "/" + vpath; // virtualPath に "/" を足すと accessorPath という仕様
@@ -387,6 +390,7 @@ export class AssetManager implements AssetLoadHandler {
 	 * @param type 取得するアセットのタイプ。対象のアセットと合致しない場合、エラー
 	 */
 	peekLiveAssetByAccessorPath<T extends OneOfAsset>(accessorPath: string, type: string): T {
+		accessorPath = this._replaceAccessorPathToAbsolute(accessorPath);
 		if (accessorPath[0] !== "/")
 			throw ExceptionFactory.createAssertionError("AssetManager#peekLiveAssetByAccessorPath(): accessorPath must start with '/'");
 		const vpath = accessorPath.slice(1); // accessorPath から "/" を削ると virtualPath という仕様
@@ -423,7 +427,8 @@ export class AssetManager implements AssetLoadHandler {
 		type: string | null
 	): T[] {
 		const vpaths = Object.keys(this._liveAssetVirtualPathTable);
-		const filter = typeof patternOrFilter === "string" ? patternToFilter(patternOrFilter) : patternOrFilter;
+		const filter =
+			typeof patternOrFilter === "string" ? patternToFilter(this._replaceAccessorPathToAbsolute(patternOrFilter)) : patternOrFilter;
 		let ret: T[] = [];
 		for (let i = 0; i < vpaths.length; ++i) {
 			const vpath = vpaths[i];
@@ -620,5 +625,19 @@ export class AssetManager implements AssetLoadHandler {
 
 		var hs = loadingInfo.handlers;
 		for (var i = 0; i < hs.length; ++i) hs[i]._onAssetLoad(asset);
+	}
+
+	/**
+	 * @private
+	 */
+	_replaceAccessorPathToAbsolute(accessorPath: string): string {
+		for (const moduleName in this._moduleMainScripts) {
+			if (!this._moduleMainScripts.hasOwnProperty(moduleName)) continue;
+			if (accessorPath.lastIndexOf(moduleName, 0) === 0) {
+				accessorPath = accessorPath.replace(moduleName, "/node_modules/" + moduleName);
+				break;
+			}
+		}
+		return accessorPath;
 	}
 }

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -634,7 +634,7 @@ export class AssetManager implements AssetLoadHandler {
 		for (const moduleName in this._moduleMainScripts) {
 			if (!this._moduleMainScripts.hasOwnProperty(moduleName)) continue;
 			if (accessorPath.lastIndexOf(moduleName, 0) === 0) {
-				return accessorPath.replace(moduleName, "/node_modules/" + moduleName);
+				return "/node_modules/" + accessorPath;
 			}
 		}
 		return accessorPath;

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -290,9 +290,7 @@ export class AssetManager implements AssetLoadHandler {
 		for (let i = 0; i < patternOrFilters.length; ++i) {
 			const patternOrFilter = patternOrFilters[i];
 			const filter =
-				typeof patternOrFilter === "string"
-					? patternToFilter(this._replaceAccessorPathToAbsolute(patternOrFilter))
-					: patternOrFilter;
+				typeof patternOrFilter === "string" ? patternToFilter(this._replaceModulePathToAbsolute(patternOrFilter)) : patternOrFilter;
 			for (let j = 0; j < vpaths.length; ++j) {
 				const vpath = vpaths[j];
 				const accessorPath = "/" + vpath; // virtualPath に "/" を足すと accessorPath という仕様
@@ -390,7 +388,7 @@ export class AssetManager implements AssetLoadHandler {
 	 * @param type 取得するアセットのタイプ。対象のアセットと合致しない場合、エラー
 	 */
 	peekLiveAssetByAccessorPath<T extends OneOfAsset>(accessorPath: string, type: string): T {
-		accessorPath = this._replaceAccessorPathToAbsolute(accessorPath);
+		accessorPath = this._replaceModulePathToAbsolute(accessorPath);
 		if (accessorPath[0] !== "/")
 			throw ExceptionFactory.createAssertionError("AssetManager#peekLiveAssetByAccessorPath(): accessorPath must start with '/'");
 		const vpath = accessorPath.slice(1); // accessorPath から "/" を削ると virtualPath という仕様
@@ -428,7 +426,7 @@ export class AssetManager implements AssetLoadHandler {
 	): T[] {
 		const vpaths = Object.keys(this._liveAssetVirtualPathTable);
 		const filter =
-			typeof patternOrFilter === "string" ? patternToFilter(this._replaceAccessorPathToAbsolute(patternOrFilter)) : patternOrFilter;
+			typeof patternOrFilter === "string" ? patternToFilter(this._replaceModulePathToAbsolute(patternOrFilter)) : patternOrFilter;
 		let ret: T[] = [];
 		for (let i = 0; i < vpaths.length; ++i) {
 			const vpath = vpaths[i];
@@ -630,12 +628,11 @@ export class AssetManager implements AssetLoadHandler {
 	/**
 	 * @private
 	 */
-	_replaceAccessorPathToAbsolute(accessorPath: string): string {
+	_replaceModulePathToAbsolute(accessorPath: string): string {
 		for (const moduleName in this._moduleMainScripts) {
 			if (!this._moduleMainScripts.hasOwnProperty(moduleName)) continue;
 			if (accessorPath.lastIndexOf(moduleName, 0) === 0) {
-				accessorPath = accessorPath.replace(moduleName, "/node_modules/" + moduleName);
-				break;
+				return accessorPath.replace(moduleName, "/node_modules/" + moduleName);
 			}
 		}
 		return accessorPath;

--- a/src/__tests__/AssetAccessorSpec.ts
+++ b/src/__tests__/AssetAccessorSpec.ts
@@ -48,7 +48,30 @@ describe("test AssetAccessor", () => {
 				virtualPath: "assets/chara01/image.png",
 				width: 32,
 				height: 32
+			},
+			"node_modules/@akashic-extension/some-library/lib/index.js": {
+				type: "script",
+				path: "node_modules/@akashic-extension/some-library/lib/index.js",
+				virtualPath: "node_modules/@akashic-extension/some-library/lib/index.js",
+				global: true
+			},
+			"node_modules/@akashic-extension/some-library/assets/image.png": {
+				type: "image",
+				path: "node_modules/@akashic-extension/some-library/assets/image.png",
+				virtualPath: "node_modules/@akashic-extension/some-library/assets/image.png",
+				width: 2048,
+				height: 1024
+			},
+			"node_modules/@akashic-extension/some-library/assets/boss.png": {
+				type: "image",
+				path: "node_modules/@akashic-extension/some-library/assets/boss.png",
+				virtualPath: "node_modules/@akashic-extension/some-library/assets/boss.png",
+				width: 324,
+				height: 196
 			}
+		},
+		moduleMainScripts: {
+			"@akashic-extension/some-library": "node_modules/@akashic-extension/some-library/lib/index.js"
 		}
 	};
 
@@ -62,7 +85,10 @@ describe("test AssetAccessor", () => {
 		"id-assets/stage01/se01",
 		"id-assets/stage01/boss.png",
 		"id-assets/stage01/map.json",
-		"id-assets/chara01/image.png"
+		"id-assets/chara01/image.png",
+		"node_modules/@akashic-extension/some-library/lib/index.js",
+		"node_modules/@akashic-extension/some-library/assets/image.png",
+		"node_modules/@akashic-extension/some-library/assets/boss.png"
 	];
 
 	function setupAssetAccessor(assetIds: string[], fail: (arg: any) => void, callback: (accessor: AssetAccessor) => void): void {
@@ -151,6 +177,16 @@ describe("test AssetAccessor", () => {
 						id: "id-assets/chara01/image.png",
 						type: "image",
 						path: "assets/chara01/image.png"
+					},
+					{
+						id: "node_modules/@akashic-extension/some-library/assets/image.png",
+						type: "image",
+						path: "node_modules/@akashic-extension/some-library/assets/image.png"
+					},
+					{
+						id: "node_modules/@akashic-extension/some-library/assets/boss.png",
+						type: "image",
+						path: "node_modules/@akashic-extension/some-library/assets/boss.png"
 					}
 				]);
 
@@ -172,6 +208,11 @@ describe("test AssetAccessor", () => {
 						id: "id-script/main.js",
 						type: "script",
 						path: "script/main.js"
+					},
+					{
+						id: "node_modules/@akashic-extension/some-library/lib/index.js",
+						type: "script",
+						path: "node_modules/@akashic-extension/some-library/lib/index.js"
 					}
 				]);
 
@@ -218,6 +259,33 @@ describe("test AssetAccessor", () => {
 
 				expect(accessor.getTextContentById("id-assets/stage01/map.json")).toBe(sampleJSONFileContent);
 				expect(accessor.getJSONContentById("id-assets/stage01/map.json")).toEqual(JSON.parse(sampleJSONFileContent));
+				done();
+			}
+		);
+	});
+
+	it("can get assets by path contains the module name", done => {
+		setupAssetAccessor(
+			assetIds,
+			s => done.fail(s),
+			accessor => {
+				expect(accessor.getAllImages("@akashic-extension/some-library/assets/*.png").map(extractAssetProps)).toEqual([
+					{
+						id: "node_modules/@akashic-extension/some-library/assets/image.png",
+						type: "image",
+						path: "node_modules/@akashic-extension/some-library/assets/image.png"
+					},
+					{
+						id: "node_modules/@akashic-extension/some-library/assets/boss.png",
+						type: "image",
+						path: "node_modules/@akashic-extension/some-library/assets/boss.png"
+					}
+				]);
+				expect(extractAssetProps(accessor.getScript("@akashic-extension/some-library/lib/index.js"))).toEqual({
+					id: "node_modules/@akashic-extension/some-library/lib/index.js",
+					type: "script",
+					path: "node_modules/@akashic-extension/some-library/lib/index.js"
+				});
 				done();
 			}
 		);

--- a/src/__tests__/AssetAccessorSpec.ts
+++ b/src/__tests__/AssetAccessorSpec.ts
@@ -68,10 +68,17 @@ describe("test AssetAccessor", () => {
 				virtualPath: "node_modules/@akashic-extension/some-library/assets/boss.png",
 				width: 324,
 				height: 196
+			},
+			"node_modules/another-extension/lib/index.js": {
+				type: "script",
+				path: "node_modules/another-extension/lib/index.js",
+				virtualPath: "node_modules/another-extension/lib/index.js",
+				global: true
 			}
 		},
 		moduleMainScripts: {
-			"@akashic-extension/some-library": "node_modules/@akashic-extension/some-library/lib/index.js"
+			"@akashic-extension/some-library": "node_modules/@akashic-extension/some-library/lib/index.js",
+			"another-extension": "node_modules/another-extension/lib/index.js"
 		}
 	};
 
@@ -88,7 +95,8 @@ describe("test AssetAccessor", () => {
 		"id-assets/chara01/image.png",
 		"node_modules/@akashic-extension/some-library/lib/index.js",
 		"node_modules/@akashic-extension/some-library/assets/image.png",
-		"node_modules/@akashic-extension/some-library/assets/boss.png"
+		"node_modules/@akashic-extension/some-library/assets/boss.png",
+		"node_modules/another-extension/lib/index.js"
 	];
 
 	function setupAssetAccessor(assetIds: string[], fail: (arg: any) => void, callback: (accessor: AssetAccessor) => void): void {
@@ -213,6 +221,11 @@ describe("test AssetAccessor", () => {
 						id: "node_modules/@akashic-extension/some-library/lib/index.js",
 						type: "script",
 						path: "node_modules/@akashic-extension/some-library/lib/index.js"
+					},
+					{
+						id: "node_modules/another-extension/lib/index.js",
+						type: "script",
+						path: "node_modules/another-extension/lib/index.js"
 					}
 				]);
 
@@ -286,6 +299,14 @@ describe("test AssetAccessor", () => {
 					type: "script",
 					path: "node_modules/@akashic-extension/some-library/lib/index.js"
 				});
+				expect(extractAssetProps(accessor.getScript("another-extension/lib/index.js"))).toEqual({
+					id: "node_modules/another-extension/lib/index.js",
+					type: "script",
+					path: "node_modules/another-extension/lib/index.js"
+				});
+				expect(() => {
+					accessor.getScript("not-exists-library/index.js");
+				}).toThrowError();
 				done();
 			}
 		);

--- a/src/__tests__/AssetManagerSpec.ts
+++ b/src/__tests__/AssetManagerSpec.ts
@@ -558,7 +558,30 @@ describe("test AssetManager", () => {
 					virtualPath: "assets/chara01/image.png",
 					width: 32,
 					height: 32
+				},
+				"node_modules/@akashic-extension/some-library/lib/index.js": {
+					type: "script",
+					path: "node_modules/@akashic-extension/some-library/lib/index.js",
+					virtualPath: "node_modules/@akashic-extension/some-library/lib/index.js",
+					global: true
+				},
+				"node_modules/@akashic-extension/some-library/assets/image.png": {
+					type: "image",
+					path: "node_modules/@akashic-extension/some-library/assets/image.png",
+					virtualPath: "node_modules/@akashic-extension/some-library/assets/image.png",
+					width: 2048,
+					height: 1024
+				},
+				"node_modules/@akashic-extension/some-library/assets/boss.png": {
+					type: "image",
+					path: "node_modules/@akashic-extension/some-library/assets/boss.png",
+					virtualPath: "node_modules/@akashic-extension/some-library/assets/boss.png",
+					width: 324,
+					height: 196
 				}
+			},
+			moduleMainScripts: {
+				"@akashic-extension/some-library": "node_modules/@akashic-extension/some-library/lib/index.js"
 			}
 		};
 
@@ -572,6 +595,12 @@ describe("test AssetManager", () => {
 				"id-assets/stage01/boss.png",
 				"id-assets/stage01/map.json",
 				"id-assets/chara01/image.png"
+			]);
+
+			expect(manager.resolvePatternsToAssetIds(["@akashic-extension/some-library/**/*"])).toEqual([
+				"node_modules/@akashic-extension/some-library/lib/index.js",
+				"node_modules/@akashic-extension/some-library/assets/image.png",
+				"node_modules/@akashic-extension/some-library/assets/boss.png"
 			]);
 		});
 
@@ -603,6 +632,7 @@ describe("test AssetManager", () => {
 			const manager = game._assetManager;
 			expect(manager.resolvePatternsToAssetIds(["**/*.js", s => /\/bgm\d+$/.test(s)])).toEqual([
 				"id-script/main.js",
+				"node_modules/@akashic-extension/some-library/lib/index.js",
 				"id-assets/stage01/bgm01"
 			]);
 		});
@@ -654,7 +684,12 @@ describe("test AssetManager", () => {
 		});
 
 		it("can peek live assets by accessorPath", done => {
-			const assetIds = ["id-script/main.js", "id-assets/stage01/se01", "id-assets/chara01/image.png"];
+			const assetIds = [
+				"id-script/main.js",
+				"id-assets/stage01/se01",
+				"id-assets/chara01/image.png",
+				"node_modules/@akashic-extension/some-library/assets/boss.png"
+			];
 			setupAssetLoadedGame(
 				assetIds,
 				s => done.fail(s),
@@ -676,6 +711,15 @@ describe("test AssetManager", () => {
 					expect(se01.path).toBe("assets/stage01/se01");
 					expect(se01.duration).toBe(10000);
 
+					const boss = manager.peekLiveAssetByAccessorPath(
+						"@akashic-extension/some-library/assets/boss.png",
+						"image"
+					) as ImageAsset;
+					expect(boss.type).toBe("image");
+					expect(boss.path).toBe("node_modules/@akashic-extension/some-library/assets/boss.png");
+					expect(boss.width).toBe(324);
+					expect(boss.height).toBe(196);
+
 					// "/" 始まりでないのはエラー
 					expect(() => manager.peekLiveAssetByAccessorPath("assets/stage01/se01", "audio")).toThrowError("AssertionError");
 					done();
@@ -694,7 +738,9 @@ describe("test AssetManager", () => {
 				"id-assets/stage01/se01",
 				"id-assets/stage01/boss.png",
 				"id-assets/stage01/map.json",
-				"id-assets/chara01/image.png"
+				"id-assets/chara01/image.png",
+				"node_modules/@akashic-extension/some-library/assets/image.png",
+				"node_modules/@akashic-extension/some-library/assets/boss.png"
 			];
 			setupAssetLoadedGame(
 				assetIds,
@@ -721,6 +767,22 @@ describe("test AssetManager", () => {
 					expect(result3.length).toEqual(2);
 					expect(result3[0]).toEqual({ id: "id-assets/stage01/boss.png", type: "image", path: "assets/stage01/boss.png" });
 					expect(result3[1]).toEqual({ id: "id-assets/chara01/image.png", type: "image", path: "assets/chara01/image.png" });
+
+					const result4 = manager
+						.peekAllLiveAssetsByPattern("@akashic-extension/some-library/*/*.png", "image")
+						.map(extractAssetProps);
+					expect(result4).toEqual([
+						{
+							id: "node_modules/@akashic-extension/some-library/assets/image.png",
+							type: "image",
+							path: "node_modules/@akashic-extension/some-library/assets/image.png"
+						},
+						{
+							id: "node_modules/@akashic-extension/some-library/assets/boss.png",
+							type: "image",
+							path: "node_modules/@akashic-extension/some-library/assets/boss.png"
+						}
+					]);
 					done();
 				}
 			);
@@ -733,7 +795,9 @@ describe("test AssetManager", () => {
 				"id-assets/stage01/se01",
 				"id-assets/stage01/boss.png",
 				"id-assets/stage01/map.json",
-				"id-assets/chara01/image.png"
+				"id-assets/chara01/image.png",
+				"node_modules/@akashic-extension/some-library/assets/image.png",
+				"node_modules/@akashic-extension/some-library/assets/boss.png"
 			];
 			setupAssetLoadedGame(
 				assetIds,
@@ -757,9 +821,28 @@ describe("test AssetManager", () => {
 					expect(result2[1]).toEqual({ id: "id-assets/stage01/se01", type: "audio", path: "assets/stage01/se01" });
 
 					const result3 = manager.peekAllLiveAssetsByPattern(s => /\.png$/.test(s), "image").map(extractAssetProps);
-					expect(result3.length).toEqual(2);
-					expect(result3[0]).toEqual({ id: "id-assets/stage01/boss.png", type: "image", path: "assets/stage01/boss.png" });
-					expect(result3[1]).toEqual({ id: "id-assets/chara01/image.png", type: "image", path: "assets/chara01/image.png" });
+					expect(result3).toEqual([
+						{
+							id: "id-assets/stage01/boss.png",
+							type: "image",
+							path: "assets/stage01/boss.png"
+						},
+						{
+							id: "id-assets/chara01/image.png",
+							type: "image",
+							path: "assets/chara01/image.png"
+						},
+						{
+							id: "node_modules/@akashic-extension/some-library/assets/image.png",
+							type: "image",
+							path: "node_modules/@akashic-extension/some-library/assets/image.png"
+						},
+						{
+							id: "node_modules/@akashic-extension/some-library/assets/boss.png",
+							type: "image",
+							path: "node_modules/@akashic-extension/some-library/assets/boss.png"
+						}
+					]);
 					done();
 				}
 			);

--- a/src/__tests__/ModuleSpec.ts
+++ b/src/__tests__/ModuleSpec.ts
@@ -877,12 +877,12 @@ describe("test Module", () => {
 				});
 				const mod = module.require("./resolve1");
 				expect(mod).toEqual([
-					"script/resolve2.js",
-					"text/dummydata.txt",
-					"node_modules/libraryA/index.js",
-					"node_modules/externalResolvedModule/index.js",
-					"node_modules/externalResolvedModule/index.js",
-					"node_modules/libraryA/index.js"
+					"/script/resolve2.js",
+					"/text/dummydata.txt",
+					"/node_modules/libraryA/index.js",
+					"/node_modules/externalResolvedModule/index.js",
+					"/node_modules/externalResolvedModule/index.js",
+					"/node_modules/libraryA/index.js"
 				]);
 				done();
 			});


### PR DESCRIPTION
## このpull requestが解決する内容
#263 の後続作業です。
`AssetAccessor#peekLiveAssetByAccessorPath()` で指定されたパスの先頭に game.json の `moduleMainScripts` のキーが存在した場合、その実態である場所へと読み替えます。

## コードイメージ

### 外部モジュール

#### @akashic/sample

```javascript
module.exports = (scene) => {
  const src = scene.asset.getImage(require.resolve("../assets/image/player.png")); // #263 で追加済み: e.g. "/node_modules/@akashic/sample/assets/image/player.png"
  return new g.Sprite({
    src,
    ...
  });
};
```

### 利用側

#### エントリポイント
```javascript
var createSprite = require("@akashic/sample");

...

module.exports = () => {
  ...
  const scene = new g.Scene({
    ...
    assetPaths: [
      "@akashic/sample/assets/image/*.png" // 今回追加: e.g. "node_modules/@akashic/sample/assets/image/player.png"
    ]
  });
  scene.onLoad.addOnce(() => {
    const sprite = createSprite(scene);
    ...
  });

  ...
};

```

#### game.json

```javascript
{
  ...
  assets: {
    ...
    "node_modules/@akashic/sample/assets/image/player": {
      "type": "image",
      "width": 32,
      "height": 32,
      "path": "node_modules/@akashic/sample/assets/image/player.png"
    },
    ...
  }
  ...
  "moduleMainScripts": {
    "@akashic/sample": "node_modules/@akashic/sample/lib/index.js"
  }
  ...
}
```

## 破壊的な変更を含んでいるか?

- 部分的に **あり**
  - #263 にて追加したいくつかのメソッドの名前・処理を変更しています
    - unrelease なので外部的な影響はありません