### PR TITLE
show external modules information in api reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## Unreleased Changes
+その他変更
+* エントリポイントでexportしている外部モジュールもAPIリファレンスでデフォルト表示されるように
+
 ## 3.7.0
 * @akashic/pdi-types@1.5.0 に追従
 * @akashic/game-configuration@1.6.0 に追従

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## Unreleased Changes
+## 3.7.1
 その他変更
 * エントリポイントでexportしている外部モジュールもAPIリファレンスでデフォルト表示されるように
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,8 @@
+{
+    "visibilityFilters": {
+        "protected": false,
+        "private": false,
+        "inherited": true,
+        "external": true
+    }
+}


### PR DESCRIPTION
## このpull requestが解決する内容
* akashic-engine v3のAPIリファレンスにエントリポイントでexportしている外部モジュールがデフォルトだと表示されていなかったの問題が解決する
  * デフォルトで表示されるようにするためtypoedocの設定ファイルを追加した

## 破壊的な変更を含んでいるか?
- なし

