### PR TITLE
Fix DynamicAssetConfiguration types extends from game-configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 その他変更
  * `any` 型の利用箇所を削減
+ * `DynamicAssetConfiguration` の継承関係を整理
 
 ## 3.3.0
 

--- a/src/DynamicAssetConfiguration.ts
+++ b/src/DynamicAssetConfiguration.ts
@@ -24,39 +24,42 @@ export interface DynamicAssetConfigurationBase extends AssetConfigurationCommonB
 	uri: string;
 }
 
-type OmitProperties = "type" | "path" | "virtualPath"| "global";
+// type は
+type UnneededKeysForDynamicAsset = "path" | "virtualPath"| "global";
 
 /**
  * ImageAssetの設定。
  */
- export interface DynamicImageAssetConfigurationBase extends DynamicAssetConfigurationBase, Omit<ImageAssetConfigurationBase, OmitProperties> {
-	 type: "image";
+ export interface DynamicImageAssetConfigurationBase extends Omit<DynamicAssetConfigurationBase, "type">, Omit<ImageAssetConfigurationBase, UnneededKeysForDynamicAsset> {
  }
  
+ const hoge: DynamicImageAssetConfigurationBase = {
+	 height: 1,
+	 width: 1,
+	 id: "",
+	 type: "image",
+	 uri: ""
+ }
+
 /**
  * VideoAssetの設定。
  */
-export interface DynamicVideoAssetConfigurationBase extends DynamicAssetConfigurationBase, Omit<VideoAssetConfigurationBase, OmitProperties> {
-	type: "video";
+export interface DynamicVideoAssetConfigurationBase extends Omit<DynamicAssetConfigurationBase, "type">, Omit<VideoAssetConfigurationBase, UnneededKeysForDynamicAsset> {
 }
 
 /**
  * AudioAssetの設定。
  */
-export interface DynamicAudioAssetConfigurationBase extends DynamicAssetConfigurationBase, Omit<AudioAssetConfigurationBase, OmitProperties> {
-	type: "audio";
+export interface DynamicAudioAssetConfigurationBase extends Omit<DynamicAssetConfigurationBase, "type">, Omit<AudioAssetConfigurationBase, UnneededKeysForDynamicAsset> {
 }
 
 /**
  * TextAssetの設定。
  */
-export interface DynamicTextAssetConfigurationBase extends DynamicAssetConfigurationBase, Omit<TextAssetConfigurationBase, OmitProperties> {
-	type: "text";
-}
+export interface DynamicTextAssetConfigurationBase extends Omit<DynamicAssetConfigurationBase, "type">, Omit<TextAssetConfigurationBase, UnneededKeysForDynamicAsset> {}
 
 /**
  * ScriptAssetの設定。
  */
-export interface DynamicScriptAssetConfigurationBase extends DynamicAssetConfigurationBase, Omit<ScriptAssetConfigurationBase, OmitProperties> {
-	type: "script";
+export interface DynamicScriptAssetConfigurationBase extends Omit<DynamicAssetConfigurationBase, "type">, Omit<ScriptAssetConfigurationBase, UnneededKeysForDynamicAsset> {
 }

--- a/src/DynamicAssetConfiguration.ts
+++ b/src/DynamicAssetConfiguration.ts
@@ -1,5 +1,4 @@
-import type { AssetConfigurationCommonBase, CommonAreaShortened } from "@akashic/game-configuration";
-import type { AudioAssetHint, ImageAssetHint, CommonArea } from "@akashic/pdi-types";
+import type { AssetConfigurationCommonBase, AudioAssetConfigurationBase, ImageAssetConfigurationBase, ScriptAssetConfigurationBase, TextAssetConfigurationBase, VideoAssetConfigurationBase } from "@akashic/game-configuration";
 
 export type DynamicAssetConfiguration =
 	| DynamicAudioAssetConfigurationBase
@@ -25,113 +24,39 @@ export interface DynamicAssetConfigurationBase extends AssetConfigurationCommonB
 	uri: string;
 }
 
+type OmitProperties = "type" | "path" | "virtualPath"| "global";
+
 /**
  * ImageAssetの設定。
  */
-export interface DynamicImageAssetConfigurationBase extends DynamicAssetConfigurationBase {
-	/**
-	 * Assetの種類。
-	 */
-	type: "image";
-
-	/**
-	 * 幅。
-	 */
-	width: number;
-
-	/**
-	 * 高さ。
-	 */
-	height: number;
-
-	/**
-	 * ヒント。akashic-engineが最適なパフォーマンスを発揮するための情報。
-	 */
-	hint?: ImageAssetHint;
-
-	/**
-	 * 切り出す領域。
-	 * 指定した場合、その部分だけの画像アセットとして扱う。
-	 */
-	slice?: CommonArea | CommonAreaShortened;
-}
-
+ export interface DynamicImageAssetConfigurationBase extends DynamicAssetConfigurationBase, Omit<ImageAssetConfigurationBase, OmitProperties> {
+	 type: "image";
+ }
+ 
 /**
  * VideoAssetの設定。
  */
-export interface DynamicVideoAssetConfigurationBase extends DynamicAssetConfigurationBase {
-	/**
-	 * Assetの種類。
-	 */
+export interface DynamicVideoAssetConfigurationBase extends DynamicAssetConfigurationBase, Omit<VideoAssetConfigurationBase, OmitProperties> {
 	type: "video";
-
-	/**
-	 * 幅。
-	 */
-	width: number;
-
-	/**
-	 * 高さ。
-	 */
-	height: number;
-
-	/**
-	 * ループ。
-	 */
-	loop?: boolean;
-
-	/**
-	 * width,heightではなく実サイズを用いる指定。
-	 */
-	useRealSize?: boolean;
 }
 
 /**
  * AudioAssetの設定。
  */
-export interface DynamicAudioAssetConfigurationBase extends DynamicAssetConfigurationBase {
-	/**
-	 * Assetの種類。
-	 */
+export interface DynamicAudioAssetConfigurationBase extends DynamicAssetConfigurationBase, Omit<AudioAssetConfigurationBase, OmitProperties> {
 	type: "audio";
-
-	/**
-	 * AudioAssetのsystem指定。
-	 */
-	systemId: "music" | "sound";
-
-	/**
-	 * 再生時間。
-	 */
-	duration: number;
-
-	/**
-	 * ループ。
-	 */
-	loop?: boolean;
-
-	/**
-	 * ヒント。akashic-engineが最適なパフォーマンスを発揮するための情報。
-	 */
-	hint?: AudioAssetHint;
 }
 
 /**
  * TextAssetの設定。
  */
-export interface DynamicTextAssetConfigurationBase extends DynamicAssetConfigurationBase {
-	/**
-	 * Assetの種類。
-	 */
+export interface DynamicTextAssetConfigurationBase extends DynamicAssetConfigurationBase, Omit<TextAssetConfigurationBase, OmitProperties> {
 	type: "text";
 }
 
 /**
  * ScriptAssetの設定。
  */
-export interface DynamicScriptAssetConfigurationBase extends DynamicAssetConfigurationBase {
-	/**
-	 * Assetの種類。
-	 */
+export interface DynamicScriptAssetConfigurationBase extends DynamicAssetConfigurationBase, Omit<ScriptAssetConfigurationBase, OmitProperties> {
 	type: "script";
 }

--- a/src/DynamicAssetConfiguration.ts
+++ b/src/DynamicAssetConfiguration.ts
@@ -31,9 +31,6 @@ export interface DynamicAssetConfigurationBase extends AssetConfigurationCommonB
 	uri: string;
 }
 
-// type は
-type UnneededKeysForDynamicAsset = "path" | "virtualPath" | "global";
-
 /**
  * ImageAssetの設定。
  */
@@ -68,3 +65,6 @@ export interface DynamicTextAssetConfigurationBase
 export interface DynamicScriptAssetConfigurationBase
 	extends Omit<DynamicAssetConfigurationBase, "type">,
 		Omit<ScriptAssetConfigurationBase, UnneededKeysForDynamicAsset> {}
+
+// interface メンバは多重継承できないため、 DynamicAssetConfigurationBase の type メンバ を Omit する
+type UnneededKeysForDynamicAsset = "path" | "virtualPath" | "global";

--- a/src/DynamicAssetConfiguration.ts
+++ b/src/DynamicAssetConfiguration.ts
@@ -1,4 +1,11 @@
-import type { AssetConfigurationCommonBase, AudioAssetConfigurationBase, ImageAssetConfigurationBase, ScriptAssetConfigurationBase, TextAssetConfigurationBase, VideoAssetConfigurationBase } from "@akashic/game-configuration";
+import type {
+	AssetConfigurationCommonBase,
+	AudioAssetConfigurationBase,
+	ImageAssetConfigurationBase,
+	ScriptAssetConfigurationBase,
+	TextAssetConfigurationBase,
+	VideoAssetConfigurationBase
+} from "@akashic/game-configuration";
 
 export type DynamicAssetConfiguration =
 	| DynamicAudioAssetConfigurationBase
@@ -25,41 +32,39 @@ export interface DynamicAssetConfigurationBase extends AssetConfigurationCommonB
 }
 
 // type は
-type UnneededKeysForDynamicAsset = "path" | "virtualPath"| "global";
+type UnneededKeysForDynamicAsset = "path" | "virtualPath" | "global";
 
 /**
  * ImageAssetの設定。
  */
- export interface DynamicImageAssetConfigurationBase extends Omit<DynamicAssetConfigurationBase, "type">, Omit<ImageAssetConfigurationBase, UnneededKeysForDynamicAsset> {
- }
- 
- const hoge: DynamicImageAssetConfigurationBase = {
-	 height: 1,
-	 width: 1,
-	 id: "",
-	 type: "image",
-	 uri: ""
- }
+export interface DynamicImageAssetConfigurationBase
+	extends Omit<DynamicAssetConfigurationBase, "type">,
+		Omit<ImageAssetConfigurationBase, UnneededKeysForDynamicAsset> {}
 
 /**
  * VideoAssetの設定。
  */
-export interface DynamicVideoAssetConfigurationBase extends Omit<DynamicAssetConfigurationBase, "type">, Omit<VideoAssetConfigurationBase, UnneededKeysForDynamicAsset> {
-}
+export interface DynamicVideoAssetConfigurationBase
+	extends Omit<DynamicAssetConfigurationBase, "type">,
+		Omit<VideoAssetConfigurationBase, UnneededKeysForDynamicAsset> {}
 
 /**
  * AudioAssetの設定。
  */
-export interface DynamicAudioAssetConfigurationBase extends Omit<DynamicAssetConfigurationBase, "type">, Omit<AudioAssetConfigurationBase, UnneededKeysForDynamicAsset> {
-}
+export interface DynamicAudioAssetConfigurationBase
+	extends Omit<DynamicAssetConfigurationBase, "type">,
+		Omit<AudioAssetConfigurationBase, UnneededKeysForDynamicAsset> {}
 
 /**
  * TextAssetの設定。
  */
-export interface DynamicTextAssetConfigurationBase extends Omit<DynamicAssetConfigurationBase, "type">, Omit<TextAssetConfigurationBase, UnneededKeysForDynamicAsset> {}
+export interface DynamicTextAssetConfigurationBase
+	extends Omit<DynamicAssetConfigurationBase, "type">,
+		Omit<TextAssetConfigurationBase, UnneededKeysForDynamicAsset> {}
 
 /**
  * ScriptAssetの設定。
  */
-export interface DynamicScriptAssetConfigurationBase extends Omit<DynamicAssetConfigurationBase, "type">, Omit<ScriptAssetConfigurationBase, UnneededKeysForDynamicAsset> {
-}
+export interface DynamicScriptAssetConfigurationBase
+	extends Omit<DynamicAssetConfigurationBase, "type">,
+		Omit<ScriptAssetConfigurationBase, UnneededKeysForDynamicAsset> {}


### PR DESCRIPTION
## このpull requestが解決する内容

akashic-engine で定義している `DynamicAssetConfiguration` の各型を、 game-configuration の 同内容の型をベースに定義するよう変更します。
従来は同名のプロパティを各々で定義していましたが、この統合で一箇所にまとめられるようになります。
生成される型のプロパティ内容に変更はないため、破壊的変更はありません。

<!-- Pull Requestの変更内容の概要を書いてください -->

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

