### PR TITLE
add SurfaceUtil#renderNinePatch()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## Unreleased changes
+* `SurfaceUtil#renderNinePatch()` の追加
+
 ## 3.5.0
 * @akashic/pdi-types@1.4.0 に追従
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## Unreleased changes
+## 3.5.1
 * `SurfaceUtil#renderNinePatch()` の追加
 
 ## 3.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/SurfaceUtil.ts
+++ b/src/SurfaceUtil.ts
@@ -80,10 +80,9 @@ export module SurfaceUtil {
 	 */
 	export function drawNinePatch(destSurface: Surface, srcSurface: Surface, borderWidth: CommonRect | number = 4): void {
 		const renderer = destSurface.renderer();
-		const destArea: CommonArea = { x: 0, y: 0, width: destSurface.width, height: destSurface.height };
 		renderer.begin();
 		renderer.clear();
-		renderNinePatch(renderer, destArea, srcSurface, borderWidth);
+		renderNinePatch(renderer, destSurface.width, destSurface.height, srcSurface, borderWidth);
 		renderer.end();
 	}
 
@@ -95,18 +94,18 @@ export module SurfaceUtil {
 	 * * Surface全体ではなく部分的に描画したい場合。drawNinePatch() では Surface 全体の描画にしか対応していないため。
 	 *
 	 * @param renderer 描画先 `Renderer`
-	 * @param destArea 描画先の描画範囲
-	 * @param srcSurface 描画元 `Surface`
+	 * @param width 描画先の横幅
+	 * @param height 描画先の縦幅
+	 * @param surface 描画元 `Surface`
 	 * @param borderWidth 上下左右の「拡大しない」領域の大きさ。すべて同じ値なら数値一つを渡すことができる。省略された場合、 `4`
 	 */
 	export function renderNinePatch(
 		renderer: Renderer,
-		destArea: CommonArea,
-		srcSurface: Surface,
+		width: number,
+		height: number,
+		surface: Surface,
 		borderWidth: CommonRect | number = 4
 	): void {
-		const { width, height } = destArea;
-
 		let border: CommonRect;
 		if (typeof borderWidth === "number") {
 			border = {
@@ -135,9 +134,9 @@ export module SurfaceUtil {
 		// 9  : 全方向へ拡縮
 
 		const sx1 = border.left;
-		const sx2 = srcSurface.width - border.right;
+		const sx2 = surface.width - border.right;
 		const sy1 = border.top;
-		const sy2 = srcSurface.height - border.bottom;
+		const sy2 = surface.height - border.bottom;
 		const dx1 = border.left;
 		const dx2 = width - border.right;
 		const dy1 = border.top;
@@ -177,12 +176,11 @@ export module SurfaceUtil {
 			{ x: dx2, y: dy2 }
 		];
 		renderer.save();
-		renderer.translate(destArea.x, destArea.y);
 		for (let i = 0; i < srcCorners.length; ++i) {
 			const c = srcCorners[i];
 			renderer.save();
 			renderer.translate(destCorners[i].x, destCorners[i].y);
-			renderer.drawImage(srcSurface, c.x, c.y, c.width, c.height, 0, 0);
+			renderer.drawImage(surface, c.x, c.y, c.width, c.height, 0, 0);
 			renderer.restore();
 		}
 		// Draw borders
@@ -204,7 +202,7 @@ export module SurfaceUtil {
 			renderer.save();
 			renderer.translate(d.x, d.y);
 			renderer.transform([d.width / s.width, 0, 0, d.height / s.height, 0, 0]);
-			renderer.drawImage(srcSurface, s.x, s.y, s.width, s.height, 0, 0);
+			renderer.drawImage(surface, s.x, s.y, s.width, s.height, 0, 0);
 			renderer.restore();
 		}
 		// Draw center
@@ -214,7 +212,7 @@ export module SurfaceUtil {
 		const dh = dy2 - dy1;
 		renderer.translate(dx1, dy1);
 		renderer.transform([dw / sw, 0, 0, dh / sh, 0, 0]);
-		renderer.drawImage(srcSurface, sx1, sy1, sw, sh, 0, 0);
+		renderer.drawImage(surface, sx1, sy1, sw, sh, 0, 0);
 		renderer.restore();
 	}
 }

--- a/src/SurfaceUtil.ts
+++ b/src/SurfaceUtil.ts
@@ -175,7 +175,6 @@ export module SurfaceUtil {
 			{ x: 0, y: dy2 },
 			{ x: dx2, y: dy2 }
 		];
-		renderer.save();
 		for (let i = 0; i < srcCorners.length; ++i) {
 			const c = srcCorners[i];
 			renderer.save();
@@ -210,6 +209,7 @@ export module SurfaceUtil {
 		const sh = sy2 - sy1;
 		const dw = dx2 - dx1;
 		const dh = dy2 - dy1;
+		renderer.save();
 		renderer.translate(dx1, dy1);
 		renderer.transform([dw / sw, 0, 0, dh / sh, 0, 0]);
 		renderer.drawImage(surface, sx1, sy1, sw, sh, 0, 0);

--- a/src/__tests__/SurfaceUtilSpec.ts
+++ b/src/__tests__/SurfaceUtilSpec.ts
@@ -1,6 +1,6 @@
 import type { ImageAsset as PdiImageAsset } from "@akashic/pdi-types";
 import { SurfaceUtil } from "..";
-import type { Renderer } from "./helpers";
+import { Renderer } from "./helpers";
 import { customMatchers, Game, skeletonRuntime, Surface } from "./helpers";
 
 expect.extend(customMatchers);
@@ -80,5 +80,56 @@ describe("test SurfaceUtil", () => {
 		// center
 		expect(drawImage[8].width).toBe(93);
 		expect(drawImage[8].height).toBe(97);
+	});
+
+	it("SurfaceUtil#rendererNinePatch()", () => {
+		const game = new Game({
+			width: 320,
+			height: 270,
+			main: "",
+			assets: {}
+		});
+		const renderer = new Renderer();
+		const srcSurface = game.resourceFactory.createSurface(200, 200);
+		const destArea = { x: 10, y: 10, width: 100, height: 100 };
+		const borderWidth = {
+			top: 1,
+			bottom: 2,
+			left: 3,
+			right: 4
+		};
+		SurfaceUtil.renderNinePatch(renderer, destArea, srcSurface, borderWidth);
+		const drawImage = renderer.methodCallParamsHistory("drawImage");
+		expect(drawImage.length).toBe(9);
+
+		// corners
+		expect(drawImage[0].width).toBe(3);
+		expect(drawImage[0].height).toBe(1);
+		expect(drawImage[1].width).toBe(4);
+		expect(drawImage[1].height).toBe(1);
+		expect(drawImage[2].width).toBe(3);
+		expect(drawImage[2].height).toBe(2);
+		expect(drawImage[3].width).toBe(4);
+		expect(drawImage[3].height).toBe(2);
+
+		// borders
+		expect(drawImage[4].width).toBe(193);
+		expect(drawImage[4].height).toBe(1);
+		expect(drawImage[5].width).toBe(3);
+		expect(drawImage[5].height).toBe(197);
+		expect(drawImage[6].width).toBe(4);
+		expect(drawImage[6].height).toBe(197);
+		expect(drawImage[7].width).toBe(193);
+		expect(drawImage[7].height).toBe(2);
+
+		// center
+		expect(drawImage[8].width).toBe(193);
+		expect(drawImage[8].height).toBe(197);
+
+		const translate = renderer.methodCallParamsHistory("translate");
+		expect(translate.length).toBe(10);
+		// (destArea.x, destArea.y)への移動
+		expect(translate[0].x).toBe(10);
+		expect(translate[0].y).toBe(10);
 	});
 });

--- a/src/__tests__/SurfaceUtilSpec.ts
+++ b/src/__tests__/SurfaceUtilSpec.ts
@@ -91,14 +91,15 @@ describe("test SurfaceUtil", () => {
 		});
 		const renderer = new Renderer();
 		const srcSurface = game.resourceFactory.createSurface(200, 200);
-		const destArea = { x: 10, y: 10, width: 100, height: 100 };
+		const width = 100;
+		const height = 100;
 		const borderWidth = {
 			top: 1,
 			bottom: 2,
 			left: 3,
 			right: 4
 		};
-		SurfaceUtil.renderNinePatch(renderer, destArea, srcSurface, borderWidth);
+		SurfaceUtil.renderNinePatch(renderer, width, height, srcSurface, borderWidth);
 		const drawImage = renderer.methodCallParamsHistory("drawImage");
 		expect(drawImage.length).toBe(9);
 
@@ -125,11 +126,5 @@ describe("test SurfaceUtil", () => {
 		// center
 		expect(drawImage[8].width).toBe(193);
 		expect(drawImage[8].height).toBe(197);
-
-		const translate = renderer.methodCallParamsHistory("translate");
-		expect(translate.length).toBe(10);
-		// (destArea.x, destArea.y)への移動
-		expect(translate[0].x).toBe(10);
-		expect(translate[0].y).toBe(10);
 	});
 });


### PR DESCRIPTION
## このpull requestが解決する内容
-  `SurfaceUtil#renderNinePatch()`を追加したことによって、surfaceを用意せずに直接rendererにナインパッチを描画することが可能になった

## 破壊的な変更を含んでいるか?
- なし

