### PR TITLE
Refactor AudioSystem#setPlaybackRae()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 3.4.4
+その他変更
+ * `g.AudioSystem#_setPlaybackRate()` の整理
+
 ## 3.4.3
 
 不具合修正

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -149,7 +149,7 @@ export abstract class AudioSystem implements PdiAudioSystem {
 
 		this._suppressed = value !== 1.0;
 		this._updateMuted();
-		this._onMutedChanged();
+		this._onPlaybackRateChanged();
 	}
 
 	/**
@@ -168,6 +168,11 @@ export abstract class AudioSystem implements PdiAudioSystem {
 	 * @private
 	 */
 	abstract _onMutedChanged(): void;
+
+	/**
+	 * @private
+	 */
+	abstract _onPlaybackRateChanged(): void;
 }
 
 export class MusicAudioSystem extends AudioSystem {
@@ -231,6 +236,13 @@ export class MusicAudioSystem extends AudioSystem {
 	 * @private
 	 */
 	_onMutedChanged(): void {
+		this.player._changeMuted(this._muted);
+	}
+
+	/**
+	 * @private
+	 */
+	_onPlaybackRateChanged(): void {
 		this.player._changeMuted(this._muted);
 	}
 
@@ -304,10 +316,20 @@ export class SoundAudioSystem extends AudioSystem {
 	 * @private
 	 */
 	_onMutedChanged(): void {
-		if (this._muted) {
-			const players = this.players;
+		const players = this.players;
+		for (let i = 0; i < players.length; ++i) {
+			players[i]._changeMuted(this._muted);
+		}
+	}
+
+	/**
+	 * @private
+	 */
+	_onPlaybackRateChanged(): void {
+		const players = this.players;
+		if (this._suppressed) {
 			for (let i = 0; i < players.length; ++i) {
-				players[i]._changeMuted(this._muted);
+				players[i]._changeMuted(true);
 			}
 		}
 	}

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -149,6 +149,7 @@ export abstract class AudioSystem implements PdiAudioSystem {
 
 		this._suppressed = value !== 1.0;
 		this._updateMuted();
+		this._onMutedChanged();
 	}
 
 	/**
@@ -236,14 +237,6 @@ export class MusicAudioSystem extends AudioSystem {
 	/**
 	 * @private
 	 */
-	_setPlaybackRate(rate: number): void {
-		super._setPlaybackRate(rate);
-		this.player._changeMuted(this._muted);
-	}
-
-	/**
-	 * @private
-	 */
 	_handlePlay(e: AudioPlayerEvent): void {
 		if (e.player !== this._player)
 			throw ExceptionFactory.createAssertionError("MusicAudioSystem#_onPlayerPlayed: unexpected audio player");
@@ -311,22 +304,10 @@ export class SoundAudioSystem extends AudioSystem {
 	 * @private
 	 */
 	_onMutedChanged(): void {
-		const players = this.players;
-		for (let i = 0; i < players.length; ++i) {
-			players[i]._changeMuted(this._muted);
-		}
-	}
-
-	/**
-	 * @private
-	 */
-	_setPlaybackRate(rate: number): void {
-		super._setPlaybackRate(rate);
-
-		const players = this.players;
-		if (this._suppressed) {
+		if (this._muted) {
+			const players = this.players;
 			for (let i = 0; i < players.length; ++i) {
-				players[i]._changeMuted(true);
+				players[i]._changeMuted(this._muted);
 			}
 		}
 	}


### PR DESCRIPTION
## このpull requestが解決する内容

AudioSystem#_setPlaybackRate() を整理します。
- AudioSystem の派生クラス(MusicAudioSystem,SoundAudioSystem)では `_setPlaybackRate()` を `_onPlaybackRateChanged()` に変更、親クラスは`_setPlaybackRate()` から呼び出すようにします。


## 破壊的な変更を含んでいるか?

- なし
