### PR TITLE
feat: `AudioPlayContext` のマップ情報を適当な頻度でクリーンするように

### DIFF
--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -70,6 +70,13 @@ export abstract class AudioSystem implements PdiAudioSystem {
 	 */
 	_contextCount: number;
 
+	/**
+	 * `this._contextMap` から不要な参照を削除する頻度。
+	 * 10 を指定した場合 `AudioPlayContext` を 10 回生成する度に参照の削除が行われる。
+	 * @private
+	 */
+	abstract _contentMapCleaningFrequency: number;
+
 	// volumeの変更時には通知が必要なのでアクセサを使う。
 	// 呼び出し頻度が少ないため許容。
 	get volume(): number {
@@ -112,6 +119,9 @@ export abstract class AudioSystem implements PdiAudioSystem {
 			system: this,
 			volume: 1.0
 		});
+		if (this._contextCount % this._contentMapCleaningFrequency === 0) {
+			this._contextMap.clean();
+		}
 		this._contextMap.set(context._id, context);
 		return context;
 	}
@@ -227,6 +237,11 @@ export class MusicAudioSystem extends AudioSystem {
 	 */
 	_player: AudioPlayer | undefined;
 
+	/**
+	 * @private
+	 */
+	_contentMapCleaningFrequency: number = 5;
+
 	// Note: 音楽のないゲームの場合に無駄なインスタンスを作るのを避けるため、アクセサを使う
 	get player(): AudioPlayer {
 		if (!this._player) {
@@ -314,6 +329,11 @@ export class MusicAudioSystem extends AudioSystem {
 
 export class SoundAudioSystem extends AudioSystem {
 	players: AudioPlayer[];
+
+	/**
+	 * @private
+	 */
+	_contentMapCleaningFrequency: number = 50;
 
 	constructor(param: AudioSystemParameterObject) {
 		super(param);

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -333,5 +333,49 @@ describe("test AudioSystem", () => {
 			expect(mockCtx2Stop).toBeCalledTimes(1);
 			expect(mockCtx3Stop).toBeCalledTimes(1);
 		});
+
+		it("MusicAudioSystem: should be cleaned the context map every 5 times an audio context is created", () => {
+			const game = new Game({ width: 320, height: 320, main: "", assets: {} });
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const mockCleanMap = jest.spyOn(system._contextMap, "clean");
+
+			for (let i = 0; i < 1; i++) {
+				system.create(asset);
+			}
+			expect(mockCleanMap).toBeCalledTimes(0);
+
+			for (let i = 0; i < 5; i++) {
+				system.create(asset);
+			}
+			expect(mockCleanMap).toBeCalledTimes(1);
+
+			for (let i = 0; i < 5; i++) {
+				system.create(asset);
+			}
+			expect(mockCleanMap).toBeCalledTimes(2);
+		});
+
+		it("SoundAudioSystem: should be cleaned the context map every 50 times an audio context is created", () => {
+			const game = new Game({ width: 320, height: 320, main: "", assets: {} });
+			const system = game.audio.sound;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const mockCleanMap = jest.spyOn(system._contextMap, "clean");
+
+			for (let i = 0; i < 5; i++) {
+				system.create(asset);
+			}
+			expect(mockCleanMap).toBeCalledTimes(0);
+
+			for (let i = 0; i < 50; i++) {
+				system.create(asset);
+			}
+			expect(mockCleanMap).toBeCalledTimes(1);
+
+			for (let i = 0; i < 50; i++) {
+				system.create(asset);
+			}
+			expect(mockCleanMap).toBeCalledTimes(2);
+		});
 	});
 });


### PR DESCRIPTION
## このpull requestが解決する内容
`AudioSystem` に紐づく `AudioPlayContext` のマップ情報を以下の回数生成されるごとにクリーンするように修正します。
- music: `5`
- sound: `50`

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

