### PR TITLE
feat: add AudioPlayContext

### DIFF
--- a/src/AudioPlayContext.ts
+++ b/src/AudioPlayContext.ts
@@ -13,7 +13,6 @@ export interface AudioPlayContextParameterObject {
 }
 
 export class AudioPlayContext {
-
 	/**
 	 * この AudioPlayContext に紐づく音声アセット。
 	 */
@@ -68,9 +67,6 @@ export class AudioPlayContext {
 		this._resourceFactory = param.resourceFactory;
 		this._volume = param.volume ?? 1.0;
 		this._muted = !!param.muted;
-
-		this.onPlay.add(this._handlePlay, this);
-		this.onStop.add(this._handleStop, this);
 	}
 
 	play(): void {
@@ -103,24 +99,8 @@ export class AudioPlayContext {
 		const audioPlayer = this._resourceFactory.createAudioPlayer(this._system);
 		audioPlayer.changeVolume(this._volume);
 		audioPlayer._changeMuted(this._muted);
-		audioPlayer.onPlay.add(this._handleAudioPlayerPlay, this);
-		audioPlayer.onStop.add(this._handleAudioPlayerStop, this);
+		audioPlayer.onPlay.add(this.onPlay.fire, this.onPlay);
+		audioPlayer.onStop.add(this.onStop.fire, this.onStop);
 		return audioPlayer;
-	}
-
-	private _handleAudioPlayerPlay(): void {
-		this.onPlay.fire({});
-	}
-
-	private _handleAudioPlayerStop(): void {
-		this.onStop.fire({});
-	}
-
-	private _handlePlay(): void {
-		// do nothing
-	}
-
-	private _handleStop(): void {
-		// do nothing
 	}
 }

--- a/src/AudioPlayContext.ts
+++ b/src/AudioPlayContext.ts
@@ -40,7 +40,7 @@ export class AudioPlayContext {
 	/**
 	 * @private
 	 */
-	_player: AudioPlayer | null = null;
+	_player: AudioPlayer;
 
 	/**
 	 * @private
@@ -56,30 +56,23 @@ export class AudioPlayContext {
 		this._system = param.system;
 		this._resourceFactory = param.resourceFactory;
 		this._volume = param.volume ?? 1.0;
+		this._player = this._createAudioPlayer();
 	}
 
 	play(): void {
-		if (this._player) {
-			// 一つの Context で再生できる AudioPlayer は一つまでとする
-			this.stop();
-		}
-
-		this._player = this._createPlayer();
 		this._player.play(this.asset);
 	}
 
 	stop(): void {
-		// NOTE: AudioPlayer#stop() を呼んだ時点で AudioPlayer が開放される
-		this._player?.stop();
-		this._player = null;
+		this._player.stop();
 	}
 
 	changeVolume(vol: number): void {
 		this._volume = vol;
-		this._player?.changeVolume(vol);
+		this._player.changeVolume(vol);
 	}
 
-	private _createPlayer(): AudioPlayer {
+	private _createAudioPlayer(): AudioPlayer {
 		const audioPlayer = this._resourceFactory.createAudioPlayer(this._system);
 		audioPlayer.changeVolume(this._volume);
 		audioPlayer.onPlay.add(this.onPlay.fire, this.onPlay);

--- a/src/AudioPlayContext.ts
+++ b/src/AudioPlayContext.ts
@@ -9,7 +9,6 @@ export interface AudioPlayContextParameterObject {
 	system: AudioSystem; // TODO: AudioSystem への依存を削除
 	asset: AudioAsset;
 	volume?: number;
-	muted?: boolean;
 }
 
 export class AudioPlayContext {
@@ -48,17 +47,8 @@ export class AudioPlayContext {
 	 */
 	_volume: number;
 
-	/**
-	 * @private
-	 */
-	_muted: boolean;
-
 	get volume(): number {
 		return this._volume;
-	}
-
-	get muted(): boolean {
-		return this._muted;
 	}
 
 	constructor(param: AudioPlayContextParameterObject) {
@@ -66,7 +56,6 @@ export class AudioPlayContext {
 		this._system = param.system;
 		this._resourceFactory = param.resourceFactory;
 		this._volume = param.volume ?? 1.0;
-		this._muted = !!param.muted;
 	}
 
 	play(): void {
@@ -90,15 +79,9 @@ export class AudioPlayContext {
 		this._player?.changeVolume(vol);
 	}
 
-	changeMute(muted: boolean): void {
-		this._muted = muted;
-		this._player?._changeMuted(muted);
-	}
-
 	private _createPlayer(): AudioPlayer {
 		const audioPlayer = this._resourceFactory.createAudioPlayer(this._system);
 		audioPlayer.changeVolume(this._volume);
-		audioPlayer._changeMuted(this._muted);
 		audioPlayer.onPlay.add(this.onPlay.fire, this.onPlay);
 		audioPlayer.onStop.add(this.onStop.fire, this.onStop);
 		return audioPlayer;

--- a/src/AudioPlayContext.ts
+++ b/src/AudioPlayContext.ts
@@ -1,0 +1,126 @@
+import type { AudioAsset, AudioPlayer, AudioSystem, ResourceFactory } from "@akashic/pdi-types";
+import { Trigger } from "@akashic/trigger";
+
+export interface AudioPlayContextPlayEvent {}
+export interface AudioPlayContextStopEvent {}
+
+export interface AudioPlayContextParameterObject {
+	resourceFactory: ResourceFactory;
+	system: AudioSystem; // TODO: AudioSystem への依存を削除
+	asset: AudioAsset;
+	volume?: number;
+	muted?: boolean;
+}
+
+export class AudioPlayContext {
+
+	/**
+	 * この AudioPlayContext に紐づく音声アセット。
+	 */
+	readonly asset: AudioAsset;
+
+	/**
+	 * `play()` が呼び出された時に通知される `Trigger` 。
+	 */
+	readonly onPlay: Trigger<AudioPlayContextPlayEvent> = new Trigger();
+
+	/**
+	 * `stop()` が呼び出された時に通知される `Trigger` 。
+	 */
+	readonly onStop: Trigger<AudioPlayContextStopEvent> = new Trigger();
+
+	/**
+	 * @private
+	 */
+	_system: AudioSystem;
+
+	/**
+	 * @private
+	 */
+	_resourceFactory: ResourceFactory;
+
+	/**
+	 * @private
+	 */
+	_player: AudioPlayer | null = null;
+
+	/**
+	 * @private
+	 */
+	_volume: number;
+
+	/**
+	 * @private
+	 */
+	_muted: boolean;
+
+	get volume(): number {
+		return this._volume;
+	}
+
+	get muted(): boolean {
+		return this._muted;
+	}
+
+	constructor(param: AudioPlayContextParameterObject) {
+		this.asset = param.asset;
+		this._system = param.system;
+		this._resourceFactory = param.resourceFactory;
+		this._volume = param.volume ?? 1.0;
+		this._muted = !!param.muted;
+
+		this.onPlay.add(this._handlePlay, this);
+		this.onStop.add(this._handleStop, this);
+	}
+
+	play(): void {
+		if (this._player) {
+			// 一つの Context で再生できる AudioPlayer は一つまでとする
+			this.stop();
+		}
+
+		this._player = this._createPlayer();
+		this._player.play(this.asset);
+	}
+
+	stop(): void {
+		// NOTE: AudioPlayer#stop() を呼んだ時点で AudioPlayer が開放される
+		this._player?.stop();
+		this._player = null;
+	}
+
+	changeVolume(vol: number): void {
+		this._volume = vol;
+		this._player?.changeVolume(vol);
+	}
+
+	changeMute(muted: boolean): void {
+		this._muted = muted;
+		this._player?._changeMuted(muted);
+	}
+
+	private _createPlayer(): AudioPlayer {
+		const audioPlayer = this._resourceFactory.createAudioPlayer(this._system);
+		audioPlayer.changeVolume(this._volume);
+		audioPlayer._changeMuted(this._muted);
+		audioPlayer.onPlay.add(this._handleAudioPlayerPlay, this);
+		audioPlayer.onStop.add(this._handleAudioPlayerStop, this);
+		return audioPlayer;
+	}
+
+	private _handleAudioPlayerPlay(): void {
+		this.onPlay.fire({});
+	}
+
+	private _handleAudioPlayerStop(): void {
+		this.onStop.fire({});
+	}
+
+	private _handlePlay(): void {
+		// do nothing
+	}
+
+	private _handleStop(): void {
+		// do nothing
+	}
+}

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -1,4 +1,5 @@
 import type { AudioAsset, AudioPlayer, AudioPlayerEvent, ResourceFactory, AudioSystem as PdiAudioSystem } from "@akashic/pdi-types";
+import { AudioPlayContext } from "./AudioPlayContext";
 import { ExceptionFactory } from "./ExceptionFactory";
 
 export interface AudioSystemParameterObject {
@@ -81,6 +82,24 @@ export abstract class AudioSystem implements PdiAudioSystem {
 		this._muted = false;
 		this._resourceFactory = param.resourceFactory;
 		this._updateMuted();
+	}
+
+	play(asset: AudioAsset): AudioPlayContext {
+		const context = this.create(asset);
+		context.play();
+		return context;
+	}
+
+	create(asset: AudioAsset): AudioPlayContext {
+		// TODO: 依存関係の見直し
+		const context = new AudioPlayContext({
+			resourceFactory: this._resourceFactory,
+			asset,
+			system: this,
+			volume: 1.0,
+			muted: this._muted
+		});
+		return context;
 	}
 
 	abstract stopAll(): void;

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -96,8 +96,7 @@ export abstract class AudioSystem implements PdiAudioSystem {
 			resourceFactory: this._resourceFactory,
 			asset,
 			system: this,
-			volume: 1.0,
-			muted: this._muted
+			volume: 1.0
 		});
 		return context;
 	}

--- a/src/AudioSystemManager.ts
+++ b/src/AudioSystemManager.ts
@@ -1,6 +1,8 @@
-import type { ResourceFactory } from "@akashic/pdi-types";
+import type { AudioAsset, ResourceFactory } from "@akashic/pdi-types";
+import type { AudioPlayContext } from "./AudioPlayContext";
 import type { AudioSystem } from "./AudioSystem";
 import { MusicAudioSystem, SoundAudioSystem } from "./AudioSystem";
+import { ExceptionFactory } from "./ExceptionFactory";
 
 /**
  * `AudioSystem` の管理クラス。
@@ -12,23 +14,69 @@ export class AudioSystemManager {
 	/**
 	 * ループ再生可能な AudioSystem
 	 */
-	// @ts-ignore
 	music: AudioSystem;
 
 	/**
 	 * 効果音を扱う AudioSystem
 	 */
-	// @ts-ignore
 	sound: AudioSystem;
 
 	/**
 	 * @private
 	 */
-	_muted: boolean;
+	_muted: boolean = false;
+
+	/**
+	 * @private
+	 */
+	_resourceFactory: ResourceFactory;
 
 	constructor(resourceFactory: ResourceFactory) {
-		this._muted = false;
-		this._initializeAudioSystems(resourceFactory);
+		this._resourceFactory = resourceFactory;
+		this.music = new MusicAudioSystem({
+			id: "music",
+			muted: this._muted,
+			resourceFactory
+		});
+		this.sound = new SoundAudioSystem({
+			id: "sound",
+			muted: this._muted,
+			resourceFactory
+		});
+	}
+
+	/**
+	 * 対象の音声アセットの AudioPlayContext を生成する。
+	 *
+	 * @param asset 音声アセット
+	 */
+	create(asset: AudioAsset): AudioPlayContext {
+		if (asset._system.id === "music") {
+			return this.music.create(asset);
+		} else if (asset._system.id === "sound") {
+			return this.sound.create(asset);
+		} else {
+			throw ExceptionFactory.createAssertionError(
+				`AudioSystemManager#create(): unknown systemId "${asset._system.id}" for asset ID "${asset.id}"`
+			);
+		}
+	}
+
+	/**
+	 * 対象の音声アセットの AudioPlayContext を生成し、再生する。
+	 *
+	 * @param asset 音声アセット
+	 */
+	play(asset: AudioAsset): AudioPlayContext {
+		if (asset._system.id === "music") {
+			return this.music.play(asset);
+		} else if (asset._system.id === "sound") {
+			return this.sound.play(asset);
+		} else {
+			throw ExceptionFactory.createAssertionError(
+				`AudioSystemManager#play(): unknown systemId "${asset._system.id}" for asset ID "${asset.id}"`
+			);
+		}
 	}
 
 	/**
@@ -57,22 +105,6 @@ export class AudioSystemManager {
 	_setPlaybackRate(rate: number): void {
 		this.music._setPlaybackRate(rate);
 		this.sound._setPlaybackRate(rate);
-	}
-
-	/**
-	 * @private
-	 */
-	_initializeAudioSystems(resourceFactory: ResourceFactory): void {
-		this.music = new MusicAudioSystem({
-			id: "music",
-			muted: this._muted,
-			resourceFactory: resourceFactory
-		});
-		this.sound = new SoundAudioSystem({
-			id: "sound",
-			muted: this._muted,
-			resourceFactory: resourceFactory
-		});
 	}
 
 	stopAll(): void {

--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -12,7 +12,6 @@ export { Module } from "./Module";
 export { ShaderProgram } from "./ShaderProgram";
 export { VideoSystem } from "./VideoSystem";
 
-export * from "./AudioSystem";
 export * from "./entities/CacheableE";
 export * from "./entities/E";
 export * from "./entities/FilledRect";
@@ -26,6 +25,8 @@ export * from "./AssetHolder";
 export * from "./AssetLoadFailureInfo";
 export * from "./AssetManager";
 export * from "./AssetManagerLoadHandler";
+export * from "./AudioPlayContext";
+export * from "./AudioSystem";
 export * from "./AudioSystemManager";
 export * from "./BitmapFont";
 export * from "./Camera";


### PR DESCRIPTION
## このpull requestが解決する内容
`AudioPlayContext` を追加します。

## このpull requestが解決しない内容
* テストの追加
* `AudioSystem#stopAll()` などによる `AudioPlayContext` の操作

## example
音声の再生直後に 3000 ms のフェードインを加える例

```javascript
const tl = require("@akashic-extension/akashic-timeline");
const timeline = new tl.Timeline(scene);
const asset = scene.asset.getAudio("/assets/audio/bgm");
const context = g.game.audio.music.create(asset);

context.changeVolume(0);
context.play();

const tw =timeline.create()
  .every((_, p) => {
    const volume = p;
    context.changeVolume(volume);
}, 3000);

context.onStop.addOnce(() => {
  tw.cancel();
});

```

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

