### PR TITLE
feat: make several unpublished matrix routines of E private

### DIFF
--- a/src/Collision.ts
+++ b/src/Collision.ts
@@ -33,7 +33,7 @@ export module Collision {
 	 * @param area2 e2 の当たり判定領域。省略された場合、`{ x: 0, y: 0, width: e2.width, hegiht: e2.height }`
 	 */
 	export function intersectEntities(e1: E, e2: E, area1?: CommonArea | null, area2?: CommonArea | null): boolean {
-		const lca = e1.findLowestCommonAncestorWith(e2);
+		const lca = e1._findLowestCommonAncestorWith(e2);
 		if (!lca) return false;
 
 		const r1 = area1
@@ -43,8 +43,8 @@ export module Collision {
 			? { left: area2.x, top: area2.y, right: area2.x + area2.width, bottom: area2.y + area2.height }
 			: { left: 0, top: 0, right: e2.width, bottom: e2.height };
 
-		const mat1 = e1.calculateMatrixTo(lca);
-		const mat2 = e2.calculateMatrixTo(lca);
+		const mat1 = e1._calculateMatrixTo(lca);
+		const mat2 = e2._calculateMatrixTo(lca);
 
 		// 座標系を合わせる: 共通祖先の座標系に合わせたそれぞれの四隅の点を求める。
 		const lt1 = mat1.multiplyPoint({ x: r1.left, y: r1.top });

--- a/src/entities/E.ts
+++ b/src/entities/E.ts
@@ -722,8 +722,9 @@ export class E extends Object2D implements CommonArea {
 	 * 指定されたシーンが、このエンティティの属するシーン出ない時、その値は無視される。
 	 *
 	 * @param target 座標系の変換先エンティティまたはシーン。省略した場合、このエンティティの属するシーン(グローバル座標系への変換行列になる)
+	 * @private
 	 */
-	calculateMatrixTo(target?: E | Scene): Matrix {
+	_calculateMatrixTo(target?: E | Scene): Matrix {
 		let matrix: Matrix = new PlainMatrix();
 		for (let entity: E | Scene | undefined = this; entity instanceof E && entity !== target; entity = entity.parent) {
 			matrix.multiplyLeft(entity.getMatrix());
@@ -736,8 +737,9 @@ export class E extends Object2D implements CommonArea {
 	 * 共通祖先がない場合、 `undefined` を返す。
 	 *
 	 * @param target このエンティティとの共通祖先を探すエンティティ
+	 * @private
 	 */
-	findLowestCommonAncestorWith(target: E): E | Scene | undefined {
+	_findLowestCommonAncestorWith(target: E): E | Scene | undefined {
 		const seen: { [id: number]: boolean } = {};
 		for (let p: E | Scene | undefined = this; p instanceof E; p = p.parent) {
 			seen[p.id] = true;


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->

#268 で追加した `E#calculateMatrixTo()` など一部のメソッドをエンジン内部用 (`_` -prefixed) にします。行列の持ち方を再検討する際に、公開のメソッドにしておくと互換性を維持しにくくなる可能性があるためです。

未 publish のためこのリポジトリ外に利用者はいません。もともと補助的に追加したもので CHANGELOG 記載もしていなかったため、そちらの変更もありません。

自明につきセルフマージします。

## 破壊的な変更を含んでいるか?

- なし
  - 未 publish の機能だったため

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

