### PR TITLE
Add actions to v2-main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - v2-main
 
 env:
-  NODE_VERSION: 14
+  NODE_VERSION: 16
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Publish and Release
+
+on:
+  push:
+    branches:
+      - v2-main
+
+env:
+  NODE_VERSION: 14
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Publish and Release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - name: Prepare
+        run: |
+          npm ci
+          npm run build
+          npm test
+      - name: Publish and Release
+        uses: akashic-games/action-release@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,18 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    name: Node 14
+    runs-on: ${{ matrix.os }}
+    name: Node ${{ matrix.node }} / ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node: [14.x, 16.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: ${{ matrix.node }}
           cache: npm
       - name: Run test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,13 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Node 12
+    name: Node 14
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version: '14'
           cache: npm
       - name: Run test
         run: |


### PR DESCRIPTION
## このpull requestが解決する内容

- v2-main ブランチにマージされた時に、v2-main が publish & release されるようにするため、release.yml を追加。
- test.yml を main の test.yml に合わせ node バージョンを修正。
 
**動作確認**
個人リポジトリで main, v1-main, v2-main ブランチを用意し、それぞれのブランチにプルリクがマージされた時にそのブランチの actions が実行されることを確認。

main:  [PR](https://github.com/ShinobuTakahashi/workflow-test/pull/6 ) がマージ後に実行された [JOB](https://github.com/ShinobuTakahashi/workflow-test/runs/7871558835?check_suite_focus=true)
v1-main: [PR](https://github.com/ShinobuTakahashi/workflow-test/pull/7)  がマージ後に実行された [JOB](https://github.com/ShinobuTakahashi/workflow-test/runs/7871590480?check_suite_focus=true)
v2-main: [PR](https://github.com/ShinobuTakahashi/workflow-test/pull/8) がマージされた後に実行された [JOB](https://github.com/ShinobuTakahashi/workflow-test/runs/7871629807?check_suite_focus=true)

main の [JOB](https://github.com/ShinobuTakahashi/workflow-test/blob/main/.github/workflows/github-actions-demo.yml) のbranches 指定を main 以外に変えて PR をマージ -> 対象のJOBは実行されない。

## 破壊的な変更を含んでいるか?

- なし
