### PR TITLE
Add g.Collision#intersectEntities()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## unreleased changes
+
+機能追加
+ * `g.Collision.intersectEntities()` を追加
+   * 同一シーン内の任意のエンティティ同士の矩形が重なっているかどうか判定することができます。
+
 ## 3.0.1
 
 機能追加

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 機能追加
  * `g.Collision.intersectEntities()` を追加
    * 同一シーン内の任意のエンティティ同士の矩形が重なっているかどうか判定することができます。
+ * `g.Collision.intersectLineSegments()` を追加
+   * 線分同士の衝突 (交差) を判定することができます。
 
 ## 3.0.1
 

--- a/src/Collision.ts
+++ b/src/Collision.ts
@@ -12,9 +12,7 @@ function sub(v1: CommonOffset, v2: CommonOffset): CommonOffset {
 }
 
 /**
- * オブジェクトの衝突判定機能を提供する。
- *
- * 距離による判定・矩形交差による判定、エンティティの親子関係を踏まえた低速だが厳密な判定
+ * オブジェクトなどの衝突判定機能を提供する。
  */
 export module Collision {
 	/**

--- a/src/Collision.ts
+++ b/src/Collision.ts
@@ -7,6 +7,7 @@ function absCross(v1: CommonOffset, v2: CommonOffset): number {
 	return v1.x * v2.y - v1.y * v2.x;
 }
 
+// 二次元ベクトルの減算
 function sub(v1: CommonOffset, v2: CommonOffset): CommonOffset {
 	return { x: v1.x - v2.x, y: v1.y - v2.y };
 }

--- a/src/Collision.ts
+++ b/src/Collision.ts
@@ -1,5 +1,45 @@
-import { CommonArea } from "@akashic/pdi-types";
+import { CommonArea, CommonOffset } from "@akashic/pdi-types";
+import { E } from "./entities/E";
 import { Util } from "./Util";
+
+// TODO collision-js を部分的に統合する？
+type Vec2 = CommonOffset;
+
+function dot(v1: Vec2, v2: Vec2): number {
+	return v1.x * v2.x + v1.y * v2.y;
+}
+
+function normalize(v: Vec2): Vec2 {
+	const len = Math.sqrt(dot(v, v));
+	v.x /= len;
+	v.y /= len;
+	return v;
+}
+
+/**
+ * 線分と、線分に重なる直線に投影した矩形の交差判定。
+ * @param lt 矩形の頂点の一つ
+ * @param rt 矩形の頂点の一つ
+ * @param lb 矩形の頂点の一つ
+ * @param rb 矩形の頂点の一つ
+ * @param p0 線分の一端
+ * @param p1 線分の一端
+ */
+function overlapBoxAndSegment(lt: Vec2, rt: Vec2, lb: Vec2, rb: Vec2, p0: Vec2, p1: Vec2): boolean {
+	const dir = normalize({ x: p1.x - p0.x, y: p1.y - p0.y });
+	const tp0 = dot(p0, dir);
+	const tp1 = dot(p1, dir);
+	const tlt = dot(lt, dir);
+	const trt = dot(rt, dir);
+	const tlb = dot(lb, dir);
+	const trb = dot(rb, dir);
+
+	const tpMin = Math.min(tp0, tp1);
+	const tpMax = Math.max(tp0, tp1);
+	const tbMin = Math.min(tlt, trt, tlb, trb);
+	const tbMax = Math.max(tlt, trt, tlb, trb);
+	return !(tbMax < tpMin || tpMax < tbMin);
+}
 
 /**
  * オブジェクトの衝突を表す。
@@ -7,6 +47,72 @@ import { Util } from "./Util";
  * - 2点間の距離による衝突
  */
 export module Collision {
+	/**
+	 * 二つのエンティティの衝突判定を行い、その結果を返す。
+	 *
+	 * 回転・拡大されたエンティティや、親の異なるエンティティ同士も扱える汎用の衝突判定処理。
+	 * ただし計算量が多いので、大量のオブジェクトとの判定には不向きである。
+	 * 親が同じで回転や拡大を行わないエンティティ同士の場合は、より軽量な Collision.intersectAreas() を利用すること。
+	 * 親が同じで中心座標同士の距離だけで判定してよい場合は、より軽量な Collision.withinAreas() を利用すること。
+	 *
+	 * エンティティの座標などを変更した場合、そのエンティティの modified() を呼び出しておく必要がある。
+	 *
+	 * @param e1 衝突判定するエンティティ
+	 * @param e2 衝突判定するエンティティ
+	 * @param area1 e1 の当たり判定領域。省略された場合、{ x: 0, y: 0, width: e1.width, hegiht: e1.height }
+	 * @param area2 e2 の当たり判定領域。省略された場合、{ x: 0, y: 0, width: e2.width, hegiht: e2.height }
+	 */
+	export function intersectEntities(e1: E, e2: E, area1?: CommonArea, area2?: CommonArea): boolean {
+		const lca = e1.findLowestCommonAncestorWith(e2);
+		if (!lca) return false;
+
+		let l1 = 0,
+			t1 = 0,
+			r1: number,
+			b1: number;
+		let l2 = 0,
+			t2 = 0,
+			r2: number,
+			b2: number;
+		if (area1) {
+			l1 = area1.x;
+			t1 = area1.y;
+			r1 = l1 + area1.width;
+			b1 = t1 + area1.height;
+		} else {
+			r1 = e1.width;
+			b1 = e1.height;
+		}
+		if (area2) {
+			l2 = area2.x;
+			t2 = area2.y;
+			r2 = l2 + area2.width;
+			b2 = t2 + area2.height;
+		} else {
+			r2 = e2.width;
+			b2 = e2.height;
+		}
+		const mat1 = e1.calculateMatrixTo(lca);
+		const mat2 = e2.calculateMatrixTo(lca);
+
+		// LCA の座標系に合わせたそれぞれの四隅の点
+		const lt1 = mat1.multiplyPoint({ x: l1, y: t1 });
+		const rt1 = mat1.multiplyPoint({ x: r1, y: t1 });
+		const lb1 = mat1.multiplyPoint({ x: l1, y: b1 });
+		const rb1 = mat1.multiplyPoint({ x: r1, y: b1 });
+		const lt2 = mat2.multiplyPoint({ x: l2, y: t2 });
+		const rt2 = mat2.multiplyPoint({ x: r2, y: t2 });
+		const lb2 = mat2.multiplyPoint({ x: l2, y: b2 });
+		const rb2 = mat2.multiplyPoint({ x: r2, y: b2 });
+
+		return (
+			overlapBoxAndSegment(lt1, rt1, lb1, rb1, lt2, rt2) &&
+			overlapBoxAndSegment(lt1, rt1, lb1, rb1, lt2, lb2) &&
+			overlapBoxAndSegment(lt2, rt2, lb2, rb2, lt1, rt1) &&
+			overlapBoxAndSegment(lt2, rt2, lb2, rb2, lt1, lb1)
+		);
+	}
+
 	/**
 	 * 矩形交差による衝突判定を行い、その結果を返す。
 	 * 戻り値は、矩形t1, t2が交差しているとき真、でなければ偽。
@@ -45,10 +151,10 @@ export module Collision {
 	/**
 	 * 2点間の距離による衝突判定を行い、その結果を返す。
 	 * 戻り値は、2点間の距離が閾値以内であるとき真、でなければ偽。
-	 * @param {number} t1x t1-X
-	 * @param {number} t1y t1-X
-	 * @param {number} t2x t1-X
-	 * @param {number} t2y t1-X
+	 * @param {number} t1x 一点の X 座標
+	 * @param {number} t1y 一点の Y 座標
+	 * @param {number} t2x もう一点の X 座標
+	 * @param {number} t2y もう一点の Y 座標
 	 * @param {number} [distance=1] 衝突判定閾値 [pixel]
 	 */
 	export function within(t1x: number, t1y: number, t2x: number, t2y: number, distance: number = 1): boolean {

--- a/src/Matrix.ts
+++ b/src/Matrix.ts
@@ -219,8 +219,8 @@ export class PlainMatrix {
 		//    R: angle度だけ回転する変換
 		//    T: x, yの値だけ平行移動する変換
 		// それらは次のように表せる:
-		//           1    0   -w           sx    0    0            c   -s    0            1    0    x-w
-		//    A = [  0    1   -h]    S = [  0   sy    0]    R = [  s    c    0]    T = [  0    1    y-h]
+		//           1    0   -w           sx    0    0            c   -s    0            1    0    x
+		//    A = [  0    1   -h]    S = [  0   sy    0]    R = [  s    c    0]    T = [  0    1    y]
 		//           0    0    1            0    0    1            0    0    1            0    0    1
 		// ここで sx, sy は scaleX, scaleY であり、c, s は cos(theta), sin(theta)
 		// (ただし theta = angle * PI / 180)、w = anchorX * width, h = anchorY * height である。

--- a/src/Object2D.ts
+++ b/src/Object2D.ts
@@ -146,7 +146,7 @@ export class Object2D implements CommonArea {
 	scaleY: number;
 
 	/**
-	 * オブジェクトの回転。度数で指定する。
+	 * オブジェクトの回転。度数 (時計回り) で指定する。
 	 * 初期値は `0` である。
 	 * `E` や `Camera2D` においてこの値を変更した場合、 `modified()` を呼び出す必要がある。
 	 */

--- a/src/__tests__/CollisionSpec.ts
+++ b/src/__tests__/CollisionSpec.ts
@@ -1,4 +1,99 @@
-import { Collision } from "..";
+import { E, Collision } from "..";
+import { skeletonRuntime } from "./helpers";
+
+describe("Collision.intersectEntities()", () => {
+	const runtime = skeletonRuntime();
+	const scene = runtime.scene;
+
+	it("disconnected", () => {
+		const e1 = new E({ scene, parent: scene, x: 10, y: 10, width: 20, height: 30 });
+		const e2 = new E({ scene, x: 28, y: 38, width: 20, height: 30 });
+		expect(Collision.intersectEntities(e1, e2)).toBe(false);
+	});
+
+	it("children of the scene, no scale, no rotation", () => {
+		const e1 = new E({ scene, parent: scene, x: 10, y: 10, width: 20, height: 30 });
+		const e2 = new E({ scene, parent: scene, x: 28, y: 38, width: 20, height: 30 });
+		expect(Collision.intersectEntities(e1, e2)).toBe(true);
+		e2.x += 10;
+		e2.modified();
+		expect(Collision.intersectEntities(e1, e2)).toBe(false);
+	});
+
+	it("brothers, scaled, no rotation", () => {
+		const parent = new E({ scene, parent: scene, x: 100, y: 100 });
+		const e1 = new E({ scene, parent: parent, x: 10, y: 10, width: 20, height: 30, scaleX: 1.5, scaleY: 1.5 });
+		const e2 = new E({ scene, parent: parent, x: 35, y: 45, width: 20, height: 30 });
+		expect(Collision.intersectEntities(e1, e2)).toBe(true);
+		e1.scaleX = e1.scaleY = 0.9;
+		e1.modified();
+		expect(Collision.intersectEntities(e1, e2)).toBe(false);
+	});
+
+	it("brothers, no scale, rotated", () => {
+		const parent = new E({ scene, parent: scene, x: 100, y: 100 });
+		const e1 = new E({ scene, parent: parent, x: 10, y: 10, width: 20, height: 30, angle: 3 });
+		const e2 = new E({ scene, parent: parent, x: 28, y: 38, width: 20, height: 30 });
+		expect(Collision.intersectEntities(e1, e2)).toBe(true);
+		e1.angle = 180;
+		e1.modified();
+		expect(Collision.intersectEntities(e1, e2)).toBe(false);
+	});
+
+	it("brothers, scaled, rotated", () => {
+		const parent = new E({ scene, parent: scene, x: 100, y: 100 });
+		const e1 = new E({ scene, parent: parent, x: 10, y: 10, width: 20, height: 30, scaleX: 1.5, scaleY: 1.5, angle: 90 });
+		const e2 = new E({ scene, parent: parent, x: 35, y: 45, width: 20, height: 30 });
+		expect(Collision.intersectEntities(e1, e2)).toBe(false);
+		e1.angle = 5;
+		e1.modified();
+		expect(Collision.intersectEntities(e1, e2)).toBe(true);
+	});
+
+	it("cousin, scaled, rotation", () => {
+		const root = new E({ scene, parent: scene, x: 100, y: 100 });
+
+		// 原点 (200, 100), 90 度回転
+		const p1 = new E({ scene, parent: root, x: 100, y: 0, width: 10, height: 10, angle: 90 });
+		// 原点 (100, 230), X 軸 2 倍拡大
+		const p2 = new E({ scene, parent: root, x: 0, y: 130, width: 10, height: 10, scaleX: 2 });
+
+		// 原点 (200, 200), 左上端 (50, 100), サイズ 50x50
+		const e1 = new E({ scene, parent: p1, x: 100, y: 0, width: 50, height: 50 });
+		// 原点＝左上端 (120, 230), サイズ 40x50
+		const e2 = new E({ scene, parent: p2, x: 10, y: 0, width: 20, height: 50 });
+
+		expect(Collision.intersectEntities(e1, e2)).toBe(true);
+
+		p2.scaleX = 1;
+		p2.modified();
+		expect(Collision.intersectEntities(e1, e2)).toBe(false);
+
+		p2.scaleX = 2;
+		p2.modified();
+		p1.angle = 45;
+		p1.modified();
+		expect(Collision.intersectEntities(e1, e2)).toBe(false);
+	});
+
+	it("cousin, scaled, rotation, with hit rects", () => {
+		const root = new E({ scene, parent: scene, x: 100, y: 100 });
+
+		// 原点 (200, 100), 90 度回転
+		const p1 = new E({ scene, parent: root, x: 100, y: 0, width: 10, height: 10, angle: 90 });
+		// 原点 (100, 230), X 軸 2 倍拡大
+		const p2 = new E({ scene, parent: root, x: 0, y: 130, width: 10, height: 10, scaleX: 2 });
+
+		// 原点 (200, 200), 左上端 (50, 100), サイズ 50x50
+		const e1 = new E({ scene, parent: p1, x: 100, y: 0, width: 50, height: 50 });
+		// 原点＝左上端 (120, 230), サイズ 40x50
+		const e2 = new E({ scene, parent: p2, x: 10, y: 0, width: 20, height: 50 });
+
+		const e2h = e2.height;
+		expect(Collision.intersectEntities(e1, e2, null, { x: 0, y: e2h / 2, width: e2.width, height: e2h })).toBe(false);
+		expect(Collision.intersectEntities(e1, e2, { x: 0, y: 0, width: e1.width / 2, height: e1.height } , null)).toBe(false);
+	});
+});
 
 describe("Collision.intersect()", () => {
 	it("Hit", () => {

--- a/src/__tests__/CollisionSpec.ts
+++ b/src/__tests__/CollisionSpec.ts
@@ -1,6 +1,24 @@
 import { E, Collision } from "..";
 import { skeletonRuntime } from "./helpers";
 
+describe("Collision.intersectEdges()", () => {
+	it("is true for crossing edges", () => {
+		expect(Collision.intersectEdges({ x: 2, y: 1 }, { x: 3, y: 4 }, { x: 1, y: 3 }, { x: 3, y: 3 })).toBe(true);
+	});
+	it("is true for identical edges", () => {
+		expect(Collision.intersectEdges({ x: 2, y: 1 }, { x: 3, y: 4 }, { x: 3, y: 4 }, { x: 2, y: 1 })).toBe(true);
+	});
+	it("is true for contacting edges", () => {
+		expect(Collision.intersectEdges({ x: 3, y: 4 }, { x: 2, y: 1 }, { x: 1, y: 3 }, { x: 3, y: 4 })).toBe(true);
+	});
+	it("is false for horizontally non-crossing edges", () => {
+		expect(Collision.intersectEdges({ x: 3, y: 4 }, { x: 2, y: 1 }, { x: 1, y: 3 }, { x: 2, y: 2 })).toBe(false);
+	});
+	it("is false for vertically non-crossing edges", () => {
+		expect(Collision.intersectEdges({ x: 3, y: 4 }, { x: 2, y: 1 }, { x: 1, y: -1 }, { x: 4, y: 1 })).toBe(false);
+	});
+});
+
 describe("Collision.intersectEntities()", () => {
 	const runtime = skeletonRuntime();
 	const scene = runtime.scene;
@@ -91,7 +109,7 @@ describe("Collision.intersectEntities()", () => {
 
 		const e2h = e2.height;
 		expect(Collision.intersectEntities(e1, e2, null, { x: 0, y: e2h / 2, width: e2.width, height: e2h })).toBe(false);
-		expect(Collision.intersectEntities(e1, e2, { x: 0, y: 0, width: e1.width / 2, height: e1.height } , null)).toBe(false);
+		expect(Collision.intersectEntities(e1, e2, { x: 0, y: 0, width: e1.width / 2, height: e1.height }, null)).toBe(false);
 	});
 });
 

--- a/src/__tests__/CollisionSpec.ts
+++ b/src/__tests__/CollisionSpec.ts
@@ -1,21 +1,21 @@
 import { E, Collision } from "..";
 import { skeletonRuntime } from "./helpers";
 
-describe("Collision.intersectEdges()", () => {
+describe("Collision.intersectLineSegments()", () => {
 	it("is true for crossing edges", () => {
-		expect(Collision.intersectEdges({ x: 2, y: 1 }, { x: 3, y: 4 }, { x: 1, y: 3 }, { x: 3, y: 3 })).toBe(true);
+		expect(Collision.intersectLineSegments({ x: 2, y: 1 }, { x: 3, y: 4 }, { x: 1, y: 3 }, { x: 3, y: 3 })).toBe(true);
 	});
 	it("is true for identical edges", () => {
-		expect(Collision.intersectEdges({ x: 2, y: 1 }, { x: 3, y: 4 }, { x: 3, y: 4 }, { x: 2, y: 1 })).toBe(true);
+		expect(Collision.intersectLineSegments({ x: 2, y: 1 }, { x: 3, y: 4 }, { x: 3, y: 4 }, { x: 2, y: 1 })).toBe(true);
 	});
 	it("is true for contacting edges", () => {
-		expect(Collision.intersectEdges({ x: 3, y: 4 }, { x: 2, y: 1 }, { x: 1, y: 3 }, { x: 3, y: 4 })).toBe(true);
+		expect(Collision.intersectLineSegments({ x: 3, y: 4 }, { x: 2, y: 1 }, { x: 1, y: 3 }, { x: 3, y: 4 })).toBe(true);
 	});
 	it("is false for horizontally non-crossing edges", () => {
-		expect(Collision.intersectEdges({ x: 3, y: 4 }, { x: 2, y: 1 }, { x: 1, y: 3 }, { x: 2, y: 2 })).toBe(false);
+		expect(Collision.intersectLineSegments({ x: 3, y: 4 }, { x: 2, y: 1 }, { x: 1, y: 3 }, { x: 2, y: 2 })).toBe(false);
 	});
 	it("is false for vertically non-crossing edges", () => {
-		expect(Collision.intersectEdges({ x: 3, y: 4 }, { x: 2, y: 1 }, { x: 1, y: -1 }, { x: 4, y: 1 })).toBe(false);
+		expect(Collision.intersectLineSegments({ x: 3, y: 4 }, { x: 2, y: 1 }, { x: 1, y: -1 }, { x: 4, y: 1 })).toBe(false);
 	});
 });
 

--- a/src/entities/E.ts
+++ b/src/entities/E.ts
@@ -733,7 +733,7 @@ export class E extends Object2D implements CommonArea {
 
 	/**
 	 * このエンティティと与えられたエンティティの共通祖先のうち、もっとも子孫側にあるものを探す。
-	 * 共通祖先がない場合、 `undfined` を返す。
+	 * 共通祖先がない場合、 `undefined` を返す。
 	 *
 	 * @param target このエンティティとの共通祖先を探すエンティティ
 	 */

--- a/src/entities/E.ts
+++ b/src/entities/E.ts
@@ -715,6 +715,14 @@ export class E extends Object2D implements CommonArea {
 		return matrix.multiplyInverseForPoint(offset);
 	}
 
+	/**
+	 * このエンティティの座標系を、指定された祖先エンティティ (またはシーン) の座標系に変換する行列を求める。
+	 *
+	 * 指定されたエンティティが、このエンティティの祖先でない時、その値は無視される。
+	 * 指定されたシーンが、このエンティティの属するシーン出ない時、その値は無視される。
+	 *
+	 * @param target 座標系の変換先エンティティまたはシーン。省略した場合、このエンティティの属するシーン(グローバル座標系への変換行列になる)
+	 */
 	calculateMatrixTo(target?: E | Scene): Matrix {
 		let matrix: Matrix = new PlainMatrix();
 		for (let entity: E | Scene | undefined = this; entity instanceof E && entity !== target; entity = entity.parent) {
@@ -723,6 +731,12 @@ export class E extends Object2D implements CommonArea {
 		return matrix;
 	}
 
+	/**
+	 * このエンティティと与えられたエンティティの共通祖先のうち、もっとも子孫側にあるものを探す。
+	 * 共通祖先がない場合、 `undfined` を返す。
+	 *
+	 * @param target このエンティティとの共通祖先を探すエンティティ
+	 */
 	findLowestCommonAncestorWith(target: E): E | Scene | undefined {
 		const seen: { [id: number]: boolean } = {};
 		for (let p: E | Scene | undefined = this; p instanceof E; p = p.parent) {

--- a/src/entities/E.ts
+++ b/src/entities/E.ts
@@ -697,7 +697,6 @@ export class E extends Object2D implements CommonArea {
 	 */
 	localToGlobal(offset: CommonOffset): CommonOffset {
 		let point = offset;
-		// TODO: Scene#root が追加されたらループ継続判定文を書き換える
 		for (let entity: E | Scene | undefined = this; entity instanceof E; entity = entity.parent) {
 			point = entity.getMatrix().multiplyPoint(point);
 		}
@@ -710,11 +709,30 @@ export class E extends Object2D implements CommonArea {
 	 */
 	globalToLocal(offset: CommonOffset): CommonOffset {
 		let matrix: Matrix = new PlainMatrix();
-		// TODO: Scene#root が追加されたらループ継続判定文を書き換える
 		for (let entity: E | Scene | undefined = this; entity instanceof E; entity = entity.parent) {
 			matrix.multiplyLeft(entity.getMatrix());
 		}
 		return matrix.multiplyInverseForPoint(offset);
+	}
+
+	calculateMatrixTo(target?: E | Scene): Matrix {
+		let matrix: Matrix = new PlainMatrix();
+		for (let entity: E | Scene | undefined = this; entity instanceof E && entity !== target; entity = entity.parent) {
+			matrix.multiplyLeft(entity.getMatrix());
+		}
+		return matrix;
+	}
+
+	findLowestCommonAncestorWith(target: E): E | Scene | undefined {
+		const seen: { [id: number]: boolean } = {};
+		for (let p: E | Scene | undefined = this; p instanceof E; p = p.parent) {
+			seen[p.id] = true;
+		}
+		let ret: E | Scene | undefined = target;
+		for (; ret instanceof E; ret = ret.parent) {
+			if (seen.hasOwnProperty(ret.id)) break;
+		}
+		return ret;
 	}
 
 	/**


### PR DESCRIPTION
## このpull requestが解決する内容

掲題どおり。

従来、親 (＝座標系) が異なるエンティティ同士や、回転・拡大されたエンティティの衝突判定を手軽に行う方法はありませんでした。 

~~[collision-js](https://github.com/akashic-games/collision-js) で後者は手軽に行えるようになりましたが、座標系の違いは補う必要があり、またそれを無駄なく行う方法も自明ではありませんでした。機能的に collision-js といささか重複しますが、~~ 簡便のためエンティティ同士の衝突を判定するメソッドを `g.Collision` に追加します。

追記: 上の認識は誤りでした。 collision-js が提供する矩形の衝突判定 `boxToBox()` は矩形 (すべての内角が等しい) 専用で、回転・拡大はともかく親の変換行列の影響を受けた状態には利用できませんでした。凸多角形 (convex) である四角形の衝突判定としてここで独自に実装します。参考:  https://ksta.skr.jp/topic/diaryb09.html

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

