### PR TITLE
feat: AudioSystem#stopAll() の実装およびテスト追加

### DIFF
--- a/src/AudioPlayContext.ts
+++ b/src/AudioPlayContext.ts
@@ -5,6 +5,7 @@ export interface AudioPlayContextPlayEvent {}
 export interface AudioPlayContextStopEvent {}
 
 export interface AudioPlayContextParameterObject {
+	id: string;
 	resourceFactory: ResourceFactory;
 	system: AudioSystem; // TODO: AudioSystem への依存を削除
 	asset: AudioAsset;
@@ -47,6 +48,11 @@ export class AudioPlayContext {
 	 */
 	_volume: number;
 
+	/**
+	 * @private
+	 */
+	_id: string;
+
 	get volume(): number {
 		return this._volume;
 	}
@@ -56,6 +62,7 @@ export class AudioPlayContext {
 		this._system = param.system;
 		this._resourceFactory = param.resourceFactory;
 		this._volume = param.volume ?? 1.0;
+		this._id = param.id;
 		this._player = this._createAudioPlayer();
 	}
 

--- a/src/__tests__/AudioPlayContextSpec.ts
+++ b/src/__tests__/AudioPlayContextSpec.ts
@@ -1,0 +1,105 @@
+import { AudioPlayContext, Scene } from "..";
+import type { GameConfiguration } from "..";
+import { Game } from "./helpers";
+
+describe("test AudioPlayContext", () => {
+	const gameConfiguration: GameConfiguration = {
+		width: 320,
+		height: 320,
+		fps: 30,
+		main: "mainScene",
+		audio: {
+			user2: {
+				loop: true,
+				hint: { streaming: true }
+			}
+		},
+		assets: {
+			zoo: {
+				type: "audio",
+				path: "/path/to/a/zoo",
+				virtualPath: "path/to/a/zoo",
+				systemId: "music",
+				duration: 1984
+			},
+			baz: {
+				type: "audio",
+				path: "/path/to/a/baz",
+				virtualPath: "path/to/a/baz",
+				systemId: "music",
+				duration: 42,
+				loop: false,
+				hint: { streaming: false }
+			},
+			qux: {
+				type: "audio",
+				path: "/path/to/a/qux",
+				virtualPath: "path/to/a/qux",
+				systemId: "sound",
+				duration: 667408
+			},
+			quux: {
+				type: "audio",
+				path: "/path/to/a/quux",
+				virtualPath: "path/to/a/quux",
+				systemId: "sound",
+				duration: 5972,
+				loop: true,
+				hint: { streaming: true }
+			}
+		}
+	};
+
+	const waitSceneLoaded = async (): Promise<{ game: Game; scene: Scene }> => {
+		return new Promise(resolve => {
+			const game = new Game(gameConfiguration);
+			const scene = new Scene({ game, assetIds: ["zoo", "baz", "qux", "quux"] });
+			game.pushScene(scene);
+			game._flushPostTickTasks();
+			scene._onReady.add(() => {
+				resolve({ game, scene });
+			});
+			scene._load();
+		});
+	};
+
+	it("初期化", async () => {
+		const { game, scene } = await waitSceneLoaded();
+
+		const resourceFactory = game.resourceFactory;
+		const music = game.audio.music;
+		const zoo = scene.asset.getAudioById("zoo");
+
+		const ctx1 = new AudioPlayContext({
+			id: "play-context-1",
+			resourceFactory,
+			system: music,
+			asset: zoo
+		});
+
+		expect(ctx1.asset).toEqual(zoo);
+		expect(ctx1._id).toBe("play-context-1");
+		expect(ctx1._system).toEqual(music);
+		expect(ctx1._volume).toBe(1.0);
+		expect(ctx1._player).toBeDefined();
+
+		const sound = game.audio.sound;
+		sound._setMuted(true);
+		sound.volume = 0.5;
+		const qux = scene.asset.getAudioById("qux");
+
+		const ctx2 = new AudioPlayContext({
+			id: "play-context-2",
+			resourceFactory,
+			system: sound,
+			asset: qux,
+			volume: 0.8
+		});
+
+		expect(ctx2.asset).toEqual(qux);
+		expect(ctx2._id).toBe("play-context-2");
+		expect(ctx2._system).toEqual(sound);
+		expect(ctx2._volume).toBe(0.8); // AudioSystem とは独立
+		expect(ctx2._player).toBeDefined();
+	});
+});

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -1,9 +1,10 @@
+import { AudioPlayContext } from "../AudioPlayContext";
 import type { AudioPlayer } from "./helpers";
 import { customMatchers, Game, ResourceFactory } from "./helpers";
 
 expect.extend(customMatchers);
 
-describe("test AudioPlayer", () => {
+describe("test AudioSystem", () => {
 	it("AudioSystem#volumeの入力値チェック", () => {
 		const game = new Game({ width: 320, height: 320, main: "", assets: {} });
 		const system = game.audio.music;
@@ -226,5 +227,111 @@ describe("test AudioPlayer", () => {
 		system.volume = 0.7;
 		expect(player.volume).toBe(0.3);
 		expect(system.volume).toBe(0.7);
+	});
+
+	describe("AudioPlayContext operations", () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+		})
+
+		it("MusicAudioSystem#create", () => {
+			const game = new Game({ width: 320, height: 320, main: "", assets: {} });
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+
+			const ctx1 = system.create(asset);
+			const ctx2 = system.create(asset);
+			const ctx3 = system.create(asset);
+
+			expect(ctx1.volume).toBe(1.0);
+			expect(ctx1._id).toBe("music-0");
+			expect(ctx2.volume).toBe(1.0);
+			expect(ctx2._id).toBe("music-1");
+			expect(ctx3.volume).toBe(1.0);
+			expect(ctx3._id).toBe("music-2");
+		});
+
+		it("SoundAudioSystem#create", () => {
+			const game = new Game({ width: 320, height: 320, main: "", assets: {} });
+			const system = game.audio.sound;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+
+			const ctx1 = system.create(asset);
+			const ctx2 = system.create(asset);
+			const ctx3 = system.create(asset);
+
+			expect(ctx1.volume).toBe(1.0);
+			expect(ctx1._id).toBe("sound-0");
+			expect(ctx2.volume).toBe(1.0);
+			expect(ctx2._id).toBe("sound-1");
+			expect(ctx3.volume).toBe(1.0);
+			expect(ctx3._id).toBe("sound-2");
+		});
+
+		it("MusicAudioSystem#play", () => {
+			const game = new Game({ width: 320, height: 320, main: "", assets: {} });
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+
+			const mockPlay = jest.spyOn(AudioPlayContext.prototype, "play");
+			const ctx = system.play(asset);
+
+			expect(ctx.volume).toBe(1.0);
+			expect(ctx._id).toBe("music-0");
+			expect(mockPlay).toBeCalledTimes(1);
+		});
+
+		it("SoundAudioSystem#play", () => {
+			const game = new Game({ width: 320, height: 320, main: "", assets: {} });
+			const system = game.audio.sound;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+
+			const mockPlay = jest.spyOn(AudioPlayContext.prototype, "play");
+			const ctx = system.play(asset);
+
+			expect(ctx.volume).toBe(1.0);
+			expect(ctx._id).toBe("sound-0");
+			expect(mockPlay).toBeCalledTimes(1);
+		});
+
+		it("MusicAudioSystem#stopAll", () => {
+			const game = new Game({ width: 320, height: 320, main: "", assets: {} });
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+
+			const ctx1 = system.play(asset);
+			const ctx2 = system.play(asset);
+			const ctx3 = system.play(asset);
+
+			const mockCtx1Stop = jest.spyOn(ctx1, "stop");
+			const mockCtx2Stop = jest.spyOn(ctx2, "stop");
+			const mockCtx3Stop = jest.spyOn(ctx3, "stop");
+
+			system.stopAll();
+
+			expect(mockCtx1Stop).toBeCalledTimes(1);
+			expect(mockCtx2Stop).toBeCalledTimes(1);
+			expect(mockCtx3Stop).toBeCalledTimes(1);
+		});
+
+		it("SoundAudioSystem#stopAll", () => {
+			const game = new Game({ width: 320, height: 320, main: "", assets: {} });
+			const system = game.audio.sound;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+
+			const ctx1 = system.play(asset);
+			const ctx2 = system.play(asset);
+			const ctx3 = system.play(asset);
+
+			const mockCtx1Stop = jest.spyOn(ctx1, "stop");
+			const mockCtx2Stop = jest.spyOn(ctx2, "stop");
+			const mockCtx3Stop = jest.spyOn(ctx3, "stop");
+
+			system.stopAll();
+
+			expect(mockCtx1Stop).toBeCalledTimes(1);
+			expect(mockCtx2Stop).toBeCalledTimes(1);
+			expect(mockCtx3Stop).toBeCalledTimes(1);
+		});
 	});
 });


### PR DESCRIPTION
## このpull requestが解決する内容
* `AudioSystem#stopAll()` の実装を追加します。
* `AudioPlayContext` のパラメータ引数に `id: string` を追加します。
* `AudioPlayContext` のテストを追加します。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

