### PR TITLE
allo minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,9 @@
     "concat": "^1.0.3",
     "cpx": "^1.5.0",
     "del": "~0.1.3",
-    "uglify-js": "^2.6.0",
+    "istanbul": "^0.3.2",
     "jasmine": "^2.1.1",
     "jasmine-reporters": "~2.0.4",
-    "istanbul": "^0.3.2",
     "renamer": "^0.6.1",
     "rimraf": "^2.6.1",
     "textlint": "^5.6.0",
@@ -19,7 +18,8 @@
     "textlint-rule-prh": "^2.4.0",
     "tslint": "^5.4.3",
     "typedoc": "^0.11.1",
-    "typescript": "~2.1.6"
+    "typescript": "^2.1.6",
+    "uglify-js": "^2.6.0"
   },
   "scripts": {
     "prepare": "npm run minify && npm run doc",


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
npm7 系で peerDependency 挙動が変わったため、現状 v1-master を `npm install` できません。
これを解決するため、 TypeScript の依存バージョンをマイナーの範囲に許容します。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

