### PR TITLE
Use integer position draw glyph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/entities/Label.ts
+++ b/src/entities/Label.ts
@@ -269,7 +269,15 @@ export class Label extends CacheableE {
 				// 非空白文字
 				renderer.save();
 				renderer.transform([glyphScale, 0, 0, glyphScale, 0, 0]);
-				renderer.drawImage(glyph.surface, glyph.x, glyph.y, glyph.width, glyph.height, glyph.offsetX, glyph.offsetY);
+				renderer.drawImage(
+					glyph.surface,
+					Math.round(glyph.x),
+					Math.round(glyph.y),
+					glyph.width,
+					glyph.height,
+					glyph.offsetX,
+					glyph.offsetY
+				);
 				renderer.restore();
 			}
 			renderer.translate(glyphWidth, 0);

--- a/src/entities/Label.ts
+++ b/src/entities/Label.ts
@@ -252,6 +252,7 @@ export class Label extends CacheableE {
 
 		renderer.save();
 		var glyphScale = this.fontSize / this.font.size;
+		var cumulativeoffset = 0;
 		for (var i = 0; i < this.glyphs.length; ++i) {
 			let glyph: Glyph | null = this.glyphs[i];
 			var glyphWidth = glyph.advanceWidth * glyphScale;
@@ -268,19 +269,12 @@ export class Label extends CacheableE {
 			if (glyph.surface) {
 				// 非空白文字
 				renderer.save();
+				renderer.translate(Math.round(cumulativeoffset), 0);
 				renderer.transform([glyphScale, 0, 0, glyphScale, 0, 0]);
-				renderer.drawImage(
-					glyph.surface,
-					glyph.x,
-					glyph.y,
-					glyph.width,
-					glyph.height,
-					glyph.offsetX,
-					glyph.offsetY
-				);
+				renderer.drawImage(glyph.surface, glyph.x, glyph.y, glyph.width, glyph.height, glyph.offsetX, glyph.offsetY);
 				renderer.restore();
 			}
-			renderer.translate(Math.round(glyphWidth), 0);
+			cumulativeoffset += glyphWidth;
 		}
 		renderer.restore();
 

--- a/src/entities/Label.ts
+++ b/src/entities/Label.ts
@@ -214,14 +214,17 @@ export class Label extends CacheableE {
 				break;
 		}
 
+		const offsetX = Math.round(this.x) -  this.x;
+		const offsetY = Math.round(this.y) -  this.y;
+
 		renderer.drawImage(
 			this._cache!,
 			0,
 			0,
 			this._cacheSize.width + CacheableE.PADDING,
 			this._cacheSize.height + CacheableE.PADDING,
-			destOffsetX,
-			0
+			destOffsetX + offsetX,
+			offsetY
 		);
 	}
 
@@ -271,8 +274,8 @@ export class Label extends CacheableE {
 				renderer.transform([glyphScale, 0, 0, glyphScale, 0, 0]);
 				renderer.drawImage(
 					glyph.surface,
-					Math.round(glyph.x),
-					Math.round(glyph.y),
+					glyph.x,
+					glyph.y,
 					glyph.width,
 					glyph.height,
 					glyph.offsetX,

--- a/src/entities/Label.ts
+++ b/src/entities/Label.ts
@@ -252,7 +252,7 @@ export class Label extends CacheableE {
 
 		renderer.save();
 		var glyphScale = this.fontSize / this.font.size;
-		var cumulativeoffset = 0;
+		var cumulativeOffset = 0;
 		for (var i = 0; i < this.glyphs.length; ++i) {
 			let glyph: Glyph | null = this.glyphs[i];
 			var glyphWidth = glyph.advanceWidth * glyphScale;
@@ -269,12 +269,12 @@ export class Label extends CacheableE {
 			if (glyph.surface) {
 				// 非空白文字
 				renderer.save();
-				renderer.translate(Math.round(cumulativeoffset), 0);
+				renderer.translate(Math.round(cumulativeOffset), 0);
 				renderer.transform([glyphScale, 0, 0, glyphScale, 0, 0]);
 				renderer.drawImage(glyph.surface, glyph.x, glyph.y, glyph.width, glyph.height, glyph.offsetX, glyph.offsetY);
 				renderer.restore();
 			}
-			cumulativeoffset += glyphWidth;
+			cumulativeOffset += glyphWidth;
 		}
 		renderer.restore();
 

--- a/src/entities/Label.ts
+++ b/src/entities/Label.ts
@@ -214,18 +214,14 @@ export class Label extends CacheableE {
 				break;
 		}
 
-		// 描画が平滑化されるよう、エンティティの描画位置を整数値に修正する。
-		const offsetX = Math.round(this.x) - this.x;
-		const offsetY = Math.round(this.y) - this.y;
-
 		renderer.drawImage(
 			this._cache!,
 			0,
 			0,
 			this._cacheSize.width + CacheableE.PADDING,
 			this._cacheSize.height + CacheableE.PADDING,
-			destOffsetX + offsetX,
-			offsetY
+			destOffsetX,
+			0
 		);
 	}
 
@@ -248,7 +244,7 @@ export class Label extends CacheableE {
 				break;
 		}
 
-		renderer.translate(offsetX, 0);
+		renderer.translate(Math.round(offsetX), 0);
 
 		if (scale !== 1) {
 			renderer.transform([scale, 0, 0, 1, 0, 0]);
@@ -284,7 +280,7 @@ export class Label extends CacheableE {
 				);
 				renderer.restore();
 			}
-			renderer.translate(glyphWidth, 0);
+			renderer.translate(Math.round(glyphWidth), 0);
 		}
 		renderer.restore();
 

--- a/src/entities/Label.ts
+++ b/src/entities/Label.ts
@@ -214,6 +214,7 @@ export class Label extends CacheableE {
 				break;
 		}
 
+		// 描画が平滑化されるよう、エンティティの描画位置を整数値に修正する。
 		const offsetX = Math.round(this.x) -  this.x;
 		const offsetY = Math.round(this.y) -  this.y;
 

--- a/src/entities/Label.ts
+++ b/src/entities/Label.ts
@@ -215,8 +215,8 @@ export class Label extends CacheableE {
 		}
 
 		// 描画が平滑化されるよう、エンティティの描画位置を整数値に修正する。
-		const offsetX = Math.round(this.x) -  this.x;
-		const offsetY = Math.round(this.y) -  this.y;
+		const offsetX = Math.round(this.x) - this.x;
+		const offsetY = Math.round(this.y) - this.y;
 
 		renderer.drawImage(
 			this._cache!,


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
`g.Label` の `_cache` への描画座標を整数値にfixさせることで、小さな文字の描画における鮮明さを改善します。
 
![image](https://user-images.githubusercontent.com/3122541/113808786-b9f06380-97a1-11eb-94e1-df281a089c1f.png)
↓
![image](https://user-images.githubusercontent.com/3122541/113808797-bfe64480-97a1-11eb-898b-f4da9c02b946.png)

## 破壊的な変更を含んでいるか?

- なし
描画位置はコンテンツロジックに影響しないため、既存コンテンツへの影響はありません。


<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

