### PR TITLE
enable _handleOperationPluginOperated

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -867,6 +867,7 @@ export class Game {
 		this.operationPluginManager = new OperationPluginManager(this, param.operationPluginViewInfo || null, operationPluginsField);
 		this._onOperationPluginOperated = new Trigger<InternalOperationPluginOperation>();
 		this._operationPluginOperated = this._onOperationPluginOperated;
+		this._onOperationPluginOperated.add(this._handleOperationPluginOperated, this);
 		this.operationPluginManager.onOperate.add(this._onOperationPluginOperated.fire, this._onOperationPluginOperated);
 
 		this.onSceneChange = new Trigger();


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
Akashic Engine v3 で一部の Operation Plugin を利用した際、正常に `g.OperationEvent` が発行されないことがある不具合を解消します。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

