### PR TITLE
feat: `g.Game#db`, `g.Game#_localDb` を弱参照で保持するように修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## unreleased changes
+## 3.6.0
 その他変更
 * `WeakRefKVS` の追加
 * `g.Game#db`, `g.Game#_localDb` を `WeakRefKVS` に変更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * `WeakRefKVS` の追加
 * `g.Game#db`, `g.Game#_localDb` を `WeakRefKVS` に変更
 
+### ゲーム開発者への影響
+`g.Game#db`, `g.Game#_localDb` の型が `WeakRefKVS` に変更されます。
+`g.game.db[e.id]` や `Object.keys(g.game.db)` のようにプロパティを参照していた場合は `g.game.db.get(e.id)` や `g.game.db.keys()` を利用するように修正してください。
+
 ## 3.5.1
 * `SurfaceUtil#renderNinePatch()` の追加
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## unreleased changes
+その他変更
+* `WeakRefKVS` の追加
+* `g.Game#db`, `g.Game#_localDb` を `WeakRefKVS` に変更
+
 ## 3.5.1
 * `SurfaceUtil#renderNinePatch()` の追加
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.5.1",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/EventConverter.ts
+++ b/src/EventConverter.ts
@@ -9,19 +9,20 @@ import { ExceptionFactory } from "./ExceptionFactory";
 import type { InternalOperationPluginOperation } from "./OperationPluginOperation";
 import type { Player } from "./Player";
 import { StorageValueStore } from "./Storage";
+import type { WeakRefKVS } from "./WeakRefKVS";
 
 /**
  * @ignore
  */
 // TODO: Game を意識しないインターフェース を検討する
-interface EventConverterParameterObejctGameLike {
-	db: { [idx: number]: E };
-	_localDb: { [id: number]: E };
+interface EventConverterParameterObjectGameLike {
+	db: WeakRefKVS<E>;
+	_localDb: WeakRefKVS<E>;
 	_decodeOperationPluginOperation: (code: number, op: (number | string)[]) => any;
 }
 
-export interface EventConverterParameterObejct {
-	game: EventConverterParameterObejctGameLike;
+export interface EventConverterParameterObject {
+	game: EventConverterParameterObjectGameLike;
 	playerId?: string;
 }
 
@@ -30,11 +31,11 @@ export interface EventConverterParameterObejct {
  * @ignore
  */
 export class EventConverter {
-	_game: EventConverterParameterObejctGameLike;
+	_game: EventConverterParameterObjectGameLike;
 	_playerId: string | null;
 	_playerTable: { [key: string]: Player };
 
-	constructor(param: EventConverterParameterObejct) {
+	constructor(param: EventConverterParameterObject) {
 		this._game = param.game;
 		this._playerId = param.playerId ?? null;
 		this._playerTable = {};
@@ -112,7 +113,7 @@ export class EventConverter {
 				local = pev[EventIndex.PointDown.Local];
 				pointerId = pev[EventIndex.PointDown.PointerId];
 				entityId = pev[EventIndex.PointDown.EntityId];
-				target = entityId == null ? undefined : entityId >= 0 ? this._game.db[entityId] : this._game._localDb[entityId];
+				target = entityId == null ? undefined : entityId >= 0 ? this._game.db.get(entityId) : this._game._localDb.get(entityId);
 				point = {
 					x: pev[EventIndex.PointDown.X],
 					y: pev[EventIndex.PointDown.Y]
@@ -123,7 +124,7 @@ export class EventConverter {
 				local = pev[EventIndex.PointMove.Local];
 				pointerId = pev[EventIndex.PointMove.PointerId];
 				entityId = pev[EventIndex.PointMove.EntityId];
-				target = entityId == null ? undefined : entityId >= 0 ? this._game.db[entityId] : this._game._localDb[entityId];
+				target = entityId == null ? undefined : entityId >= 0 ? this._game.db.get(entityId) : this._game._localDb.get(entityId);
 				point = {
 					x: pev[EventIndex.PointMove.X],
 					y: pev[EventIndex.PointMove.Y]
@@ -142,7 +143,7 @@ export class EventConverter {
 				local = pev[EventIndex.PointUp.Local];
 				pointerId = pev[EventIndex.PointUp.PointerId];
 				entityId = pev[EventIndex.PointUp.EntityId];
-				target = entityId == null ? undefined : entityId >= 0 ? this._game.db[entityId] : this._game._localDb[entityId];
+				target = entityId == null ? undefined : entityId >= 0 ? this._game.db.get(entityId) : this._game._localDb.get(entityId);
 				point = {
 					x: pev[EventIndex.PointUp.X],
 					y: pev[EventIndex.PointUp.Y]

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -537,13 +537,13 @@ export class Scene implements StorageLoaderHandler {
 		this.onStateChange.fire(this.state);
 
 		// TODO: (GAMEDEV-483) Sceneスタックがそれなりの量になると重くなるのでScene#dbが必要かもしれない
-		let gameDb = this.game.db;
-		for (const p in gameDb) {
-			if (gameDb.hasOwnProperty(p) && gameDb[p].scene === this) gameDb[p].destroy();
-		}
-		gameDb = this.game._localDb;
-		for (const p in gameDb) {
-			if (gameDb.hasOwnProperty(p) && gameDb[p].scene === this) gameDb[p].destroy();
+		for (const db of [this.game.db, this.game._localDb]) {
+			for (const key of db.keys()) {
+				const e = db.get(key);
+				if (e?.scene === this) {
+					e.destroy();
+				}
+			}
 		}
 
 		this._timer.destroy();

--- a/src/WeakRefKVS.ts
+++ b/src/WeakRefKVS.ts
@@ -1,0 +1,70 @@
+interface WeakRefLike<T extends object> {
+	deref(): T | undefined;
+}
+
+/**
+ * @private
+ */
+class PseudoWeakRef<T extends object> {
+	private _target: T;
+
+	constructor(target: T) {
+		this._target = target;
+	}
+
+	deref(): T | undefined {
+		return this._target;
+	}
+}
+
+/**
+ * 対象の値を弱参照として保持する Key-Value 型データストア。
+ * 通常、ゲーム開発者はこのクラスを利用する必要はない。
+ */
+export class WeakRefKVS<T extends object> {
+	_weakRefClass: any = typeof WeakRef !== "undefined" ? WeakRef<T> : PseudoWeakRef<T>;
+	_refMap: { [key: string]: WeakRefLike<T> } = Object.create(null);
+
+	set(key: string | number, value: T): void {
+		if (this._refMap[key]) {
+			this.delete(key);
+		}
+
+		this._refMap[key] = new this._weakRefClass(value);
+	}
+
+	get(key: string | number): T | undefined {
+		const ref = this._refMap[key];
+
+		if (!ref) {
+			return undefined;
+		}
+
+		return ref.deref();
+	}
+
+	has(key: string | number): boolean {
+		return key in this._refMap;
+	}
+
+	delete(key: string | number): void {
+		delete this._refMap[key];
+	}
+
+	keys(): string[] {
+		return Object.keys(this._refMap);
+	}
+
+	clear(): void {
+		this._refMap = Object.create(null);
+	}
+
+	/**
+	 * 参照されなくなった target のキーをマップから削除する。
+	 */
+	clean(): void {
+		for (const [key, ref] of Object.entries(this._refMap)) {
+			if (ref.deref() === undefined) this.delete(key);
+		}
+	}
+}

--- a/src/__tests__/ESpec.ts
+++ b/src/__tests__/ESpec.ts
@@ -72,8 +72,8 @@ describe("test E", () => {
 		expect(e.scene).toBe(runtime.scene);
 		expect(e.state).toBe(EntityStateFlags.Modified | EntityStateFlags.Hidden);
 		expect(e._hasTouchableChildren).toBe(false);
-		expect(e.id in runtime.game.db).toBe(false);
-		expect(e.id in runtime.game._localDb).toBe(true);
+		expect(runtime.game.db.get(e.id)).toBeUndefined();
+		expect(runtime.game._localDb.get(e.id)).toBe(e);
 		expect(e.x).toBe(10);
 		expect(e.y).toBe(20);
 		expect(e.width).toBe(5);
@@ -95,7 +95,7 @@ describe("test E", () => {
 			y: 10
 		});
 		expect(e.id).toBe(400);
-		expect(runtime.game.db[e.id]).toBe(e);
+		expect(runtime.game.db.get(e.id)).toBe(e);
 		expect(e.scene).toBe(runtime.scene);
 		expect(e.x).toBe(100);
 		expect(e.y).toBe(10);
@@ -250,9 +250,9 @@ describe("test E", () => {
 		const e3 = new E({ scene: runtime.scene });
 		expect(e2.scene).toBe(runtime.scene);
 		expect(e3.scene).toBe(runtime.scene);
-		expect(runtime.game.db[e.id]).toBe(e);
-		expect(runtime.game.db[e2.id]).toBe(e2);
-		expect(runtime.game.db[e3.id]).toBe(e3);
+		expect(runtime.game.db.get(e.id)).toBe(e);
+		expect(runtime.game.db.get(e2.id)).toBe(e2);
+		expect(runtime.game.db.get(e3.id)).toBe(e3);
 
 		e.append(e2);
 		expect(e.parent).toBe(runtime.scene);
@@ -261,11 +261,11 @@ describe("test E", () => {
 		e2.remove();
 		expect(e.parent).toBe(runtime.scene);
 		expect(e2.parent).toBeUndefined();
-		expect(runtime.game.db[e.id]).toBe(e);
-		expect(runtime.game.db[e2.id]).toBe(e2);
+		expect(runtime.game.db.get(e.id)).toBe(e);
+		expect(runtime.game.db.get(e2.id)).toBe(e2);
 
 		e2.destroy();
-		expect(runtime.game.db[e2.id]).toBeUndefined();
+		expect(runtime.game.db.get(e2.id)).toBeUndefined();
 		expect(e2.destroyed()).toBe(true);
 
 		runtime.scene.append(e3);
@@ -273,10 +273,10 @@ describe("test E", () => {
 
 		runtime.scene.remove(e3);
 		expect(e3.parent).toBeUndefined();
-		expect(runtime.game.db[e3.id]).toBe(e3);
+		expect(runtime.game.db.get(e3.id)).toBe(e3);
 
 		e3.destroy();
-		expect(runtime.game.db[e3.id]).toBeUndefined();
+		expect(runtime.game.db.get(e3.id)).toBeUndefined();
 	});
 
 	it("remove - AssertionError", () => {

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -9,7 +9,7 @@ describe("test Game", () => {
 	it("初期化", () => {
 		const game = new Game({ width: 320, height: 270, main: "", assets: {} }, undefined, "foo");
 		expect(game._idx).toBe(0);
-		expect(game.db).toEqual({});
+		expect(game.db.keys()).toEqual([]);
 		expect(game.renderers.length).toBe(0);
 		expect(game.scenes.length).toBe(0);
 		expect(game.random).toBeUndefined();
@@ -758,31 +758,33 @@ describe("test Game", () => {
 		const scene = new Scene({ game: game });
 		const e = new E({ scene: scene });
 		expect(e.id).toBe(1);
-		expect(game.db).toEqual({ 1: e });
-		const e2 = new E({ scene: scene });
+		expect(game.db.get(e.id)).toEqual(e);
+		expect(game.db.keys().length).toBe(1);
+		const e2 = new E({ scene });
 		expect(e2.id).toBe(2);
-		expect(game.db).toEqual({ 1: e, 2: e2 });
+		expect(game.db.get(e2.id)).toEqual(e2);
+		expect(game.db.keys().length).toBe(2);
 		const n = { id: undefined as any, age: 100 };
 		game.register(n as any);
-		expect(game.db[n.id]).toEqual(n);
+		expect(game.db.get(n.id)).toEqual(n);
 
 		const e3 = new E({ scene: scene, local: true });
-		expect(game._localDb[e3.id].id).toBe(e3.id);
+		expect(game._localDb.get(e3.id)!.id).toBe(e3.id);
 	});
 
 	it("unregister", () => {
 		const game = new Game({ width: 320, height: 320, main: "", assets: {} });
 		const scene = new Scene({ game: game });
 		const e = new E({ scene: scene });
-		expect(game.db).toEqual({ 1: e });
+		expect(game.db.get(e.id)).toEqual(e);
 		game.unregister(e);
-		expect(game.db).toEqual({});
+		expect(game.db.keys()).toEqual([]);
 
 		const e2 = new E({ scene: scene, local: true });
-		expect(game.db).toEqual({});
-		expect(game._localDb[e2.id]).toBe(e2);
+		expect(game.db.keys()).toEqual([]);
+		expect(game._localDb.get(e2.id)).toBe(e2);
 		game.unregister(e2);
-		expect(game._localDb[e2.id]).toBeUndefined();
+		expect(game._localDb.get(e2.id)).toBeUndefined();
 	});
 
 	it("terminateGame", () => {

--- a/src/__tests__/WeakRefKVSSpec.ts
+++ b/src/__tests__/WeakRefKVSSpec.ts
@@ -1,4 +1,4 @@
-import { WeakRefKVS } from "../WeakRefKVS";
+import { WeakRefKVS } from "..";
 
 describe("WeakRefKVS", () => {
 	it("check the CRUD operations", () => {

--- a/src/__tests__/WeakRefKVSSpec.ts
+++ b/src/__tests__/WeakRefKVSSpec.ts
@@ -1,0 +1,27 @@
+import { WeakRefKVS } from "../WeakRefKVS";
+
+describe("WeakRefKVS", () => {
+	it("check the CRUD operations", () => {
+		const db = new WeakRefKVS();
+		const target = {
+			value: "test"
+		};
+
+		db.set("key", target);
+		expect(db.get("key")).toBe(target);
+		expect(db.get("another-key")).toBeUndefined();
+
+		db.delete("key");
+		expect(db.get("key")).toBeUndefined();
+		expect(db.keys()).toEqual([]);
+
+		db.set("key-1", {});
+		db.set("key-2", {});
+		expect(db.keys()).toEqual(["key-1", "key-2"]);
+
+		db.clear();
+		expect(db.get("key-1")).toBeUndefined();
+		expect(db.get("key-2")).toBeUndefined();
+		expect(db.keys()).toEqual([]);
+	});
+});

--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -82,6 +82,7 @@ export * from "./Timer";
 export * from "./TimerManager";
 export * from "./Util";
 export * from "./VideoSystem";
+export * from "./WeakRefKVS";
 export * from "./Xorshift";
 export * from "./XorshiftRandomGenerator";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,11 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
-    "lib": ["es5"],
+    "lib": ["ES2021"],
     "strict": true,
     "declaration": true,
     "outDir": "lib",
-    "sourceMap": false,
+    "sourceMap": true,
     "useUnknownInCatchVariables": false,
     "types": ["console"],
     "typeRoots": [


### PR DESCRIPTION
## このpull requestが解決する内容
* `WeakRefKVS` を追加します
* `g.Game#db`, `g.Game#_localDb` を `WeakRefKVS` に変更します
  * `g.game.db[e.id]` や `Object.keys(g.game.db)` のようにプロパティを参照していた場合は `g.game.db.get(e.id)` や `g.game.db.keys()` を利用するように修正する必要があります


## 動作確認

<details>
<summary>展開</summary>

https://github.com/akashic-games/pdi-browser/pull/243 の修正を適用した engine-files にて参照の切れた `g.Sprite` の surface が破棄できていることを確認 (Canvas の dispose 時にログを出力)。

```javascript
module.exports = () => {
  const scene = new g.Scene({
    game: g.game
  });

  scene.onLoad.add(() => {
    scene.onUpdate.add(() => {
      const surface = g.game.resourceFactory.createSurface(100, 100);
      const sprite = new g.Sprite({
        scene,
        src: surface,
        width: 32,
        height: 32
      });
      scene.append(sprite);

      scene.setTimeout(() => {
        sprite.remove();
      }, 10);
    });
  });
  g.game.pushScene(scene);
}
```

![スクリーンショット 2022-09-21 11 50 13](https://user-images.githubusercontent.com/16933898/191403456-2f0959fe-b3df-4655-9297-f77090b2caa3.png)
</details>

## 破壊的な変更を含んでいるか?
- 部分的に **あり**
  - `g.Game#db`, `g.Game#_localDb` を直接参照している場合は修正が必要です。

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

