### PR TITLE
Fix schedule in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,11 @@
     "config:base"
   ],
   "timezone": "Asia/Tokyo",
-  "schedule": ["every weekend"],
+  "schedule": [
+    "every weekend",
+    "after 10pm every weekday",
+    "before 6am every weekday"
+  ],
   "labels": ["dependencies"],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
@@ -13,7 +17,8 @@
   "packageRules": [
     {
       "matchPackagePatterns": ["^@akashic/"],
-      "groupName": "all dependencies (akashic)"
+      "groupName": "all dependencies (akashic)",
+      "schedule": "at any time"
     },
     {
       "matchUpdateTypes": ["minor"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,9 @@
 {
   "extends": [
-    "github>akashic-games/renovate-config"
+    "github>akashic-games/renovate-config",
+    "github>akashic-games/renovate-config:groupPatchMinor"
   ],
   "packageRules": [
-    {
-      "matchUpdateTypes": ["minor"],
-      "excludePackagePatterns": ["^@akashic/"],
-      "groupName": "all dependencies"
-    },
-    {
-      "matchUpdateTypes": ["patch"],
-      "excludePackagePatterns": ["^@akashic/"],
-      "groupName": "all dependencies"
-    },
     {
       "matchPackageNames": ["xorshift"],
       "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -1,25 +1,10 @@
 {
   "extends": [
-    "config:base"
+    "github>akashic-games/renovate-config"
   ],
-  "timezone": "Asia/Tokyo",
-  "schedule": [
-    "every weekend",
-    "after 10pm every weekday",
-    "before 6am every weekday"
-  ],
-  "labels": ["dependencies"],
-  "prConcurrentLimit": 0,
-  "prHourlyLimit": 0,
-  "separateMinorPatch": true,
   "pin": false,
   "rangeStrategy": "bump",
   "packageRules": [
-    {
-      "matchPackagePatterns": ["^@akashic/"],
-      "groupName": "all dependencies (akashic)",
-      "schedule": "at any time"
-    },
     {
       "matchUpdateTypes": ["minor"],
       "excludePackagePatterns": ["^@akashic/"],

--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,6 @@
   "extends": [
     "github>akashic-games/renovate-config"
   ],
-  "pin": false,
-  "rangeStrategy": "bump",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor"],


### PR DESCRIPTION
## このpull requestが解決する内容

renovate.json に @akashic/renovate-config の適応

renovate-config 適応によりスケジュールが non-office Time へ、akashic 関連は `at any time` になります。


## 破壊的な変更を含んでいるか?

- なし

