### PR TITLE
fix: g.Scene#requestAssets() で DynamicAsset の読み込みを要求した際に引数が normalize されていなかった不具合を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## unreleased changes
+
+不具合修正
+* `g.Scene#requestAssets()` で DynamicAsset の読み込みを要求した際に引数が normalize されていなかった不具合を修正
+
 ## 3.4.1
 * 早送りの終了時にスキッピングシーンが描画され続けるケースがある問題の修正
 

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -375,7 +375,7 @@ export class AssetManager implements AssetLoadHandler {
 			assetId = assetIdOrConf;
 		} else {
 			assetId = assetIdOrConf.id;
-			assetIdOrConf = this._normalizeAssetDeclarationBase(assetId, assetIdOrConf);
+			assetIdOrConf = this._normalizeAssetBaseDeclaration(assetId, assetIdOrConf);
 		}
 		let waiting = false;
 		let loadingInfo: AssetLoadingInfo;
@@ -519,7 +519,7 @@ export class AssetManager implements AssetLoadHandler {
 		if (!(configuration instanceof Object)) throw ExceptionFactory.createAssertionError("AssetManager#_normalize: invalid arguments.");
 		for (const p in configuration) {
 			if (!configuration.hasOwnProperty(p)) continue;
-			const conf = Object.create(this._normalizeAssetDeclarationBase<AssetConfiguration>(p, configuration[p]));
+			const conf = Object.create(this._normalizeAssetBaseDeclaration<AssetConfiguration>(p, configuration[p]));
 			if (!conf.path) {
 				throw ExceptionFactory.createAssertionError("AssetManager#_normalize: No path given for: " + p);
 			}
@@ -535,7 +535,7 @@ export class AssetManager implements AssetLoadHandler {
 	/**
 	 * @private
 	 */
-	_normalizeAssetDeclarationBase<T extends AssetConfigurationCore>(assetId: string, conf: T): T {
+	_normalizeAssetBaseDeclaration<T extends AssetConfigurationCore>(assetId: string, conf: T): T {
 		if (!conf.type) {
 			throw ExceptionFactory.createAssertionError("AssetManager#_normalize: No type given for: " + assetId);
 		}

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -370,7 +370,13 @@ export class AssetManager implements AssetLoadHandler {
 	 * @param handler 要求結果を受け取るハンドラ
 	 */
 	requestAsset(assetIdOrConf: string | DynamicAssetConfiguration, handler: AssetManagerLoadHandler): boolean {
-		const assetId = typeof assetIdOrConf === "string" ? assetIdOrConf : (<DynamicAssetConfiguration>assetIdOrConf).id;
+		let assetId: string;
+		if (typeof assetIdOrConf === "string") {
+			assetId = assetIdOrConf;
+		} else {
+			assetId = assetIdOrConf.id;
+			assetIdOrConf = this._normalizeAssetDeclarationBase(assetId, assetIdOrConf);
+		}
 		let waiting = false;
 		let loadingInfo: AssetLoadingInfo;
 		if (this._assets.hasOwnProperty(assetId)) {
@@ -382,13 +388,6 @@ export class AssetManager implements AssetLoadHandler {
 			++this._refCounts[assetId];
 			waiting = true;
 		} else {
-			let assetId: string;
-			if (typeof assetIdOrConf === "string") {
-				assetId = assetIdOrConf;
-			} else {
-				assetId = assetIdOrConf.id;
-				assetIdOrConf = this._normalizeAssetDeclarationBase(assetIdOrConf.id, assetIdOrConf);
-			}
 			const system = this._getAudioSystem(assetIdOrConf);
 			const audioAsset = system?.getDestroyRequestedAsset(assetId);
 			if (system && audioAsset) {

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -375,7 +375,7 @@ export class AssetManager implements AssetLoadHandler {
 			assetId = assetIdOrConf;
 		} else {
 			assetId = assetIdOrConf.id;
-			assetIdOrConf = this._normalizeAssetBaseDeclaration(assetId, assetIdOrConf);
+			assetIdOrConf = this._normalizeAssetBaseDeclaration(assetId, Object.create(assetIdOrConf));
 		}
 		let waiting = false;
 		let loadingInfo: AssetLoadingInfo;
@@ -519,7 +519,7 @@ export class AssetManager implements AssetLoadHandler {
 		if (!(configuration instanceof Object)) throw ExceptionFactory.createAssertionError("AssetManager#_normalize: invalid arguments.");
 		for (const p in configuration) {
 			if (!configuration.hasOwnProperty(p)) continue;
-			const conf = Object.create(this._normalizeAssetBaseDeclaration<AssetConfiguration>(p, configuration[p]));
+			const conf = this._normalizeAssetBaseDeclaration<AssetConfiguration>(p, Object.create(configuration[p]));
 			if (!conf.path) {
 				throw ExceptionFactory.createAssertionError("AssetManager#_normalize: No path given for: " + p);
 			}

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -3,7 +3,14 @@ import type {
 	AssetConfigurationMap,
 	AudioSystemConfigurationMap,
 	ModuleMainScriptsMap,
-	CommonAreaShortened
+	CommonAreaShortened,
+	AssetConfigurationCommonBase,
+	ImageAssetConfigurationBase,
+	ScriptAssetConfigurationBase,
+	TextAssetConfigurationBase,
+	AudioAssetConfigurationBase,
+	VideoAssetConfigurationBase,
+	VectorImageAssetConfigurationBase
 } from "@akashic/game-configuration";
 import type {
 	Asset,
@@ -30,6 +37,36 @@ import { ExceptionFactory } from "./ExceptionFactory";
 import { VideoSystem } from "./VideoSystem";
 
 export type OneOfAsset = AudioAsset | ImageAsset | ScriptAsset | TextAsset | VideoAsset | VectorImageAsset;
+
+// TODO: 以下の internal types を game-configuration に切り出す
+type AssetConfigurationCore =
+	| ImageAssetConfiguration
+	| VectorImageAssetConfiguration
+	| VideoAssetConfiguration
+	| AudioAssetConfiguration
+	| TextAssetConfiguration
+	| ScriptAssetConfiguration;
+
+type UnneededKeysForAsset = "path" | "virtualPath" | "global";
+
+interface ImageAssetConfiguration
+	extends Omit<AssetConfigurationCommonBase, "type">,
+		Omit<ImageAssetConfigurationBase, UnneededKeysForAsset> {}
+interface VectorImageAssetConfiguration
+	extends Omit<AssetConfigurationCommonBase, "type">,
+		Omit<VectorImageAssetConfigurationBase, UnneededKeysForAsset> {}
+interface VideoAssetConfiguration
+	extends Omit<AssetConfigurationCommonBase, "type">,
+		Omit<VideoAssetConfigurationBase, UnneededKeysForAsset> {}
+interface AudioAssetConfiguration
+	extends Omit<AssetConfigurationCommonBase, "type">,
+		Omit<AudioAssetConfigurationBase, UnneededKeysForAsset> {}
+interface TextAssetConfiguration
+	extends Omit<AssetConfigurationCommonBase, "type">,
+		Omit<TextAssetConfigurationBase, UnneededKeysForAsset> {}
+interface ScriptAssetConfiguration
+	extends Omit<AssetConfigurationCommonBase, "type">,
+		Omit<ScriptAssetConfigurationBase, UnneededKeysForAsset> {}
 
 export interface AssetManagerParameterGameLike {
 	resourceFactory: ResourceFactory;
@@ -198,6 +235,11 @@ export class AssetManager implements AssetLoadHandler {
 	private _loadings: { [key: string]: AssetLoadingInfo };
 
 	/**
+	 * オーディオシステムの宣言。
+	 */
+	private _audioSystemConfMap: AudioSystemConfigurationMap;
+
+	/**
 	 * `AssetManager` のインスタンスを生成する。
 	 *
 	 * @param gameParams このインスタンスが属するゲーム。
@@ -214,7 +256,8 @@ export class AssetManager implements AssetLoadHandler {
 		this._resourceFactory = gameParams.resourceFactory;
 		this._audioSystemManager = gameParams.audio;
 		this._defaultAudioSystemId = gameParams.defaultAudioSystemId;
-		this.configuration = this._normalize(conf || {}, normalizeAudioSystemConfMap(audioSystemConfMap));
+		this._audioSystemConfMap = normalizeAudioSystemConfMap(audioSystemConfMap);
+		this.configuration = this._normalize(conf || {});
 		this._assets = {};
 		this._virtualPathToIdTable = {};
 		this._liveAssetVirtualPathTable = {};
@@ -339,6 +382,13 @@ export class AssetManager implements AssetLoadHandler {
 			++this._refCounts[assetId];
 			waiting = true;
 		} else {
+			let assetId: string;
+			if (typeof assetIdOrConf === "string") {
+				assetId = assetIdOrConf;
+			} else {
+				assetId = assetIdOrConf.id;
+				assetIdOrConf = this._normalizeAssetDeclarationBase(assetIdOrConf.id, assetIdOrConf);
+			}
 			const system = this._getAudioSystem(assetIdOrConf);
 			const audioAsset = system?.getDestroyRequestedAsset(assetId);
 			if (system && audioAsset) {
@@ -465,67 +515,78 @@ export class AssetManager implements AssetLoadHandler {
 	/**
 	 * @ignore
 	 */
-	_normalize(configuration: AssetConfigurationMap, audioSystemConfMap: AudioSystemConfigurationMap): AssetConfigurationMap {
+	_normalize(configuration: AssetConfigurationMap): AssetConfigurationMap {
 		const ret: { [key: string]: AssetConfiguration } = {};
 		if (!(configuration instanceof Object)) throw ExceptionFactory.createAssertionError("AssetManager#_normalize: invalid arguments.");
 		for (const p in configuration) {
 			if (!configuration.hasOwnProperty(p)) continue;
-			const conf = <AssetConfiguration>Object.create(configuration[p]);
+			const conf = Object.create(this._normalizeAssetDeclarationBase<AssetConfiguration>(p, configuration[p]));
 			if (!conf.path) {
 				throw ExceptionFactory.createAssertionError("AssetManager#_normalize: No path given for: " + p);
 			}
 			if (!conf.virtualPath) {
 				throw ExceptionFactory.createAssertionError("AssetManager#_normalize: No virtualPath given for: " + p);
 			}
-			if (!conf.type) {
-				throw ExceptionFactory.createAssertionError("AssetManager#_normalize: No type given for: " + p);
-			}
-			if (conf.type === "image") {
-				if (typeof conf.width !== "number")
-					throw ExceptionFactory.createAssertionError("AssetManager#_normalize: wrong width given for the image asset: " + p);
-				if (typeof conf.height !== "number")
-					throw ExceptionFactory.createAssertionError("AssetManager#_normalize: wrong height given for the image asset: " + p);
-				conf.slice = conf.slice ? normalizeCommonArea(conf.slice) : undefined;
-			}
-			if (conf.type === "audio") {
-				// durationというメンバは後から追加したため、古いgame.jsonではundefinedになる場合がある
-				if (conf.duration === undefined) conf.duration = 0;
-				const audioSystemConf = audioSystemConfMap[conf.systemId];
-				if (conf.loop === undefined) {
-					conf.loop = !!audioSystemConf && !!audioSystemConf.loop;
-				}
-				if (conf.hint === undefined) {
-					conf.hint = audioSystemConf ? audioSystemConf.hint : {};
-				}
-				if (conf.systemId !== "music" && conf.systemId !== "sound") {
-					throw ExceptionFactory.createAssertionError("AssetManager#_normalize: wrong systemId given for the audio asset: " + p);
-				}
-			}
-			if (conf.type === "video") {
-				if (!conf.useRealSize) {
-					if (typeof conf.width !== "number")
-						throw ExceptionFactory.createAssertionError("AssetManager#_normalize: wrong width given for the video asset: " + p);
-					if (typeof conf.height !== "number")
-						throw ExceptionFactory.createAssertionError(
-							"AssetManager#_normalize: wrong height given for the video asset: " + p
-						);
-					conf.useRealSize = false;
-				}
-			}
-			if (conf.type === "vector-image") {
-				if (typeof conf.width !== "number")
-					throw ExceptionFactory.createAssertionError(
-						"AssetManager#_normalize: wrong width given for the vector-image asset: " + p
-					);
-				if (typeof conf.height !== "number")
-					throw ExceptionFactory.createAssertionError(
-						"AssetManager#_normalize: wrong height given for the vector-image asset: " + p
-					);
-			}
 			if (!conf.global) conf.global = false;
 			ret[p] = conf;
 		}
 		return ret;
+	}
+
+	/**
+	 * @private
+	 */
+	_normalizeAssetDeclarationBase<T extends AssetConfigurationCore>(assetId: string, conf: T): T {
+		if (!conf.type) {
+			throw ExceptionFactory.createAssertionError("AssetManager#_normalize: No type given for: " + assetId);
+		}
+		if (conf.type === "image") {
+			if (typeof conf.width !== "number")
+				throw ExceptionFactory.createAssertionError("AssetManager#_normalize: wrong width given for the image asset: " + assetId);
+			if (typeof conf.height !== "number")
+				throw ExceptionFactory.createAssertionError("AssetManager#_normalize: wrong height given for the image asset: " + assetId);
+			conf.slice = conf.slice ? normalizeCommonArea(conf.slice) : undefined;
+		}
+		if (conf.type === "audio") {
+			// durationというメンバは後から追加したため、古いgame.jsonではundefinedになる場合がある
+			if (conf.duration === undefined) conf.duration = 0;
+			const audioSystemConf = this._audioSystemConfMap[conf.systemId];
+			if (conf.loop === undefined) {
+				conf.loop = !!audioSystemConf && !!audioSystemConf.loop;
+			}
+			if (conf.hint === undefined) {
+				conf.hint = audioSystemConf ? audioSystemConf.hint : {};
+			}
+			if (conf.systemId !== "music" && conf.systemId !== "sound") {
+				throw ExceptionFactory.createAssertionError(
+					"AssetManager#_normalize: wrong systemId given for the audio asset: " + assetId
+				);
+			}
+		}
+		if (conf.type === "video") {
+			if (!conf.useRealSize) {
+				if (typeof conf.width !== "number")
+					throw ExceptionFactory.createAssertionError(
+						"AssetManager#_normalize: wrong width given for the video asset: " + assetId
+					);
+				if (typeof conf.height !== "number")
+					throw ExceptionFactory.createAssertionError(
+						"AssetManager#_normalize: wrong height given for the video asset: " + assetId
+					);
+				conf.useRealSize = false;
+			}
+		}
+		if (conf.type === "vector-image") {
+			if (typeof conf.width !== "number")
+				throw ExceptionFactory.createAssertionError(
+					"AssetManager#_normalize: wrong width given for the vector-image asset: " + assetId
+				);
+			if (typeof conf.height !== "number")
+				throw ExceptionFactory.createAssertionError(
+					"AssetManager#_normalize: wrong height given for the vector-image asset: " + assetId
+				);
+		}
+		return conf;
 	}
 
 	/**

--- a/src/DynamicAssetConfiguration.ts
+++ b/src/DynamicAssetConfiguration.ts
@@ -4,12 +4,14 @@ import type {
 	ImageAssetConfigurationBase,
 	ScriptAssetConfigurationBase,
 	TextAssetConfigurationBase,
+	VectorImageAssetConfigurationBase,
 	VideoAssetConfigurationBase
 } from "@akashic/game-configuration";
 
 export type DynamicAssetConfiguration =
 	| DynamicAudioAssetConfigurationBase
 	| DynamicImageAssetConfigurationBase
+	| DynamicVectorImageAssetConfigurationBase
 	| DynamicTextAssetConfigurationBase
 	| DynamicScriptAssetConfigurationBase
 	| DynamicVideoAssetConfigurationBase;
@@ -37,6 +39,13 @@ export interface DynamicAssetConfigurationBase extends AssetConfigurationCommonB
 export interface DynamicImageAssetConfigurationBase
 	extends Omit<DynamicAssetConfigurationBase, "type">,
 		Omit<ImageAssetConfigurationBase, UnneededKeysForDynamicAsset> {}
+
+/**
+ * VectorImageAssetの設定。
+ */
+export interface DynamicVectorImageAssetConfigurationBase
+	extends Omit<DynamicAssetConfigurationBase, "type">,
+		Omit<VectorImageAssetConfigurationBase, UnneededKeysForDynamicAsset> {}
 
 /**
  * VideoAssetの設定。

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -811,7 +811,7 @@ export class Scene implements StorageLoaderHandler {
 		if (this._loadingState !== "ready-fired" && this._loadingState !== "loaded-fired") {
 			// このメソッドは読み込み完了前には呼び出せない。これは実装上の制限である。
 			// やろうと思えば _load() で読み込む対象として加えることができる。が、その場合 `handler` を呼び出す方法が単純でないので対応を見送る。
-			throw ExceptionFactory.createAssertionError("Scene#requestAsset(): can be called after loaded.");
+			throw ExceptionFactory.createAssertionError("Scene#requestAssets(): can be called after loaded.");
 		}
 
 		const holder = new AssetHolder<SceneRequestAssetHandler>({

--- a/src/__tests__/AssetManagerSpec.ts
+++ b/src/__tests__/AssetManagerSpec.ts
@@ -3,6 +3,7 @@ import type {
 	AssetManagerLoadHandler,
 	AudioAssetConfigurationBase,
 	AudioSystem,
+	DynamicAssetConfiguration,
 	GameConfiguration,
 	Asset,
 	ScriptAsset,
@@ -356,6 +357,39 @@ describe("test AssetManager", () => {
 			}
 		};
 		manager.requestAssets(outerAssets, handlerOuter);
+	});
+
+	it("should normalize the dynamic asset configuration", async () => {
+		const game = new Game(gameConfiguration, "/");
+		const manager = game._assetManager;
+
+		function requestAsset(conf: DynamicAssetConfiguration): Promise<AudioAsset> {
+			return new Promise((resolve, reject) => {
+				manager.requestAsset(conf, { _onAssetError: e => reject(e), _onAssetLoad: (a: AudioAsset) => resolve(a) });
+			});
+		}
+
+		const asset1 = await requestAsset({
+			id: "test-dynamic-audio-asset-1",
+			uri: "test-dynamic-audio-asset-1-uri",
+			type: "audio",
+			duration: 1234,
+			systemId: "sound"
+		});
+		expect(asset1.hint).toEqual({
+			streaming: false // hint 属性が補完されていることを確認
+		});
+
+		const asset2 = await requestAsset({
+			id: "test-dynamic-audio-asset-2",
+			uri: "test-dynamic-audio-asset-2-uri",
+			type: "audio",
+			duration: 1234,
+			systemId: "music"
+		});
+		expect(asset2.hint).toEqual({
+			streaming: true // hint 属性が補完されていることを確認
+		});
 	});
 
 	it("can instantiate PartialImageAsset", done => {


### PR DESCRIPTION
## このpull requestが解決する内容

`g.Scene#requestAssets()` で DynamicAsset の読み込みを要求した際に引数が normalize されていなかった不具合を修正します。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

