### PR TITLE
Fix bug OperationPluginManager when game reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 3.4.3
+
+不具合修正
+* `g.OperationPluginManager` のゲーム状態リセットでの不具合を修正
+
 ## 3.4.2
 
 不具合修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.4.3
 
 不具合修正
-* `g.OperationPluginManager` のゲーム状態リセットでの不具合を修正
+* `g.OperationPluginManager#stopAll()` で登録済みの操作プラグインが正常に停止できなかった不具合を修正
 
 ## 3.4.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1398,7 +1398,7 @@ export class Game {
 	 * @private
 	 */
 	_reset(param?: GameResetParameterObject): void {
-		this.operationPluginManager.stopAll();
+		this.operationPluginManager.reset(this._onOperationPluginOperated);
 		if (this.scene()) {
 			while (this.scene() !== this._initialScene) {
 				this.popScene();

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1802,9 +1802,9 @@ export class Game {
 		for (const pluginInfo of operationPluginsField) {
 			if (!pluginInfo.script) continue;
 			const pluginClass = this._moduleManager._require(pluginInfo.script);
-			this.operationPluginManager.register(pluginClass, pluginInfo.code, pluginInfo.option);
-			if (!pluginInfo.manualStart && this.operationPluginManager.plugins[pluginInfo.code]) {
-				this.operationPluginManager.plugins[pluginInfo.code].start();
+			const plugin = this.operationPluginManager.register(pluginClass, pluginInfo.code, pluginInfo.option);
+			if (!pluginInfo.manualStart && plugin) {
+				plugin.start();
 			}
 		}
 		this.operationPlugins = this.operationPluginManager.plugins;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -912,7 +912,6 @@ export class Game {
 		this._onOperationPluginOperated = new Trigger<InternalOperationPluginOperation>();
 		this._operationPluginOperated = this._onOperationPluginOperated;
 		this._onOperationPluginOperated.add(this._handleOperationPluginOperated, this);
-		this.operationPluginManager.onOperate.add(this._onOperationPluginOperated.fire, this._onOperationPluginOperated);
 
 		this.onSceneChange = new Trigger();
 		this._onSceneChange = new Trigger();

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1398,7 +1398,8 @@ export class Game {
 	 * @private
 	 */
 	_reset(param?: GameResetParameterObject): void {
-		this.operationPluginManager.reset(this._onOperationPluginOperated);
+		this.operationPluginManager.reset();
+		this.operationPluginManager.onOperate.add(this._onOperationPluginOperated.fire, this._onOperationPluginOperated);
 		if (this.scene()) {
 			while (this.scene() !== this._initialScene) {
 				this.popScene();

--- a/src/InternalOperationPluginInfo.ts
+++ b/src/InternalOperationPluginInfo.ts
@@ -4,6 +4,7 @@ import type { OperationPlugin } from "./OperationPlugin";
 /**
  * エンジン内部で用いる、操作プラグインの管理情報
  * 本インターフェースをゲーム開発者が利用する必要はない。
+ * @deprecated 利用しないでください。
  */
 export interface InternalOperationPluginInfo extends OperationPluginInfo {
 	/**

--- a/src/OperationPluginManager.ts
+++ b/src/OperationPluginManager.ts
@@ -113,7 +113,6 @@ export class OperationPluginManager {
 	reset(): void {
 		this.stopAll();
 		this.onOperate.removeAll();
-		this.operated = this.onOperate;
 		this.plugins = {};
 	}
 

--- a/src/OperationPluginManager.ts
+++ b/src/OperationPluginManager.ts
@@ -60,7 +60,7 @@ export class OperationPluginManager {
 
 	private _game: Game;
 	private _viewInfo: OperationPluginViewInfo | null;
-	private _infos: InternalOperationPluginInfo[];
+	private _infos: { [code: string]: InternalOperationPluginInfo };
 	private _initialized: boolean;
 
 	constructor(game: Game, viewInfo: OperationPluginViewInfo | null, infos: InternalOperationPluginInfo[]) {
@@ -69,7 +69,10 @@ export class OperationPluginManager {
 		this.plugins = {};
 		this._game = game;
 		this._viewInfo = viewInfo;
-		this._infos = infos;
+		this._infos = {};
+		for (const info of infos) {
+			this._infos[info.code] = info;
+		}
 		this._initialized = false;
 	}
 
@@ -137,7 +140,7 @@ export class OperationPluginManager {
 		this.onOperate.removeAll();
 		this.operated = this.onOperate;
 		this.plugins = {};
-		this._infos = [];
+		this._infos = {};
 	}
 
 	stopAll(): void {
@@ -173,9 +176,6 @@ export class OperationPluginManager {
 		}
 		if (this.plugins[code]) {
 			throw new Error(`Plugin#code conflicted for code: ${code}`);
-		}
-		if (this._infos[code]) {
-			throw new Error(`this plugin (code: ${code}) is already defined in game.json`);
 		}
 		const plugin = new pluginClass(this._game, this._viewInfo, option);
 		this.plugins[code] = plugin;

--- a/src/OperationPluginManager.ts
+++ b/src/OperationPluginManager.ts
@@ -131,12 +131,10 @@ export class OperationPluginManager {
 		this._infos = undefined!;
 	}
 
-	reset(onOperationPluginOperated: Trigger<InternalOperationPluginOperation>): void {
+	reset(): void {
 		if (!this._initialized) return;
 		this.stopAll();
-		this.onOperate.destroy();
-		this.onOperate = new Trigger<InternalOperationPluginOperation>();
-		this.onOperate.add(onOperationPluginOperated.fire, onOperationPluginOperated);
+		this.onOperate.removeAll();
 		this.operated = this.onOperate;
 		this.plugins = {};
 		this._infos = [];
@@ -145,30 +143,27 @@ export class OperationPluginManager {
 	stopAll(): void {
 		if (!this._initialized) return;
 		for (const code in this._infos) {
-			if (this._infos.hasOwnProperty(code)) {
-				const info = this._infos[code];
-				if (info._plugin) info._plugin.stop();
-			}
+			if (!this._infos.hasOwnProperty(code)) continue;
+			const info = this._infos[code];
+			if (info._plugin) info._plugin.stop();
 		}
 	}
 
 	private _doAutoStart(): void {
 		for (const code in this._infos) {
-			if (this._infos.hasOwnProperty(code)) {
-				const info = this._infos[code];
-				if (!info.manualStart && info._plugin) info._plugin.start();
-			}
+			if (!this._infos.hasOwnProperty(code)) continue;
+			const info = this._infos[code];
+			if (!info.manualStart && info._plugin) info._plugin.start();
 		}
 	}
 
 	private _loadOperationPlugins(): void {
 		for (const code in this._infos) {
-			if (this._infos.hasOwnProperty(code)) {
-				const info = this._infos[code];
-				if (!info.script) continue;
-				const pluginClass = this._game._moduleManager._require(info.script);
-				info._plugin = this._instantiateOperationPlugin(pluginClass, info.code, info.option);
-			}
+			if (!this._infos.hasOwnProperty(code)) continue;
+			const info = this._infos[code];
+			if (!info.script) continue;
+			const pluginClass = this._game._moduleManager._require(info.script);
+			info._plugin = this._instantiateOperationPlugin(pluginClass, info.code, info.option);
 		}
 	}
 

--- a/src/OperationPluginManager.ts
+++ b/src/OperationPluginManager.ts
@@ -131,27 +131,44 @@ export class OperationPluginManager {
 		this._infos = undefined!;
 	}
 
+	reset(onOperationPluginOperated: Trigger<InternalOperationPluginOperation>): void {
+		if (!this._initialized) return;
+		this.stopAll();
+		this.onOperate.destroy();
+		this.onOperate = new Trigger<InternalOperationPluginOperation>();
+		this.onOperate.add(onOperationPluginOperated.fire, onOperationPluginOperated);
+		this.operated = this.onOperate;
+		this.plugins = {};
+		this._infos = [];
+	}
+
 	stopAll(): void {
 		if (!this._initialized) return;
-		for (let i = 0; i < this._infos.length; ++i) {
-			const info = this._infos[i];
-			if (info._plugin) info._plugin.stop();
+		for (const code in this._infos) {
+			if (this._infos.hasOwnProperty(code)) {
+				const info = this._infos[code];
+				if (info._plugin) info._plugin.stop();
+			}
 		}
 	}
 
 	private _doAutoStart(): void {
-		for (let i = 0; i < this._infos.length; ++i) {
-			const info = this._infos[i];
-			if (!info.manualStart && info._plugin) info._plugin.start();
+		for (const code in this._infos) {
+			if (this._infos.hasOwnProperty(code)) {
+				const info = this._infos[code];
+				if (!info.manualStart && info._plugin) info._plugin.start();
+			}
 		}
 	}
 
 	private _loadOperationPlugins(): void {
-		for (let i = 0; i < this._infos.length; ++i) {
-			const info = this._infos[i];
-			if (!info.script) continue;
-			const pluginClass = this._game._moduleManager._require(info.script);
-			info._plugin = this._instantiateOperationPlugin(pluginClass, info.code, info.option);
+		for (const code in this._infos) {
+			if (this._infos.hasOwnProperty(code)) {
+				const info = this._infos[code];
+				if (!info.script) continue;
+				const pluginClass = this._game._moduleManager._require(info.script);
+				info._plugin = this._instantiateOperationPlugin(pluginClass, info.code, info.option);
+			}
 		}
 	}
 

--- a/src/OperationPluginManager.ts
+++ b/src/OperationPluginManager.ts
@@ -60,7 +60,7 @@ export class OperationPluginManager {
 
 	private _game: Game;
 	private _viewInfo: OperationPluginViewInfo | null;
-	private _infos: { [code: string]: InternalOperationPluginInfo };
+	private _infoTable: { [code: number]: InternalOperationPluginInfo };
 	private _initialized: boolean;
 
 	constructor(game: Game, viewInfo: OperationPluginViewInfo | null, infos: InternalOperationPluginInfo[]) {
@@ -69,9 +69,9 @@ export class OperationPluginManager {
 		this.plugins = {};
 		this._game = game;
 		this._viewInfo = viewInfo;
-		this._infos = {};
+		this._infoTable = {};
 		for (const info of infos) {
-			this._infos[info.code] = info;
+			this._infoTable[info.code] = info;
 		}
 		this._initialized = false;
 	}
@@ -97,7 +97,7 @@ export class OperationPluginManager {
 	 * @param option 操作プラグインのコンストラクタに渡すパラメータ
 	 */
 	register(pluginClass: OperationPluginStatic, code: number, option?: any): void {
-		this._infos[code] = {
+		this._infoTable[code] = {
 			code,
 			_plugin: this._instantiateOperationPlugin(pluginClass, code, option)
 		};
@@ -108,7 +108,7 @@ export class OperationPluginManager {
 	 * @param code 操作プラグインの識別コード
 	 */
 	start(code: number): void {
-		const info = this._infos[code];
+		const info = this._infoTable[code];
 		if (!info || !info._plugin) return;
 		info._plugin.start();
 	}
@@ -118,7 +118,7 @@ export class OperationPluginManager {
 	 * @param code 操作プラグインの識別コード
 	 */
 	stop(code: number): void {
-		const info = this._infos[code];
+		const info = this._infoTable[code];
 		if (!info || !info._plugin) return;
 		info._plugin.stop();
 	}
@@ -131,7 +131,7 @@ export class OperationPluginManager {
 		this.plugins = undefined!;
 		this._game = undefined!;
 		this._viewInfo = undefined!;
-		this._infos = undefined!;
+		this._infoTable = undefined!;
 	}
 
 	reset(): void {
@@ -140,30 +140,30 @@ export class OperationPluginManager {
 		this.onOperate.removeAll();
 		this.operated = this.onOperate;
 		this.plugins = {};
-		this._infos = {};
+		this._infoTable = {};
 	}
 
 	stopAll(): void {
 		if (!this._initialized) return;
-		for (const code in this._infos) {
-			if (!this._infos.hasOwnProperty(code)) continue;
-			const info = this._infos[code];
+		for (const code in this._infoTable) {
+			if (!this._infoTable.hasOwnProperty(code)) continue;
+			const info = this._infoTable[code];
 			if (info._plugin) info._plugin.stop();
 		}
 	}
 
 	private _doAutoStart(): void {
-		for (const code in this._infos) {
-			if (!this._infos.hasOwnProperty(code)) continue;
-			const info = this._infos[code];
+		for (const code in this._infoTable) {
+			if (!this._infoTable.hasOwnProperty(code)) continue;
+			const info = this._infoTable[code];
 			if (!info.manualStart && info._plugin) info._plugin.start();
 		}
 	}
 
 	private _loadOperationPlugins(): void {
-		for (const code in this._infos) {
-			if (!this._infos.hasOwnProperty(code)) continue;
-			const info = this._infos[code];
+		for (const code in this._infoTable) {
+			if (!this._infoTable.hasOwnProperty(code)) continue;
+			const info = this._infoTable[code];
 			if (!info.script) continue;
 			const pluginClass = this._game._moduleManager._require(info.script);
 			info._plugin = this._instantiateOperationPlugin(pluginClass, info.code, info.option);

--- a/src/OperationPluginManager.ts
+++ b/src/OperationPluginManager.ts
@@ -76,8 +76,8 @@ export class OperationPluginManager {
 	 * @param code 操作プラグインの識別コード
 	 * @param option 操作プラグインのコンストラクタに渡すパラメータ
 	 */
-	register(pluginClass: OperationPluginStatic, code: number, option?: any): void {
-		this._instantiateOperationPlugin(pluginClass, code, option);
+	register(pluginClass: OperationPluginStatic, code: number, option?: any): OperationPlugin | undefined {
+		return this._instantiateOperationPlugin(pluginClass, code, option);
 	}
 
 	/**

--- a/src/__tests__/OperationPluginManagerSpec.ts
+++ b/src/__tests__/OperationPluginManagerSpec.ts
@@ -79,13 +79,10 @@ describe("test OperationPluginManager", () => {
 	});
 
 	it("初期化", done => {
-		game._onLoad.add(() => {
-			expect(game.operationPluginManager).not.toBeFalsy();
-			expect(game.operationPluginManager.onOperate instanceof Trigger).toBe(true);
-			expect(game.operationPluginManager.plugins).toEqual({});
-			done();
-		});
-		game._startLoadingGlobalAssets();
+		expect(game.operationPluginManager).not.toBeFalsy();
+		expect(game.operationPluginManager.onOperate instanceof Trigger).toBe(true);
+		expect(game.operationPluginManager.plugins).toEqual({});
+		done();
 	});
 
 	it("Register gameConfiguration.operationPlugins with _onStart", done => {
@@ -178,7 +175,9 @@ describe("test OperationPluginManager", () => {
 	it("reset", done => {
 		game._onStart.add(() => {
 			const self = game.operationPluginManager;
-			self.onOperate.add(() => { return });
+			self.onOperate.add(() => {
+				return;
+			});
 			// @ts-ignore
 			const plugin = self.register(TestOperationPlugin, 11, { dummy: true }) as TestOperationPlugin;
 			expect(self.plugins[11]).toBeDefined();

--- a/src/__tests__/OperationPluginManagerSpec.ts
+++ b/src/__tests__/OperationPluginManagerSpec.ts
@@ -178,16 +178,18 @@ describe("test OperationPluginManager", () => {
 	it("reset", done => {
 		game._onStart.add(() => {
 			const self = game.operationPluginManager;
-			expect(self.onOperate._handlers[0]).toBeDefined();
-			expect(self.operated._handlers[0]).toBeDefined();
-			expect(Object.keys(self.plugins).length).toEqual(2);
+			self.onOperate.add(() => { return });
+			expect(self.plugins[30]).toBeUndefined();
+			// @ts-ignore
+			const plugin = self.register(TestOperationPlugin, 11, { dummy: true });
+			expect(self.plugins[11]).toBeDefined();
+			if (plugin) plugin.start();
+			expect((plugin as any)._started).toBe(true);
 
 			self.reset();
-			expect(self.onOperate._handlers[0]).toBeUndefined();
-			expect(self.onOperate._handlers.length).toEqual(0);
-			expect(self.onOperate._handlers).toEqual([]);
-			expect(self.operated).toEqual(self.onOperate);
+			expect(self.onOperate.length).toBe(0);
 			expect(self.plugins).toEqual({});
+			expect((plugin as any)._started).toBe(false);
 			done();
 		});
 		game._loadAndStart();

--- a/src/__tests__/OperationPluginManagerSpec.ts
+++ b/src/__tests__/OperationPluginManagerSpec.ts
@@ -175,4 +175,19 @@ describe("test OperationPluginManager", () => {
 		});
 		game._startLoadingGlobalAssets();
 	});
+
+	it("reset", done => {
+		game._onLoad.add(() => {
+			const self = game.operationPluginManager;
+			self.initialize();
+
+			self.reset(game._onOperationPluginOperated);
+			expect(self.onOperate._handlers[0].func).toBe(game._onOperationPluginOperated.fire);
+			expect(self.onOperate._handlers[0].owner).toBe(game._onOperationPluginOperated);
+			expect(self.operated).toEqual(self.onOperate);
+			expect(self.plugins).toEqual({});
+			done();
+		});
+		game._startLoadingGlobalAssets();
+	});
 });

--- a/src/__tests__/OperationPluginManagerSpec.ts
+++ b/src/__tests__/OperationPluginManagerSpec.ts
@@ -127,23 +127,24 @@ describe("test OperationPluginManager", () => {
 			const self = game.operationPluginManager;
 			self.initialize();
 
-			expect((self as any)._infos[30]).toBeUndefined();
+			expect((self as any)._infoTable[30]).toBeUndefined();
 			// @ts-ignore
 			self.register(TestOperationPlugin, 30, { dummy: true });
 
-			expect((self as any)._infos[30]).toBeDefined();
-			expect((self as any)._infos[30]._plugin).toBeDefined();
+			expect((self as any)._infoTable[30]).toBeDefined();
+			expect((self as any)._infoTable[30]._plugin).toBeDefined();
+
 			const plugin1 = self.plugins[30] as TestOperationPlugin;
 			expect(plugin1._option).toEqual({ dummy: true });
 			expect(plugin1._started).toBe(false);
 			self.start(30);
 			expect(plugin1._started).toBe(true);
 
-			expect((self as any)._infos[60]).toBeUndefined();
+			expect((self as any)._infoTable[60]).toBeUndefined();
 			// @ts-ignore
 			self.register(TestOperationPluginUnsupported, 60, { dummy: false });
-			expect((self as any)._infos[60]).toBeDefined();
-			expect((self as any)._infos[60]._plugin).toBeUndefined();
+			expect((self as any)._infoTable[60]).toBeDefined();
+			expect((self as any)._infoTable[60]._plugin).toBeUndefined();
 			const plugin2 = self.plugins[60] as TestOperationPluginUnsupported;
 			expect(plugin2).toBeUndefined();
 			self.start(60);
@@ -180,12 +181,18 @@ describe("test OperationPluginManager", () => {
 		game._onLoad.add(() => {
 			const self = game.operationPluginManager;
 			self.initialize();
+			expect(self.onOperate._handlers[0]).toBeDefined();
+			expect(self.operated._handlers[0]).toBeDefined();
+			expect(Object.keys((self as any)._infoTable).length).toEqual(3);
+			expect(Object.keys(self.plugins).length).toEqual(1);
 
 			self.reset();
+			expect(self.onOperate._handlers[0]).toBeUndefined();
 			expect(self.onOperate._handlers.length).toEqual(0);
 			expect(self.onOperate._handlers).toEqual([]);
 			expect(self.operated).toEqual(self.onOperate);
 			expect(self.plugins).toEqual({});
+			expect((self as any)._infoTable).toEqual({});
 			done();
 		});
 		game._startLoadingGlobalAssets();

--- a/src/__tests__/OperationPluginManagerSpec.ts
+++ b/src/__tests__/OperationPluginManagerSpec.ts
@@ -181,9 +181,9 @@ describe("test OperationPluginManager", () => {
 			const self = game.operationPluginManager;
 			self.initialize();
 
-			self.reset(game._onOperationPluginOperated);
-			expect(self.onOperate._handlers[0].func).toBe(game._onOperationPluginOperated.fire);
-			expect(self.onOperate._handlers[0].owner).toBe(game._onOperationPluginOperated);
+			self.reset();
+			expect(self.onOperate._handlers.length).toEqual(0);
+			expect(self.onOperate._handlers).toEqual([]);
 			expect(self.operated).toEqual(self.onOperate);
 			expect(self.plugins).toEqual({});
 			done();

--- a/src/__tests__/OperationPluginManagerSpec.ts
+++ b/src/__tests__/OperationPluginManagerSpec.ts
@@ -179,17 +179,16 @@ describe("test OperationPluginManager", () => {
 		game._onStart.add(() => {
 			const self = game.operationPluginManager;
 			self.onOperate.add(() => { return });
-			expect(self.plugins[30]).toBeUndefined();
 			// @ts-ignore
-			const plugin = self.register(TestOperationPlugin, 11, { dummy: true });
+			const plugin = self.register(TestOperationPlugin, 11, { dummy: true }) as TestOperationPlugin;
 			expect(self.plugins[11]).toBeDefined();
-			if (plugin) plugin.start();
-			expect((plugin as any)._started).toBe(true);
+			plugin!.start();
+			expect(plugin._started).toBe(true);
 
 			self.reset();
 			expect(self.onOperate.length).toBe(0);
 			expect(self.plugins).toEqual({});
-			expect((plugin as any)._started).toBe(false);
+			expect(plugin._started).toBe(false);
 			done();
 		});
 		game._loadAndStart();

--- a/src/__tests__/OperationPluginManagerSpec.ts
+++ b/src/__tests__/OperationPluginManagerSpec.ts
@@ -47,13 +47,21 @@ describe("test OperationPluginManager", () => {
 		const conf: GameConfiguration = {
 			width: 320,
 			height: 270,
-			assets: {},
+			assets: {
+				mainScene: {
+					type: "script",
+					path: "/dummy/dummy.js",
+					virtualPath: "dummy/dummy.js",
+					global: true
+				}
+			},
 			operationPlugins: [
 				{ code: 42, script: "/script/op-plugin.js" },
 				{ code: 10, script: undefined },
-				{ code: 15, script: "/script/op-plugin-unsupported.js" }
+				{ code: 15, script: "/script/op-plugin-unsupported.js" },
+				{ code: 2, script: "/script/op-plugin.js", manualStart: true }
 			],
-			main: ""
+			main: "./dummy/dummy.js"
 		};
 		game = new Game(conf, "/", "foo", dummyViewInfo);
 		const manager = game._moduleManager;
@@ -80,28 +88,25 @@ describe("test OperationPluginManager", () => {
 		game._startLoadingGlobalAssets();
 	});
 
-	it("initialize()", done => {
-		game._onLoad.add(() => {
+	it("Register gameConfiguration.operationPlugins with _onStart", done => {
+		game._onStart.add(() => {
 			const self = game.operationPluginManager;
-			expect((self as any)._initialized).toBe(false);
-			self.initialize();
-			expect((self as any)._initialized).toBe(true);
-			self.initialize(); // 通過パス稼ぎのため二度目の呼び出し
 			expect(self.plugins[42]).not.toBeFalsy();
 			expect((self.plugins[42] as any)._started).toBe(true);
 			expect((self.plugins[42] as any)._game).toBe(game);
 			expect((self.plugins[42] as any)._viewInfo).toBe(dummyViewInfo);
+			expect(self.plugins[2]).not.toBeFalsy();
+			expect((self.plugins[2] as any)._started).toBe(false);
 			expect(self.plugins[10]).toBeFalsy();
 			expect(self.plugins[15]).toBeFalsy();
 			done();
 		});
-		game._startLoadingGlobalAssets();
+		game._loadAndStart();
 	});
 
 	it("operated", done => {
-		game._onLoad.add(() => {
+		game._onStart.add(() => {
 			const self = game.operationPluginManager;
-			self.initialize();
 
 			const ops: InternalOperationPluginOperation[] = [];
 			self.onOperate.add(op => {
@@ -119,20 +124,18 @@ describe("test OperationPluginManager", () => {
 			expect(ops[2]).toEqual({ _code: 42, local: true, data: [] });
 			done();
 		});
-		game._startLoadingGlobalAssets();
+		game._loadAndStart();
 	});
 
 	it("register", done => {
-		game._onLoad.add(() => {
+		game._onStart.add(() => {
 			const self = game.operationPluginManager;
-			self.initialize();
 
-			expect((self as any)._infoTable[30]).toBeUndefined();
+			expect(self.plugins[30]).toBeUndefined();
 			// @ts-ignore
 			self.register(TestOperationPlugin, 30, { dummy: true });
 
-			expect((self as any)._infoTable[30]).toBeDefined();
-			expect((self as any)._infoTable[30]._plugin).toBeDefined();
+			expect(self.plugins[30]).toBeDefined();
 
 			const plugin1 = self.plugins[30] as TestOperationPlugin;
 			expect(plugin1._option).toEqual({ dummy: true });
@@ -140,15 +143,10 @@ describe("test OperationPluginManager", () => {
 			self.start(30);
 			expect(plugin1._started).toBe(true);
 
-			expect((self as any)._infoTable[60]).toBeUndefined();
+			expect(self.plugins[60]).toBeUndefined();
 			// @ts-ignore
 			self.register(TestOperationPluginUnsupported, 60, { dummy: false });
-			expect((self as any)._infoTable[60]).toBeDefined();
-			expect((self as any)._infoTable[60]._plugin).toBeUndefined();
-			const plugin2 = self.plugins[60] as TestOperationPluginUnsupported;
-			expect(plugin2).toBeUndefined();
-			self.start(60);
-			expect(plugin2).toBeUndefined();
+			expect(self.plugins[60]).toBeUndefined();
 
 			expect(() => {
 				// @ts-ignore
@@ -162,29 +160,27 @@ describe("test OperationPluginManager", () => {
 
 			done();
 		});
-		game._startLoadingGlobalAssets();
+		game._loadAndStart();
 	});
 
 	it("destroy", done => {
-		game._onLoad.add(() => {
+		game._onStart.add(() => {
 			const self = game.operationPluginManager;
-			self.initialize();
+
 			self.destroy();
 			expect(self.onOperate).toBeFalsy();
 			expect(self.plugins).toBeFalsy();
 			done();
 		});
-		game._startLoadingGlobalAssets();
+		game._loadAndStart();
 	});
 
 	it("reset", done => {
-		game._onLoad.add(() => {
+		game._onStart.add(() => {
 			const self = game.operationPluginManager;
-			self.initialize();
 			expect(self.onOperate._handlers[0]).toBeDefined();
 			expect(self.operated._handlers[0]).toBeDefined();
-			expect(Object.keys((self as any)._infoTable).length).toEqual(3);
-			expect(Object.keys(self.plugins).length).toEqual(1);
+			expect(Object.keys(self.plugins).length).toEqual(2);
 
 			self.reset();
 			expect(self.onOperate._handlers[0]).toBeUndefined();
@@ -192,9 +188,8 @@ describe("test OperationPluginManager", () => {
 			expect(self.onOperate._handlers).toEqual([]);
 			expect(self.operated).toEqual(self.onOperate);
 			expect(self.plugins).toEqual({});
-			expect((self as any)._infoTable).toEqual({});
 			done();
 		});
-		game._startLoadingGlobalAssets();
+		game._loadAndStart();
 	});
 });


### PR DESCRIPTION
## このpull requestが解決する内容

`Game#_reset()`  時に `OperationPluginManager` が異常終了する不具合を修正。
-  `stopAll()`, `_doAutoStart()` 等で forループ(for ([初期化式]; [条件式]; [加算式])) を使用していたが、条件となる `this._infos` は配列のインデックスが 0 から連番でないためエラーとなっていた。`infos` を削除。
- `initialize()` を削除し、`register()` を利用で統一するよう修正。
- 一部の変数を初期化する `OperationPluginManager#reset()` を追加し、`Game#_reset()` で 呼ぶように修正。


## 破壊的な変更を含んでいるか?

- なし
