### PR TITLE
initialize _scriptCaches when reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## Unreleased chnages
+* `g.Game#_reset()` 実行時に `g.ModuleManager#_scriptCaches` を初期化する処理を追加
+
 ## 3.0.2
 * @akashic/pdi-types@1.1.1 に更新
 * `g.Player#id` の型を `string | undefined` に修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## Unreleased chnages
+## 3.0.3
 * `g.Game#_reset()` 実行時に `g.Game#_moduleManager` を初期化する処理を追加
 
 ## 3.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # ChangeLog
 
 ## Unreleased chnages
-* `g.Game#_reset()` 実行時に `g.ModuleManager#_scriptCaches` を初期化する処理を追加
+* `g.Game#_reset()` 実行時に `g.Game#_moduleManager` を初期化する処理を追加
 
 ## 3.0.2
 * @akashic/pdi-types@1.1.1 に更新

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8279,9 +8279,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.18.0.tgz",
-      "integrity": "sha512-D9Tu8nE3E7D1Bsf/V29oMHceMf+gnVO+pDguk/A5YRo1cLpkiQ48ZnbbS57pvvHeY+OIeNQx1vf4ASPlEtRpcA==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.19.0.tgz",
+      "integrity": "sha512-A7BaLUPvcQ1cxVu72YfD+UMI3SQPTDv/w4ol6TOwLyI0hwfG9EC+cYlhdflJTmtYTgZ3KqdPSe/otxU4K3kArg==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -845,7 +845,7 @@ export class Game {
 		this._mainParameter = undefined;
 		this._configuration = gameConfiguration;
 		this._assetManager = new AssetManager(this, gameConfiguration.assets, gameConfiguration.audio, gameConfiguration.moduleMainScripts);
-		this._moduleManager = new ModuleManager(this._runtimeValueBase, this._assetManager);
+		this._moduleManager = undefined!;
 
 		const operationPluginsField = gameConfiguration.operationPlugins || [];
 		this.operationPluginManager = new OperationPluginManager(this, param.operationPluginViewInfo || null, operationPluginsField);
@@ -1479,6 +1479,7 @@ export class Game {
 		this._postTickTasks = [];
 		this.surfaceAtlasSet.destroy();
 		this.surfaceAtlasSet = undefined!;
+		this._moduleManager = undefined!;
 	}
 
 	/**

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1354,6 +1354,7 @@ export class Game {
 
 		this._isTerminated = false;
 		this.vars = {};
+		this._moduleManager._scriptCaches = {};
 
 		this.surfaceAtlasSet.destroy();
 		this.surfaceAtlasSet = new SurfaceAtlasSet({ resourceFactory: this.resourceFactory });

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1354,7 +1354,7 @@ export class Game {
 
 		this._isTerminated = false;
 		this.vars = {};
-		this._moduleManager._scriptCaches = {};
+		this._moduleManager = new ModuleManager(this._runtimeValueBase, this._assetManager);
 
 		this.surfaceAtlasSet.destroy();
 		this.surfaceAtlasSet = new SurfaceAtlasSet({ resourceFactory: this.resourceFactory });

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -39,6 +39,7 @@ describe("test Game", () => {
 		expect(game._onSceneChange).not.toBeUndefined();
 		expect(game).toHaveProperty("_assetManager");
 		expect(game).toHaveProperty("_initialScene");
+		expect(game._moduleManager).toBeDefined();
 	});
 
 	it("_destroy()", () => {
@@ -56,6 +57,7 @@ describe("test Game", () => {
 		expect(game.onSkipChange).toBeUndefined();
 		expect(game.onSceneChange).toBeUndefined();
 		expect(game._onSceneChange).toBeUndefined();
+		expect(game._moduleManager).toBeUndefined();
 	});
 
 	it("global assets", done => {

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -885,6 +885,9 @@ describe("test Game", () => {
 				local: "interpolate-local",
 				tickGenerationMode: "by-clock"
 			}); // scene2
+			// ScriptAssetのrequire後にキャッシュができていることを確認
+			game._moduleManager._require("./script/mainScene.js");
+			expect(game._moduleManager._scriptCaches).toHaveProperty("script/mainScene.js");
 
 			const randGen1 = new XorshiftRandomGenerator(10);
 			game._pointEventResolver.pointDown({
@@ -913,6 +916,8 @@ describe("test Game", () => {
 			// reset で Game#onSceneChange は removeAll() されるが、Game#_onSceneChange は removeAll() されないことを確認
 			expect(game.onSceneChange.length).toBe(0);
 			expect(game._onSceneChange.length).not.toBe(0);
+			// reset後、ScriptAssetのキャッシュが消えていることを確認
+			expect(game._moduleManager._scriptCaches).toEqual({});
 			done();
 		});
 		game._loadAndStart();

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -885,9 +885,6 @@ describe("test Game", () => {
 				local: "interpolate-local",
 				tickGenerationMode: "by-clock"
 			}); // scene2
-			// ScriptAssetのrequire後にキャッシュができていることを確認
-			game._moduleManager._require("./script/mainScene.js");
-			expect(game._moduleManager._scriptCaches).toHaveProperty("script/mainScene.js");
 
 			const randGen1 = new XorshiftRandomGenerator(10);
 			game._pointEventResolver.pointDown({
@@ -895,6 +892,7 @@ describe("test Game", () => {
 				identifier: 0,
 				offset: { x: 0, y: 0 }
 			});
+			const moduleManagerBeforeReset = game._moduleManager;
 			game._reset({
 				age: 3,
 				randSeed: 10,
@@ -916,8 +914,8 @@ describe("test Game", () => {
 			// reset で Game#onSceneChange は removeAll() されるが、Game#_onSceneChange は removeAll() されないことを確認
 			expect(game.onSceneChange.length).toBe(0);
 			expect(game._onSceneChange.length).not.toBe(0);
-			// reset後、ScriptAssetのキャッシュが消えていることを確認
-			expect(game._moduleManager._scriptCaches).toEqual({});
+			// reset後、Game#_moduleManagerが作り直されていることを確認
+			expect(game._moduleManager).not.toBe(moduleManagerBeforeReset);
 			done();
 		});
 		game._loadAndStart();

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -892,7 +892,7 @@ describe("test Game", () => {
 				identifier: 0,
 				offset: { x: 0, y: 0 }
 			});
-			const moduleManagerBeforeReset = game._moduleManager;
+			const moduleManager = game._moduleManager;
 			game._reset({
 				age: 3,
 				randSeed: 10,
@@ -915,7 +915,7 @@ describe("test Game", () => {
 			expect(game.onSceneChange.length).toBe(0);
 			expect(game._onSceneChange.length).not.toBe(0);
 			// reset後、Game#_moduleManagerが作り直されていることを確認
-			expect(game._moduleManager).not.toBe(moduleManagerBeforeReset);
+			expect(game._moduleManager).not.toBe(moduleManager);
 			done();
 		});
 		game._loadAndStart();


### PR DESCRIPTION
## このpull requestが解決する内容

- `g.Game#_reset()` 実行時に `g.ModuleManager#_scriptCaches` を初期化する処理を追加
  - これを行わないと、g.Fontが`g.Scene.onLoad()`の外で定義されていた場合、リプレイ時に`g.ModuleManager#_scriptCaches`に登録されている古いFontを参照しにいってエラーが発生してしまう
  - ちなみに、v2とv1では既にこの対応は行われているのでv3のみの問題であることが分かった(おそらくv3移行作業中に漏れがあった？)。

## 破壊的な変更を含んでいるか?

- なし
