### PR TITLE
リリース時に Node 16 を利用するように修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  NODE_VERSION: 15
+  NODE_VERSION: 16
   cache-version: v1
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  NODE_VERSION: 14
+  NODE_VERSION: 15
   cache-version: v1
 
 jobs:


### PR DESCRIPTION
## このpull requestが解決する内容
原因は不明ですが Node 14 の npm だと以下の部分で正常な戻り値を取得することができずにエラーとなっていました。
https://github.com/JS-DevTools/npm-publish/blob/0f451a94170d1699fd50710966d48fb26194d939/src/npm-config.ts#L103

Node 16 に更新することで dry-run による publish まで到達していることを確認しています。
https://github.com/yu-ogi/akashic-engine/runs/3504292010

## 破壊的な変更を含んでいるか?
- なし

