### PR TITLE
Fix jest.config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,12 +13,11 @@ module.exports = {
 		"js"
 	],
 	transform: {
-		"^.+\\.ts$": "ts-jest"
-	},
-	globals: {
-		"ts-jest": {
-			tsconfig: "tsconfig.jest.json"
-		}
+		"^.+\\.ts$": [
+			"ts-jest", {
+				tsconfig: "tsconfig.jest.json"
+			}
+		]
 	},
 	testMatch: [
 		"<rootDir>/src/__tests__/*Spec.ts"


### PR DESCRIPTION
## このpull requestが解決する内容

ts-jest@29 による jest.config.js の修正。
`globals` が deprecated となった。ts-jestの[document](https://kulshekhar.github.io/ts-jest/docs/getting-started/options)

renovate の#406 にマージします。

## 破壊的な変更を含んでいるか?

- なし

