### PR TITLE
chore: 非対応環境での GeneratedAsset の生成時にダミーのアセットを返すように

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## 3.5.0-beta.2
+* 非対応環境での GeneratedAsset の生成時にダミーのアセットを返すように
+
 ## 3.5.0-beta.1
 * @akashic/pdi-types@1.4.0-beta.1 に追従
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.5.0-beta.1",
+  "version": "3.5.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.5.0-beta.1",
+      "version": "3.5.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.5.0-beta.1",
+  "version": "3.5.0-beta.2",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -31,6 +31,7 @@ import type { AssetGenerationConfiguration } from "./AssetGenerationConfiguratio
 import type { AssetManagerLoadHandler } from "./AssetManagerLoadHandler";
 import type { AudioSystem } from "./AudioSystem";
 import type { AudioSystemManager } from "./AudioSystemManager";
+import { EmptyGeneratedVectorImageAsset } from "./auxiliary/EmptyGeneratedVectorImageAsset";
 import { EmptyVectorImageAsset } from "./auxiliary/EmptyVectorImageAsset";
 import { PartialImageAsset } from "./auxiliary/PartialImageAsset";
 import type { DynamicAssetConfiguration } from "./DynamicAssetConfiguration";
@@ -662,7 +663,7 @@ export class AssetManager implements AssetLoadHandler {
 		switch (conf.type) {
 			case "vector-image":
 				if (!resourceFactory.createVectorImageAssetFromString) {
-					throw ExceptionFactory.createAssertionError("AssertionError#_createFromAssetGenerationFor: unsupported");
+					return new EmptyGeneratedVectorImageAsset(conf.id, path, conf.data);
 				}
 				return resourceFactory.createVectorImageAssetFromString(conf.id, path, conf.data);
 			default:

--- a/src/auxiliary/EmptyGeneratedVectorImageAsset.ts
+++ b/src/auxiliary/EmptyGeneratedVectorImageAsset.ts
@@ -1,0 +1,10 @@
+import { EmptyVectorImageAsset } from "./EmptyVectorImageAsset";
+
+export class EmptyGeneratedVectorImageAsset extends EmptyVectorImageAsset {
+	data: string;
+
+	constructor(id: string, path: string, data: string) {
+		super(id, path, 0, 0);
+		this.data = data;
+	}
+}


### PR DESCRIPTION
## このpull requestが解決する内容
非対応環境での GeneratedAsset の生成時にダミーのアセットを返すように修正します。

## 破壊的な変更を含んでいるか?

- なし


