### PR TITLE
feat: `AudioPlayContext` に紐づく音声アセットが解放されたタイミングでオーディオプレイヤーを明示的に停止するように修正

### DIFF
--- a/src/AudioPlayContext.ts
+++ b/src/AudioPlayContext.ts
@@ -64,6 +64,8 @@ export class AudioPlayContext {
 		this._volume = param.volume ?? 1.0;
 		this._id = param.id;
 		this._player = this._createAudioPlayer();
+
+		this.asset.onDestroyed.addOnce(this.stop, this);
 	}
 
 	play(): void {

--- a/src/__tests__/AudioPlayContextSpec.ts
+++ b/src/__tests__/AudioPlayContextSpec.ts
@@ -3,6 +3,10 @@ import type { GameConfiguration } from "..";
 import { Game } from "./helpers";
 
 describe("test AudioPlayContext", () => {
+	beforeAll(() => {
+		jest.resetAllMocks();
+	});
+
 	const gameConfiguration: GameConfiguration = {
 		width: 320,
 		height: 320,
@@ -63,7 +67,7 @@ describe("test AudioPlayContext", () => {
 		});
 	};
 
-	it("初期化", async () => {
+	it("initialize", async () => {
 		const { game, scene } = await prepareLoadedScene();
 
 		const resourceFactory = game.resourceFactory;
@@ -101,5 +105,25 @@ describe("test AudioPlayContext", () => {
 		expect(ctx2._system).toEqual(sound);
 		expect(ctx2._volume).toBe(0.8); // AudioSystem とは独立
 		expect(ctx2._player).toBeDefined();
+	});
+
+	it("should stop audio context when its asset has been destroyed", async () => {
+		const { game, scene } = await prepareLoadedScene();
+
+		const resourceFactory = game.resourceFactory;
+		const music = game.audio.music;
+		const zoo = scene.asset.getAudioById("zoo");
+
+		const ctx = new AudioPlayContext({
+			id: "play-context",
+			resourceFactory,
+			system: music,
+			asset: zoo
+		});
+
+		const mockStop = jest.spyOn(ctx._player, "stop");
+		zoo.onDestroyed.fire(zoo);
+
+		expect(mockStop).toBeCalledTimes(1);
 	});
 });

--- a/src/__tests__/AudioPlayContextSpec.ts
+++ b/src/__tests__/AudioPlayContextSpec.ts
@@ -3,7 +3,7 @@ import type { GameConfiguration } from "..";
 import { Game } from "./helpers";
 
 describe("test AudioPlayContext", () => {
-	beforeAll(() => {
+	beforeEach(() => {
 		jest.resetAllMocks();
 	});
 

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -304,6 +304,45 @@ describe("test Game", () => {
 		game._startLoadingGlobalAssets();
 	});
 
+	it("popScene & pushScene - reuse asset", done => {
+		const game = new Game({
+			width: 320,
+			height: 320,
+			main: "",
+			assets: {
+				foo: {
+					type: "image",
+					path: "/path1.png",
+					virtualPath: "path1.png",
+					width: 1,
+					height: 1
+				}
+			}
+		});
+
+		game._onLoad.add(() => {
+			// game.scenes テストのため _loaded を待つ必要がある
+			const scene1 = new Scene({ game, assetIds: ["foo"] });
+			const scene2 = new Scene({ game, assetIds: ["foo"] });
+			game.pushScene(scene1);
+
+			let scene1foo: Asset;
+
+			scene1.onLoad.addOnce(() => {
+				scene1foo = scene1.assets.foo;
+				game.popScene();
+				game.pushScene(scene2);
+			});
+			scene2.onLoad.addOnce(() => {
+				expect(game.scenes).toEqual([game._initialScene, scene2]);
+				// 同一IDのアセットを前のシーンで読み込んでいた場合はアセットの再読み込みが発生しない （= 同一インスタンスである） ことを確認
+				expect(scene1foo).toBe(scene2.assets.foo);
+				done();
+			});
+		});
+		game._startLoadingGlobalAssets();
+	});
+
 	it("replaceScene", done => {
 		const game = new Game({
 			width: 320,

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -334,7 +334,6 @@ describe("test Game", () => {
 				game.pushScene(scene2);
 			});
 			scene2.onLoad.addOnce(() => {
-				expect(game.scenes).toEqual([game._initialScene, scene2]);
 				// 同一IDのアセットを前のシーンで読み込んでいた場合はアセットの再読み込みが発生しない （= 同一インスタンスである） ことを確認
 				expect(scene1foo).toBe(scene2.assets.foo);
 				done();

--- a/src/__tests__/SceneSpec.ts
+++ b/src/__tests__/SceneSpec.ts
@@ -346,7 +346,7 @@ describe("test Scene", () => {
 	//     a -> b        -- (2)
 	// (1), (2) から
 	//     a -> b -> d   -- (3)
-	// また Assetmanager#requestAssets() の呼び出し箇所から、c は a または b の後にのみ生じる。よって (2) から
+	// また AssetManager#requestAssets() の呼び出し箇所から、c は a または b の後にのみ生じる。よって (2) から
 	//     a -> c        -- (4)
 	// さてここで我々が確認すべきことは「e は常に b, c, d すべての後に生じる」である。
 	// d が存在しないケースを踏まえると、(3), (4) から、確認すべきケースは次の五つである:
@@ -936,17 +936,17 @@ describe("test Scene", () => {
 	it("state - change order and count", done => {
 		const expected = [
 			["S1", "active"],
+			["S2", "active"],
 			["S1", "before-destroyed"],
 			["S1", "destroyed"],
-			["S2", "active"],
 			["S2", "deactive"],
 			["S3", "active"],
+			["S4", "active"],
 			["S3", "before-destroyed"],
 			["S3", "destroyed"],
-			["S4", "active"],
+			["S2", "active"],
 			["S4", "before-destroyed"],
 			["S4", "destroyed"],
-			["S2", "active"],
 			["S2", "before-destroyed"],
 			["S2", "destroyed"]
 		];


### PR DESCRIPTION
## このpull requestが解決する内容
* `AudioPlayContext` に紐づく音声アセットが解放されたタイミングでオーディオプレイヤーを明示的に停止するように修正
* シーン遷移に伴う直前のシーンの破壊タイミングを post-tick タスクの後に行うように修正
  * `g.Game#popScene()` と `g.Game#pushScene()` を同期的に実行したケースにおいて、両者のシーンで共通のアセットを利用していた場合はそのインスタンスを持ち越すようなります。 この挙動は `g.Game#replaceScene()` を利用していたケースにおいてのみ有効でした。

これにより `AudioPlayContext` の再生区間は「シーンで利用する音声アセットが解放されるまで」となります。

## 破壊的な変更を含んでいるか?
- なし


