### PR TITLE
feat: API リファレンスを gh-pages にデプロイするワークフローを追加

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,77 @@
+name: Deploy API Document on GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  NODE_VERSION: '16'
+  PUBLIC_DIR: public
+  V3_REF: main
+  V2_REF: v2-master
+  V1_REF: v1-master
+  V3_DIR: v3
+  V2_DIR: v2
+  V1_DIR: v1
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Checkout (v3)
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.V3_REF }}
+          path: ${{ env.V3_DIR }}
+      - name: Checkout (v2)
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.V2_REF }}
+          path: ${{ env.V2_DIR }}
+      - name: Checkout (v1)
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.V1_REF }}
+          path: ${{ env.V1_DIR }}
+      - name: Install and Build (v3)
+        working-directory: ${{ env.V3_DIR }}
+        run: |
+          npm ci
+          npm run doc
+      - name: Install and Build (v2)
+        working-directory: ${{ env.V2_DIR }}
+        run: |
+          npm ci
+          npm run doc
+      - name: Install and Build (v1)
+        working-directory: ${{ env.V1_DIR }}
+        run: |
+          npm install
+          npm run doc
+      - name: Copy API docs
+        run: |
+          mkdir -p ${{ env.PUBLIC_DIR }}
+          cp -r ${{ env.V3_DIR }}/doc/html/ ${{ env.PUBLIC_DIR }}/${{ env.V3_DIR }}/
+          cp -r ${{ env.V2_DIR }}/doc/html/ ${{ env.PUBLIC_DIR }}/${{ env.V2_DIR }}/
+          cp -r ${{ env.V1_DIR }}/doc/html/ ${{ env.PUBLIC_DIR }}/${{ env.V1_DIR }}/
+      - name: Check API docs
+        run: |
+          for dir in ${{ env.V1_DIR }} ${{ env.V2_DIR }} ${{ env.V3_DIR }}
+          do
+            if [ ! -e ${{ env.PUBLIC_DIR }}/${dir}/index.html ]; then
+              echo "'${{ env.PUBLIC_DIR }}/${dir}/index.html' not found."
+              exit 1;
+            fi
+          done
+      - name: Deploy on gh-pages branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ env.PUBLIC_DIR }}
+          user_name: 'github-actions'
+          user_email: '41898282+github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,8 +1,12 @@
 name: Deploy API Document on GitHub Pages
 
 on:
+  workflow_dispatch:
   push:
     branches:
+      # 現状過去バージョンのブランチでは GitHub Actions が有効になっておらず、また過去バージョンを更新することは事実上ほとんどないという理由により、
+      # main ブランチへの push 契機ですべてのバージョンを更新するように意図している。
+      # 万が一過去バージョンのみの更新が発生した場合は workflow_dispatch を手動で実行すること。
       - main
 
 env:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="https://raw.githubusercontent.com/akashic-games/akashic-engine/master/img/akashic.png"/>
+<img src="https://raw.githubusercontent.com/akashic-games/akashic-engine/main/img/akashic.png"/>
 </p>
 
 # Akashic Engine
@@ -13,6 +13,11 @@ JavaScriptゲームエンジン [Akashic Engine](https://akashic-games.github.io
 ゲーム開発には [Akashic Sandbox](http://github.com/akashic-games/akashic-sandbox) と
 [Akashic CLI](http://github.com/akashic-games/akashic-cli) をご利用ください。
 Akashic Engineの詳細な利用方法については、 [公式ページ](https://akashic-games.github.io/) を参照してください。
+
+API リファレンスは以下から参照できます。
+- [akashic-engine v3.x](https://akashic-games.github.io/akashic-engine/v3/)
+- [akashic-engine v2.x (旧版)](https://akashic-games.github.io/akashic-engine/v2/modules/_lib_main_d_.g.html)
+- [akashic-engine v1.x (旧版)](https://akashic-games.github.io/akashic-engine/v1/modules/_lib_main_d_.g.html)
 
 ### TypeScript での型定義の利用
 


### PR DESCRIPTION
# このpull requestが解決する内容
API リファレンスを gh-pages にデプロイするワークフローを追加します。

## 動作確認
以下から実際にデプロイされる API リファレンスのページを確認できます。
- [akashic-engine v3.x](https://yu-ogi.github.io/akashic-engine/v3/)
- [akashic-engine v2.x (旧版)](https://yu-ogi.github.io/akashic-engine/v2/modules/_lib_main_d_.g.html)
- [akashic-engine v1.x (旧版)](https://yu-ogi.github.io/akashic-engine/v1/modules/_lib_main_d_.g.html)

## 破壊的な変更を含んでいるか?

- なし

