### PR TITLE
fix: 早送り中の AudioPlayContext の再生を抑制するように修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## unreleased changes
+## 3.9.1
 * 早送り中に `g.AudioPlayContext` の再生を抑制するように
 
 ## 3.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## unreleased changes
+* 早送り中に `g.AudioPlayContext` の再生を抑制するように
+
 ## 3.9.0
 * `g.AudioPlayContext` を追加
 * `g.AudioSystemManager#create()`, `g.AudioSystemManager#play()` を追加

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/AudioPlayContext.ts
+++ b/src/AudioPlayContext.ts
@@ -81,6 +81,20 @@ export class AudioPlayContext {
 		this._player.changeVolume(vol);
 	}
 
+	/**
+	 * @private
+	 */
+	_startSuppress(): void {
+		this._player.changeVolume(0);
+	}
+
+	/**
+	 * @private
+	 */
+	_endSuppress(): void {
+		this._player.changeVolume(this._volume);
+	}
+
 	private _createAudioPlayer(): AudioPlayer {
 		const audioPlayer = this._resourceFactory.createAudioPlayer(this._system);
 		audioPlayer.changeVolume(this._volume);

--- a/src/AudioPlayContext.ts
+++ b/src/AudioPlayContext.ts
@@ -8,6 +8,7 @@ export interface AudioPlayContextParameterObject {
 	id: string;
 	resourceFactory: ResourceFactory;
 	system: AudioSystem; // TODO: AudioSystem への依存を削除
+	systemId: string;
 	asset: AudioAsset;
 	volume?: number;
 }
@@ -53,6 +54,11 @@ export class AudioPlayContext {
 	 */
 	_id: string;
 
+	/**
+	 * @private
+	 */
+	_systemId: string;
+
 	get volume(): number {
 		return this._volume;
 	}
@@ -63,6 +69,7 @@ export class AudioPlayContext {
 		this._resourceFactory = param.resourceFactory;
 		this._volume = param.volume ?? 1.0;
 		this._id = param.id;
+		this._systemId = param.systemId;
 		this._player = this._createAudioPlayer();
 
 		this.asset.onDestroyed.addOnce(this.stop, this);
@@ -85,14 +92,22 @@ export class AudioPlayContext {
 	 * @private
 	 */
 	_startSuppress(): void {
-		this._player.changeVolume(0);
+		if (this._systemId === "music") {
+			this._player.changeVolume(0);
+			return;
+		}
+
+		this.stop();
 	}
 
 	/**
 	 * @private
 	 */
 	_endSuppress(): void {
-		this._player.changeVolume(this._volume);
+		if (this._systemId === "music") {
+			this._player.changeVolume(this._volume);
+			return;
+		}
 	}
 
 	private _createAudioPlayer(): AudioPlayer {

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -220,6 +220,9 @@ export abstract class AudioSystem implements PdiAudioSystem {
 	 * @private
 	 */
 	_startSuppress(): void {
+		// NOTE: 既存の AudioSystem は playbackRate に 1.0 以外を指定するとミュートとなる
+		this._setPlaybackRate(100);
+
 		for (const key of this._contextMap.keys()) {
 			const ctx = this._contextMap.get(key);
 			ctx?._startSuppress();
@@ -230,6 +233,9 @@ export abstract class AudioSystem implements PdiAudioSystem {
 	 * @private
 	 */
 	_endSuppress(): void {
+		// NOTE: 既存の AudioSystem は playbackRate に 1.0 を指定するとミュートが解除される
+		this._setPlaybackRate(1.0);
+
 		for (const key of this._contextMap.keys()) {
 			const ctx = this._contextMap.get(key);
 			ctx?._endSuppress();

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -218,6 +218,16 @@ export abstract class AudioSystem implements PdiAudioSystem {
 	/**
 	 * @private
 	 */
+	abstract _startSuppress(): void;
+
+	/**
+	 * @private
+	 */
+	abstract _endSuppress(): void;
+
+	/**
+	 * @private
+	 */
 	abstract _onVolumeChanged(): void;
 
 	/**
@@ -323,6 +333,26 @@ export class MusicAudioSystem extends AudioSystem {
 		if (this._destroyRequestedAssets[e.audio.id]) {
 			delete this._destroyRequestedAssets[e.audio.id];
 			e.audio.destroy();
+		}
+	}
+
+	/**
+	 * @private
+	 */
+	_startSuppress(): void {
+		for (const key of this._contextMap.keys()) {
+			const ctx = this._contextMap.get(key);
+			ctx?._startSuppress();
+		}
+	}
+
+	/**
+	 * @private
+	 */
+	_endSuppress(): void {
+		for (const key of this._contextMap.keys()) {
+			const ctx = this._contextMap.get(key);
+			ctx?._endSuppress();
 		}
 	}
 }
@@ -431,5 +461,22 @@ export class SoundAudioSystem extends AudioSystem {
 		for (let i = 0; i < this.players.length; ++i) {
 			this.players[i]._notifyVolumeChanged();
 		}
+	}
+
+	/**
+	 * @private
+	 */
+	_startSuppress(): void {
+		for (const key of this._contextMap.keys()) {
+			const ctx = this._contextMap.get(key);
+			ctx?.stop();
+		}
+	}
+
+	/**
+	 * @private
+	 */
+	_endSuppress(): void {
+		// do nothing
 	}
 }

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -117,6 +117,7 @@ export abstract class AudioSystem implements PdiAudioSystem {
 			resourceFactory: this._resourceFactory,
 			asset,
 			system: this,
+			systemId: this.id,
 			volume: 1.0
 		});
 		if (this._contextCount % this._contentMapCleaningFrequency === 0) {
@@ -218,12 +219,22 @@ export abstract class AudioSystem implements PdiAudioSystem {
 	/**
 	 * @private
 	 */
-	abstract _startSuppress(): void;
+	_startSuppress(): void {
+		for (const key of this._contextMap.keys()) {
+			const ctx = this._contextMap.get(key);
+			ctx?._startSuppress();
+		}
+	}
 
 	/**
 	 * @private
 	 */
-	abstract _endSuppress(): void;
+	_endSuppress(): void {
+		for (const key of this._contextMap.keys()) {
+			const ctx = this._contextMap.get(key);
+			ctx?._endSuppress();
+		}
+	}
 
 	/**
 	 * @private
@@ -335,26 +346,6 @@ export class MusicAudioSystem extends AudioSystem {
 			e.audio.destroy();
 		}
 	}
-
-	/**
-	 * @private
-	 */
-	_startSuppress(): void {
-		for (const key of this._contextMap.keys()) {
-			const ctx = this._contextMap.get(key);
-			ctx?._startSuppress();
-		}
-	}
-
-	/**
-	 * @private
-	 */
-	_endSuppress(): void {
-		for (const key of this._contextMap.keys()) {
-			const ctx = this._contextMap.get(key);
-			ctx?._endSuppress();
-		}
-	}
 }
 
 export class SoundAudioSystem extends AudioSystem {
@@ -461,22 +452,5 @@ export class SoundAudioSystem extends AudioSystem {
 		for (let i = 0; i < this.players.length; ++i) {
 			this.players[i]._notifyVolumeChanged();
 		}
-	}
-
-	/**
-	 * @private
-	 */
-	_startSuppress(): void {
-		for (const key of this._contextMap.keys()) {
-			const ctx = this._contextMap.get(key);
-			ctx?.stop();
-		}
-	}
-
-	/**
-	 * @private
-	 */
-	_endSuppress(): void {
-		// do nothing
 	}
 }

--- a/src/AudioSystemManager.ts
+++ b/src/AudioSystemManager.ts
@@ -103,8 +103,29 @@ export class AudioSystemManager {
 	 * @private
 	 */
 	_setPlaybackRate(rate: number): void {
-		this.music._setPlaybackRate(rate);
-		this.sound._setPlaybackRate(rate);
+		if (rate !== 1.0) {
+			this._startSuppress();
+		} else {
+			this._endSuppress();
+		}
+	}
+
+	_startSuppress(): void {
+		// NOTE: 既存の AudioSystem は playbackRate に 1.0 以外を指定するとミュートとなる
+		this.music._setPlaybackRate(100);
+		this.sound._setPlaybackRate(100);
+
+		this.music._startSuppress();
+		this.sound._startSuppress();
+	}
+
+	_endSuppress(): void {
+		// NOTE: 既存の AudioSystem は playbackRate に 1.0 を指定するとミュートが解除される
+		this.music._setPlaybackRate(1.0);
+		this.sound._setPlaybackRate(1.0);
+
+		this.music._endSuppress();
+		this.sound._endSuppress();
 	}
 
 	stopAll(): void {

--- a/src/AudioSystemManager.ts
+++ b/src/AudioSystemManager.ts
@@ -103,27 +103,16 @@ export class AudioSystemManager {
 	 * @private
 	 */
 	_setPlaybackRate(rate: number): void {
-		if (rate !== 1.0) {
-			this._startSuppress();
-		} else {
-			this._endSuppress();
-		}
+		this.music._setPlaybackRate(rate);
+		this.sound._setPlaybackRate(rate);
 	}
 
 	_startSuppress(): void {
-		// NOTE: 既存の AudioSystem は playbackRate に 1.0 以外を指定するとミュートとなる
-		this.music._setPlaybackRate(100);
-		this.sound._setPlaybackRate(100);
-
 		this.music._startSuppress();
 		this.sound._startSuppress();
 	}
 
 	_endSuppress(): void {
-		// NOTE: 既存の AudioSystem は playbackRate に 1.0 を指定するとミュートが解除される
-		this.music._setPlaybackRate(1.0);
-		this.sound._setPlaybackRate(1.0);
-
 		this.music._endSuppress();
 		this.sound._endSuppress();
 	}

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1383,16 +1383,14 @@ export class Game {
 	 * @private
 	 */
 	_startSuppressAudio(): void {
-		// FIXME: this.audio._startSuppress() を直接呼ぶように修正
-		this._setAudioPlaybackRate(100);
+		this.audio._startSuppress();
 	}
 
 	/**
 	 * @private
 	 */
 	_endSuppressAudio(): void {
-		// FIXME: this.audio._endSuppress() を直接呼ぶように修正
-		this._setAudioPlaybackRate(1.0);
+		this.audio._endSuppress();
 	}
 
 	/**

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1382,6 +1382,22 @@ export class Game {
 	/**
 	 * @private
 	 */
+	_startSuppressAudio(): void {
+		// FIXME: this.audio._startSuppress() を直接呼ぶように修正
+		this._setAudioPlaybackRate(100);
+	}
+
+	/**
+	 * @private
+	 */
+	_endSuppressAudio(): void {
+		// FIXME: this.audio._endSuppress() を直接呼ぶように修正
+		this._setAudioPlaybackRate(1.0);
+	}
+
+	/**
+	 * @private
+	 */
 	_setMuted(muted: boolean): void {
 		this.audio._setMuted(muted);
 	}

--- a/src/__tests__/AudioPlayContextSpec.ts
+++ b/src/__tests__/AudioPlayContextSpec.ts
@@ -127,7 +127,7 @@ describe("test AudioPlayContext", () => {
 		expect(mockStop).toBeCalledTimes(1);
 	});
 
-	it("should suppress the audio player when AudioPlayContext#_suppress()", async () => {
+	it("should suppress the audio player when AudioPlayContext#_suppress() is called", async () => {
 		const { game, scene } = await prepareLoadedScene();
 
 		const resourceFactory = game.resourceFactory;

--- a/src/__tests__/AudioPlayContextSpec.ts
+++ b/src/__tests__/AudioPlayContextSpec.ts
@@ -126,4 +126,26 @@ describe("test AudioPlayContext", () => {
 
 		expect(mockStop).toBeCalledTimes(1);
 	});
+
+	it("should suppress the audio player when AudioPlayContext#_suppress()", async () => {
+		const { game, scene } = await prepareLoadedScene();
+
+		const resourceFactory = game.resourceFactory;
+		const music = game.audio.music;
+		const zoo = scene.asset.getAudioById("zoo");
+
+		const ctx = new AudioPlayContext({
+			id: "play-context",
+			resourceFactory,
+			system: music,
+			asset: zoo
+		});
+
+		ctx.changeVolume(0.3);
+		ctx._startSuppress();
+		expect(ctx._player.volume).toBe(0);
+
+		ctx._endSuppress();
+		expect(ctx._player.volume).toBe(0.3);
+	});
 });

--- a/src/__tests__/AudioPlayContextSpec.ts
+++ b/src/__tests__/AudioPlayContextSpec.ts
@@ -78,6 +78,7 @@ describe("test AudioPlayContext", () => {
 			id: "play-context-1",
 			resourceFactory,
 			system: music,
+			systemId: music.id,
 			asset: zoo
 		});
 
@@ -96,6 +97,7 @@ describe("test AudioPlayContext", () => {
 			id: "play-context-2",
 			resourceFactory,
 			system: sound,
+			systemId: sound.id,
 			asset: qux,
 			volume: 0.8
 		});
@@ -118,6 +120,7 @@ describe("test AudioPlayContext", () => {
 			id: "play-context",
 			resourceFactory,
 			system: music,
+			systemId: music.id,
 			asset: zoo
 		});
 
@@ -132,20 +135,38 @@ describe("test AudioPlayContext", () => {
 
 		const resourceFactory = game.resourceFactory;
 		const music = game.audio.music;
+		const sound = game.audio.sound;
 		const zoo = scene.asset.getAudioById("zoo");
 
-		const ctx = new AudioPlayContext({
-			id: "play-context",
+		const ctx1 = new AudioPlayContext({
+			id: "play-context-1",
 			resourceFactory,
 			system: music,
+			systemId: music.id,
 			asset: zoo
 		});
 
-		ctx.changeVolume(0.3);
-		ctx._startSuppress();
-		expect(ctx._player.volume).toBe(0);
+		ctx1.changeVolume(0.3);
+		ctx1._startSuppress();
+		expect(ctx1._player.volume).toBe(0);
 
-		ctx._endSuppress();
-		expect(ctx._player.volume).toBe(0.3);
+		ctx1._endSuppress();
+		// systemId: music の場合は endSuppress 後に再生を続ける
+		expect(ctx1._player.volume).toBe(0.3);
+
+		const ctx2 = new AudioPlayContext({
+			id: "play-context-2",
+			resourceFactory,
+			system: sound,
+			systemId: sound.id,
+			asset: zoo
+		});
+
+		const mockCtx2Stop = jest.spyOn(ctx2._player, "stop");
+		ctx2._startSuppress();
+
+		// systemId: music 以外の場合は startSuppress 時点で停止する
+		expect(mockCtx2Stop).toBeCalledTimes(1);
+		ctx2._endSuppress();
 	});
 });

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -377,5 +377,53 @@ describe("test AudioSystem", () => {
 			}
 			expect(mockCleanMap).toBeCalledTimes(2);
 		});
+
+		it("MusicAudioSystem: should suppress audio players when AudioSystem#_startSuppress() is called", () => {
+			const game = new Game({ width: 320, height: 320, main: "", assets: {} });
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+
+			const ctx1 = system.create(asset);
+			const ctx2 = system.create(asset);
+			const ctx3 = system.create(asset);
+
+			expect(ctx1._player.volume).toBe(1.0);
+			expect(ctx2._player.volume).toBe(1.0);
+			expect(ctx3._player.volume).toBe(1.0);
+
+			system._startSuppress();
+			expect(ctx1._player.volume).toBe(0);
+			expect(ctx2._player.volume).toBe(0);
+			expect(ctx3._player.volume).toBe(0);
+
+			system._endSuppress();
+			expect(ctx1._player.volume).toBe(1.0);
+			expect(ctx2._player.volume).toBe(1.0);
+			expect(ctx3._player.volume).toBe(1.0);
+		});
+
+		it("SoundAudioSystem: should suppress audio players when AudioSystem#_startSuppress() is called", () => {
+			const game = new Game({ width: 320, height: 320, main: "", assets: {} });
+			const system = game.audio.sound;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+
+			const ctx1 = system.create(asset);
+			const ctx2 = system.create(asset);
+			const ctx3 = system.create(asset);
+
+			expect(ctx1._player.volume).toBe(1.0);
+			expect(ctx2._player.volume).toBe(1.0);
+			expect(ctx3._player.volume).toBe(1.0);
+
+			const mockCtx1Stop = jest.spyOn(ctx1._player, "stop");
+			const mockCtx2Stop = jest.spyOn(ctx2._player, "stop");
+			const mockCtx3Stop = jest.spyOn(ctx3._player, "stop");
+
+			system._startSuppress();
+
+			expect(mockCtx1Stop).toBeCalledTimes(1);
+			expect(mockCtx2Stop).toBeCalledTimes(1);
+			expect(mockCtx3Stop).toBeCalledTimes(1);
+		});
 	});
 });

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -387,9 +387,13 @@ describe("test AudioSystem", () => {
 			const ctx2 = system.create(asset);
 			const ctx3 = system.create(asset);
 
-			expect(ctx1._player.volume).toBe(1.0);
-			expect(ctx2._player.volume).toBe(1.0);
-			expect(ctx3._player.volume).toBe(1.0);
+			ctx1.changeVolume(0.3);
+			ctx2.changeVolume(0.4);
+			ctx3.changeVolume(0.5);
+
+			expect(ctx1._player.volume).toBe(0.3);
+			expect(ctx2._player.volume).toBe(0.4);
+			expect(ctx3._player.volume).toBe(0.5);
 
 			system._startSuppress();
 			expect(ctx1._player.volume).toBe(0);
@@ -397,9 +401,9 @@ describe("test AudioSystem", () => {
 			expect(ctx3._player.volume).toBe(0);
 
 			system._endSuppress();
-			expect(ctx1._player.volume).toBe(1.0);
-			expect(ctx2._player.volume).toBe(1.0);
-			expect(ctx3._player.volume).toBe(1.0);
+			expect(ctx1._player.volume).toBe(0.3);
+			expect(ctx2._player.volume).toBe(0.4);
+			expect(ctx3._player.volume).toBe(0.5);
 		});
 
 		it("SoundAudioSystem: should suppress audio players when AudioSystem#_startSuppress() is called", () => {

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -1056,9 +1056,6 @@ describe("test Game", () => {
 		const game = new Game({ width: 320, height: 320, main: "", assets: {} });
 
 		expect(game.audio._muted).toBe(false);
-		expect(() => {
-			game._setAudioPlaybackRate(-0.5);
-		}).toThrowError("AssertionError");
 
 		expect(game.audio.sound._muted).toBe(false);
 		expect(game.audio.music._muted).toBe(false);


### PR DESCRIPTION
## このpull requestが解決する内容
早送り中の AudioPlayContext の再生を抑制するように修正します。

## 動作確認
本修正を入れた serve にて以下のミニマムコンテンツが期待通り動作することを確認。

* 早送り中に音声が鳴らないことを確認
* 早送り後に BGM (systemId: music) が鳴ることを確認
* 早送り後に SE (systemId: sound) が鳴らないことを確認

<details>
<summary>展開</summary>

```javascript
module.exports = () => {
  const scene = new g.Scene({
    game: g.game,
    assetPaths: ["/assets/*"],
  });

  scene.onLoad.addOnce(() => {
    const bgm = g.game.audio.create(scene.asset.getAudio("/assets/bgm"));
    bgm.changeVolume(0.1);
    bgm.play();

    // const bgm = scene.asset.getAudio("/assets/bgm").play();
    // bgm.changeVolume(0.1);

    const rect1 = new g.FilledRect({
      scene,
      cssColor: "red",
      width: 32,
      height: 32,
      touchable: true,
    });
    rect1.onPointDown.add(() => {
      const se = g.game.audio.create(scene.asset.getAudio("/assets/se"));
      se.play();
    });
    scene.append(rect1);

    const rect2 = new g.FilledRect({
      scene,
      cssColor: "blue",
      width: 32,
      height: 32,
      x: 40,
      touchable: true,
    });
    rect2.onPointDown.add(() => {
      scene.asset.getAudio("/assets/se").play();
    });
    scene.append(rect2);
  });

  g.game.pushScene(scene);
};
```
</details>

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

