### PR TITLE
feat: クロスフェード機構を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # ChangeLog
 
+## 3.9.2
+機能追加
+* `g.AudioUtil` を追加
+  * 音声のフェードイン・フェードアウト・クロスフェード等の機能を提供します。
+* `g.Game#onUpdate` を追加
+  * ティックの進行後 (`g.Scene#onUpdate` が発火した後) に発火します。
+* `g.Util#clamp()` を追加
+* `EasingFunction` `AudioTransitionContext` を追加
+
 ## 3.9.1
 * 早送り中に `g.AudioPlayContext` の再生を抑制するように
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.9.1",
+      "version": "3.9.2",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/AudioUtil.ts
+++ b/src/AudioUtil.ts
@@ -14,12 +14,13 @@ export type EasingFunction = (t: number, b: number, c: number, d: number) => num
 
 export type AudioFadeContext = {
 	/**
-	 * フェードイン・フェードアウトを即座に完了する。
+	 * フェードを即座に完了する。
+	 * 音量はフェード完了後の値となる。
 	 */
 	complete: () => void;
 	/**
-	 * フェードイン・フェードアウトを取り消す。
-	 * @param revert イージング実行前まで戻すかどうか。省略時は `false` 。
+	 * フェードを取り消す。音量はこの関数を実行した時点での値となる。
+	 * @param revert 音量をフェード実行前まで戻すかどうか。省略時は `false` 。
 	 */
 	cancel: (revert?: boolean) => void;
 };

--- a/src/AudioUtil.ts
+++ b/src/AudioUtil.ts
@@ -1,0 +1,157 @@
+import type { AudioPlayContext } from "./AudioPlayContext";
+import type { Game } from "./Game";
+import { Util } from "./Util";
+
+/**
+ * イージング関数。
+ *
+ * @param t 経過時間
+ * @param b 開始位置
+ * @param c 差分
+ * @param d 所要時間
+ */
+export type EasingFunction = (t: number, b: number, c: number, d: number) => number;
+
+/**
+ * イージング終了のための関数群。
+ */
+export type EasingFinishFunctions = {
+	/**
+	 * イージングを即座に完了する。
+	 */
+	complete: () => void;
+	/**
+	 * イージングを取り消す。
+	 * @param revert イージング実行前まで戻すかどうか。省略時は `false` 。
+	 */
+	cancel: (revert?: boolean) => void;
+};
+
+/**
+ * linear のイージング関数。
+ */
+const linear: EasingFunction = (t: number, b: number, c: number, d: number) => (c * t) / d + b;
+
+/**
+ * Audio に関連するユーティリティ。
+ */
+export module AudioUtil {
+	/**
+	 * 音声をフェードインさせる。
+	 *
+	 * @param game 対象の `Game`。
+	 * @param context 対象の `AudioPlayContext` 。
+	 * @param duration フェードインの長さ (ms)。
+	 * @param to フェードイン後の音量。0 未満または 1 より大きい値を指定した場合の挙動は不定である。省略時は `1` 。
+	 * @param easing イージング関数。省略時は linear 。
+	 */
+	export function fadeIn(
+		game: Game,
+		context: AudioPlayContext,
+		duration: number,
+		to: number = 1,
+		easing: EasingFunction = linear
+	): EasingFinishFunctions {
+		context.changeVolume(0);
+		context.play();
+		const cancel = fade(game, context, duration, 0, to, easing);
+
+		return {
+			complete: () => {
+				cancel();
+				context.changeVolume(to);
+			},
+			cancel: (revert: boolean = false) => {
+				cancel();
+				if (revert) {
+					context.changeVolume(0);
+					context.stop();
+				}
+			}
+		};
+	}
+
+	/**
+	 * 音声をフェードアウトさせる。
+	 *
+	 * @param game 対象の `Game`。
+	 * @param context 対象の `AudioPlayContext` 。
+	 * @param duration フェードインの長さ (ms)。
+	 * @param easing イージング関数。省略時は linear が指定される。
+	 */
+	export function fadeOut(
+		game: Game,
+		context: AudioPlayContext,
+		duration: number,
+		easing: EasingFunction = linear
+	): EasingFinishFunctions {
+		const from = context.volume;
+		const cancel = fade(game, context, duration, from, -from, easing);
+
+		return {
+			complete: () => {
+				cancel();
+				context.changeVolume(0);
+				context.stop();
+			},
+			cancel: (revert: boolean = false) => {
+				cancel();
+				if (revert) {
+					context.changeVolume(from);
+				}
+			}
+		};
+	}
+
+	/**
+	 * 二つの音声をクロスフェードさせる。
+	 *
+	 * @param game 対象の `Game`。
+	 * @param fadeInContext フェードイン対象の `AudioPlayContext` 。
+	 * @param fadeOutContext フェードアウト対象の `AudioPlayContext` 。
+	 * @param duration クロスフェードの長さ (ms)。
+	 * @param to クロスフェード後の音量。0 未満または 1 より大きい値を指定した場合の挙動は不定。省略時は `1` 。
+	 * @param easing イージング関数。フェードインとフェードアウトで共通であることに注意。省略時は linear が指定される。
+	 */
+	export function crossFade(
+		game: Game,
+		fadeInContext: AudioPlayContext,
+		fadeOutContext: AudioPlayContext,
+		duration: number,
+		to: number = 1,
+		easing: EasingFunction = linear
+	): EasingFinishFunctions {
+		const fadeInFuncs = fadeIn(game, fadeInContext, duration, to, easing);
+		const fadeOutFuncs = fadeOut(game, fadeOutContext, duration, easing);
+
+		return {
+			complete: () => {
+				fadeInFuncs.complete();
+				fadeOutFuncs.complete();
+			},
+			cancel: (revert: boolean = false) => {
+				fadeInFuncs.cancel(revert);
+				fadeOutFuncs.cancel(revert);
+			}
+		};
+	}
+
+	function fade(game: Game, context: AudioPlayContext, duration: number, from: number, to: number, easing: EasingFunction): () => void {
+		const frame = 1000 / game.fps;
+		let elapsed = 0;
+
+		const handler = (): boolean => {
+			elapsed = Math.min(elapsed + frame, duration);
+			const progress = easing(elapsed, from, to, duration);
+			context.changeVolume(Util.clamp(progress, 0, 1));
+			return duration <= elapsed;
+		};
+		game.onUpdate.add(handler);
+
+		return (): void => {
+			if (game.onUpdate.contains(handler)) {
+				game.onUpdate.remove(handler);
+			}
+		};
+	}
+}

--- a/src/AudioUtil.ts
+++ b/src/AudioUtil.ts
@@ -14,13 +14,13 @@ export type EasingFunction = (t: number, b: number, c: number, d: number) => num
 
 export type AudioTransitionContext = {
 	/**
-	 * フェードを即座に完了する。
-	 * 音量はフェード完了後の値となる。
+	 * 遷移を即座に完了する。
+	 * 音量は遷移完了後の値となる。
 	 */
 	complete: () => void;
 	/**
-	 * フェードを取り消す。音量はこの関数を実行した時点での値となる。
-	 * @param revert 音量をフェード実行前まで戻すかどうか。省略時は `false` 。
+	 * 遷移を取り消す。音量はこの関数を実行した時点での値となる。
+	 * @param revert 音量を遷移実行前まで戻すかどうか。省略時は `false` 。
 	 */
 	cancel: (revert?: boolean) => void;
 };
@@ -72,7 +72,7 @@ export module AudioUtil {
 	 *
 	 * @param game 対象の `Game`。
 	 * @param context 対象の `AudioPlayContext` 。
-	 * @param duration フェードインの長さ (ms)。
+	 * @param duration フェードアウトの長さ (ms)。
 	 * @param easing イージング関数。省略時は linear が指定される。
 	 */
 	export function fadeOut(
@@ -128,13 +128,13 @@ export module AudioUtil {
 	}
 
 	/**
-	 * 音声を指定のイージングで遷移させる。
+	 * 音量を指定のイージングで遷移させる。
 	 *
 	 * @param game 対象の `Game`。
 	 * @param context 対象の `AudioPlayContext` 。
 	 * @param duration 遷移の長さ (ms)。
 	 * @param to 遷移後の音量。0 未満または 1 より大きい値を指定した場合の挙動は不定。
-	 * @param easing イージング関数。フェードインとフェードアウトで共通であることに注意。省略時は linear が指定される。
+	 * @param easing イージング関数。省略時は linear が指定される。
 	 */
 	export function transitionVolume(
 		game: Game,

--- a/src/AudioUtil.ts
+++ b/src/AudioUtil.ts
@@ -12,16 +12,13 @@ import { Util } from "./Util";
  */
 export type EasingFunction = (t: number, b: number, c: number, d: number) => number;
 
-/**
- * イージング終了のための関数群。
- */
-export type EasingFinishFunctions = {
+export type AudioFadeContext = {
 	/**
-	 * イージングを即座に完了する。
+	 * フェードイン・フェードアウトを即座に完了する。
 	 */
 	complete: () => void;
 	/**
-	 * イージングを取り消す。
+	 * フェードイン・フェードアウトを取り消す。
 	 * @param revert イージング実行前まで戻すかどうか。省略時は `false` 。
 	 */
 	cancel: (revert?: boolean) => void;
@@ -51,7 +48,7 @@ export module AudioUtil {
 		duration: number,
 		to: number = 1,
 		easing: EasingFunction = linear
-	): EasingFinishFunctions {
+	): AudioFadeContext {
 		context.changeVolume(0);
 		context.play();
 		const cancel = fade(game, context, duration, 0, to, easing);
@@ -79,12 +76,7 @@ export module AudioUtil {
 	 * @param duration フェードインの長さ (ms)。
 	 * @param easing イージング関数。省略時は linear が指定される。
 	 */
-	export function fadeOut(
-		game: Game,
-		context: AudioPlayContext,
-		duration: number,
-		easing: EasingFunction = linear
-	): EasingFinishFunctions {
+	export function fadeOut(game: Game, context: AudioPlayContext, duration: number, easing: EasingFunction = linear): AudioFadeContext {
 		const from = context.volume;
 		const cancel = fade(game, context, duration, from, -from, easing);
 
@@ -120,7 +112,7 @@ export module AudioUtil {
 		duration: number,
 		to: number = 1,
 		easing: EasingFunction = linear
-	): EasingFinishFunctions {
+	): AudioFadeContext {
 		const fadeInFuncs = fadeIn(game, fadeInContext, duration, to, easing);
 		const fadeOutFuncs = fadeOut(game, fadeOutContext, duration, easing);
 

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -539,6 +539,11 @@ export class Game {
 	skippingChanged: Trigger<boolean>;
 
 	/**
+	 * ティック消化後にfireされるTrigger。
+	 */
+	onUpdate: Trigger<void>;
+
+	/**
 	 * ゲームが早送りに状態にあるかどうか。
 	 *
 	 * スキップ状態であれば真、非スキップ状態であれば偽である。
@@ -924,6 +929,8 @@ export class Game {
 		this._onSceneChange.add(this._handleSceneChanged, this);
 		this._sceneChanged = this._onSceneChange;
 
+		this.onUpdate = new Trigger<void>();
+
 		this._initialScene = new Scene({
 			game: this,
 			assetIds: this._assetManager.globalAssetIds(),
@@ -1032,6 +1039,8 @@ export class Game {
 			scene.onUpdate.fire();
 			if (advanceAge) ++this.age;
 		}
+
+		this.onUpdate.fire();
 
 		if (this._postTickTasks.length) {
 			this._flushPostTickTasks();
@@ -1449,6 +1458,7 @@ export class Game {
 		this.onResized.removeAll();
 		this.onSkipChange.removeAll();
 		this.onSceneChange.removeAll();
+		this.onUpdate.removeAll();
 		this.handlerSet.removeAllEventFilters();
 
 		this.isSkipping = false;
@@ -1573,6 +1583,8 @@ export class Game {
 		this.onSkipChange = undefined!;
 		this.onSceneChange.destroy();
 		this.onSceneChange = undefined!;
+		this.onUpdate.destroy();
+		this.onUpdate = undefined!;
 		this.onSnapshotRequest.destroy();
 		this.onSnapshotRequest = undefined!;
 		this.join = undefined!;

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -72,6 +72,16 @@ export module Util {
 	}
 
 	/**
+	 * 数値を範囲内［min, max］に丸める
+	 * @param num 丸める値
+	 * @param min 値の下限
+	 * @param max 値の上限
+	 */
+	export function clamp(num: number, min: number, max: number): number {
+		return Math.min(Math.max(num, min), max);
+	}
+
+	/**
 	 * CompositeOperation を CompositeOperationString に読み替えるテーブル。
 	 * @deprecated 非推奨である。非推奨の機能との互換性のために存在する。ゲーム開発者が使用すべきではない。
 	 */

--- a/src/__tests__/AudioUtilSpec.ts
+++ b/src/__tests__/AudioUtilSpec.ts
@@ -8,6 +8,7 @@ describe("test AudioUtil", () => {
 			const system = game.audio.music;
 			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
 			const context = system.create(asset);
+			const mockContextPlay = jest.spyOn(context, "play");
 			expect(context.volume).toBe(1.0);
 
 			AudioUtil.fadeIn(game, context, 1000, 0.3);
@@ -24,6 +25,7 @@ describe("test AudioUtil", () => {
 			} while (beforeVolume < context.volume);
 
 			expect(context.volume).toBe(0.3);
+			expect(mockContextPlay).toBeCalledTimes(1);
 		});
 
 		it("complete", () => {

--- a/src/__tests__/AudioUtilSpec.ts
+++ b/src/__tests__/AudioUtilSpec.ts
@@ -1,0 +1,367 @@
+import { AudioUtil } from "../AudioUtil";
+import { skeletonRuntime } from "./helpers";
+
+describe("test AudioUtil", () => {
+	describe("fadeIn", () => {
+		it("normal", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const context = system.create(asset);
+			expect(context.volume).toBe(1.0);
+
+			AudioUtil.fadeIn(game, context, 1000, 0.3);
+			expect(context.volume).toBe(0);
+
+			// 音量の変化がなくなるまで手動で tick を進める
+			let beforeVolume: number;
+			do {
+				beforeVolume = context.volume;
+				game.tick(true);
+				expect(context.volume).toBeGreaterThanOrEqual(0);
+				expect(context.volume).toBeLessThanOrEqual(0.3);
+				expect(context.volume).toBeGreaterThanOrEqual(beforeVolume);
+			} while (beforeVolume < context.volume);
+
+			expect(context.volume).toBe(0.3);
+		});
+
+		it("complete", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const context = system.create(asset);
+			const { complete } = AudioUtil.fadeIn(game, context, 1000, 0.3);
+
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+
+			// complete 後に tick を進めても音量が変更しないことを確認
+			complete();
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			expect(context.volume).toBe(0.3);
+		});
+
+		it("cancel", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const context = system.create(asset);
+			const mockContextStop = jest.spyOn(context, "stop");
+			const { cancel } = AudioUtil.fadeIn(game, context, 1000, 0.3);
+
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+
+			const volume = context.volume;
+
+			// cancel 後に tick を進めても音量が変更しないことを確認
+			cancel();
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			expect(context.volume).toBe(volume);
+
+			// 音声は停止しない
+			expect(mockContextStop).toBeCalledTimes(0);
+		});
+
+		it("cancel (revert)", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const context = system.create(asset);
+			const mockContextStop = jest.spyOn(context, "stop");
+			const { cancel } = AudioUtil.fadeIn(game, context, 1000, 0.3);
+
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+
+			// cancel 後に tick を進めても音量が変更しないことを確認
+			cancel(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			expect(context.volume).toBe(0);
+			expect(mockContextStop).toBeCalledTimes(1);
+		});
+	});
+
+	describe("fadeOut", () => {
+		it("normal", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const context = system.create(asset);
+			context.changeVolume(0.3);
+
+			AudioUtil.fadeOut(game, context, 1000);
+
+			// 音量の変化がなくなるまで手動で tick を進める
+			let beforeVolume: number;
+			do {
+				beforeVolume = context.volume;
+				game.tick(true);
+				expect(context.volume).toBeGreaterThanOrEqual(0);
+				expect(context.volume).toBeLessThanOrEqual(0.3);
+				expect(context.volume).toBeLessThanOrEqual(beforeVolume);
+			} while (context.volume < beforeVolume);
+
+			expect(context.volume).toBe(0);
+		});
+
+		it("complete", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const context = system.create(asset);
+			const { complete } = AudioUtil.fadeOut(game, context, 1000);
+
+			let beforeVolume = context.volume;
+
+			game.tick(true);
+			expect(context.volume).toBeLessThan(beforeVolume);
+			beforeVolume = context.volume;
+
+			game.tick(true);
+			expect(context.volume).toBeLessThan(beforeVolume);
+			beforeVolume = context.volume;
+
+			// complete 後に tick を進めても音量が変更しないことを確認
+			complete();
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			expect(context.volume).toBe(0);
+		});
+
+		it("complete", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const context = system.create(asset);
+			const mockContextStop = jest.spyOn(context, "stop");
+			const { complete } = AudioUtil.fadeOut(game, context, 1000);
+
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+
+			// complete 後に tick を進めても音量が変更しないことを確認
+			complete();
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			expect(context.volume).toBe(0);
+			expect(mockContextStop).toBeCalledTimes(1);
+		});
+
+		it("cancel", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const context = system.create(asset);
+			const mockContextStop = jest.spyOn(context, "stop");
+			const { cancel } = AudioUtil.fadeOut(game, context, 1000);
+
+			const volume = context.volume;
+
+			// cancel 後に tick を進めても音量が変更しないことを確認
+			cancel();
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			expect(context.volume).toBe(volume);
+
+			// 音声は停止しない
+			expect(mockContextStop).toBeCalledTimes(0);
+		});
+
+		it("cancel (revert)", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const context = system.create(asset);
+			const mockContextStop = jest.spyOn(context, "stop");
+			const { cancel } = AudioUtil.fadeOut(game, context, 1000);
+
+			const volume = context.volume;
+
+			// cancel 後に tick を進めても音量が変更しないことを確認
+			cancel();
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			expect(context.volume).toBe(volume);
+
+			// 音声は停止しない
+			expect(mockContextStop).toBeCalledTimes(0);
+		});
+	});
+
+	describe("crossFade", () => {
+		it("normal", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const fadeInContext = system.create(asset);
+			const fadeOutContext = system.create(asset);
+
+			fadeOutContext.changeVolume(0.3);
+
+			AudioUtil.crossFade(game, fadeInContext, fadeOutContext, 1000, 0.5);
+
+			let beforeFadeInContextVolume: number;
+			let beforeFadeOutContextVolume: number;
+
+			// 音量の変化がなくなるまで手動で tick を進める
+			do {
+				beforeFadeInContextVolume = fadeInContext.volume;
+				beforeFadeOutContextVolume = fadeOutContext.volume;
+
+				game.tick(true);
+
+				expect(fadeInContext.volume).toBeGreaterThanOrEqual(0);
+				expect(fadeInContext.volume).toBeLessThanOrEqual(0.5);
+				expect(fadeInContext.volume).toBeGreaterThanOrEqual(beforeFadeInContextVolume);
+				expect(fadeOutContext.volume).toBeGreaterThanOrEqual(0);
+				expect(fadeOutContext.volume).toBeLessThanOrEqual(0.3);
+				expect(fadeOutContext.volume).toBeLessThanOrEqual(beforeFadeOutContextVolume);
+			} while (beforeFadeInContextVolume < fadeInContext.volume || fadeOutContext.volume < beforeFadeOutContextVolume);
+
+			expect(fadeInContext.volume).toBe(0.5);
+			expect(fadeOutContext.volume).toBe(0);
+		});
+
+		it("complete", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const fadeInContext = system.create(asset);
+			const fadeOutContext = system.create(asset);
+			const mockFadeInContextStop = jest.spyOn(fadeInContext, "stop");
+			const mockFadeOutContextStop = jest.spyOn(fadeOutContext, "stop");
+
+			fadeOutContext.changeVolume(0.3);
+
+			const { complete } = AudioUtil.crossFade(game, fadeInContext, fadeOutContext, 1000, 0.5);
+
+			let beforeFadeInContextVolume = fadeInContext.volume;
+			let beforeFadeOutContextVolume = fadeOutContext.volume;
+
+			game.tick(true);
+			expect(fadeInContext.volume).toBeGreaterThanOrEqual(beforeFadeInContextVolume);
+			expect(fadeOutContext.volume).toBeLessThanOrEqual(beforeFadeOutContextVolume);
+			beforeFadeInContextVolume = fadeInContext.volume;
+			beforeFadeOutContextVolume = fadeOutContext.volume;
+
+			game.tick(true);
+			expect(fadeInContext.volume).toBeGreaterThanOrEqual(beforeFadeInContextVolume);
+			expect(fadeOutContext.volume).toBeLessThanOrEqual(beforeFadeOutContextVolume);
+			beforeFadeInContextVolume = fadeInContext.volume;
+			beforeFadeOutContextVolume = fadeOutContext.volume;
+
+			// complete 後に tick を進めても音量が変更しないことを確認
+			complete();
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			expect(fadeInContext.volume).toBe(0.5);
+			expect(fadeOutContext.volume).toBe(0);
+
+			expect(mockFadeInContextStop).toBeCalledTimes(0);
+			expect(mockFadeOutContextStop).toBeCalledTimes(1);
+		});
+
+		it("cancel", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const fadeInContext = system.create(asset);
+			const fadeOutContext = system.create(asset);
+			const mockFadeInContextStop = jest.spyOn(fadeInContext, "stop");
+			const mockFadeOutContextStop = jest.spyOn(fadeOutContext, "stop");
+
+			const { cancel } = AudioUtil.crossFade(game, fadeInContext, fadeOutContext, 1000, 0.6);
+
+			game.tick(true);
+			game.tick(true);
+
+			const fadeInVolume = fadeInContext.volume;
+			const fadeOutVolume = fadeOutContext.volume;
+
+			// cancel 後に tick を進めても音量が変更しないことを確認
+			cancel();
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			expect(fadeInContext.volume).toBe(fadeInVolume);
+			expect(fadeOutContext.volume).toBe(fadeOutVolume);
+
+			expect(mockFadeInContextStop).toBeCalledTimes(0);
+			expect(mockFadeOutContextStop).toBeCalledTimes(0);
+		});
+
+		it("cancel (revert)", () => {
+			const { game } = skeletonRuntime();
+			const system = game.audio.music;
+			const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+			const fadeInContext = system.create(asset);
+			const fadeOutContext = system.create(asset);
+			const mockFadeInContextStop = jest.spyOn(fadeInContext, "stop");
+			const mockFadeOutContextStop = jest.spyOn(fadeOutContext, "stop");
+
+			const fadeOutVolume = fadeOutContext.volume;
+			const { cancel } = AudioUtil.crossFade(game, fadeInContext, fadeOutContext, 1000, 0.6);
+
+			game.tick(true);
+			game.tick(true);
+
+			// cancel 後に tick を進めても音量が変更しないことを確認
+			cancel(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			game.tick(true);
+			expect(fadeInContext.volume).toBe(0);
+			expect(fadeOutContext.volume).toBe(fadeOutVolume);
+
+			expect(mockFadeInContextStop).toBeCalledTimes(1);
+			expect(mockFadeOutContextStop).toBeCalledTimes(0);
+		});
+	});
+});

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -26,6 +26,7 @@ describe("test Game", () => {
 		expect(game.onSkipChange).not.toBeUndefined();
 		expect(game.onSceneChange).not.toBeUndefined();
 		expect(game._onSceneChange).not.toBeUndefined();
+		expect(game.onUpdate).toBeDefined();
 		expect(game).toHaveProperty("_assetManager");
 		expect(game).toHaveProperty("_initialScene");
 		expect(game._moduleManager).toBeDefined();
@@ -46,6 +47,7 @@ describe("test Game", () => {
 		expect(game.onSkipChange).toBeUndefined();
 		expect(game.onSceneChange).toBeUndefined();
 		expect(game._onSceneChange).toBeUndefined();
+		expect(game.onUpdate).toBeUndefined();
 		expect(game._moduleManager).toBeUndefined();
 	});
 
@@ -394,19 +396,25 @@ describe("test Game", () => {
 		game._onLoad.add(() => {
 			const scene = new Scene({ game: game });
 			game.pushScene(scene);
+			const mockOnUpdate = jest.fn();
+			game.onUpdate.add(mockOnUpdate);
 			expect(game.age).toBe(0);
 			expect(game.classicTick()).toBe(true);
 			expect(game.scene()!.local).toBe("non-local");
+			expect(mockOnUpdate).toBeCalledTimes(1);
 			expect(game.classicTick()).toBe(false);
 			expect(game.age).toBe(1);
+			expect(mockOnUpdate).toBeCalledTimes(2);
 			expect(game.tick(false, 3)).toBe(false);
 			expect(game.age).toBe(1);
 			expect(game.isLastTickLocal).toBe(true);
 			expect(game.lastOmittedLocalTickCount).toBe(3);
+			expect(mockOnUpdate).toBeCalledTimes(3);
 			expect(game.tick(true)).toBe(false);
 			expect(game.age).toBe(2);
 			expect(game.isLastTickLocal).toBe(false);
 			expect(game.lastOmittedLocalTickCount).toBe(0);
+			expect(mockOnUpdate).toBeCalledTimes(4);
 			done();
 		});
 		game._loadAndStart();

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -926,6 +926,9 @@ describe("test Game", () => {
 		game._onSceneChange.add(() => {
 			//
 		});
+		game.onUpdate.add(() => {
+			//
+		});
 		game.resourceFactory.scriptContents["/script/mainScene.js"] =
 			"module.exports = () => { const s = new g.Scene({game: g.game}); g.game.pushScene(s);}";
 		expect(game.age).toBe(0);
@@ -989,6 +992,7 @@ describe("test Game", () => {
 			expect(game.age).toBe(3);
 			const randGen2 = XorshiftRandomGenerator.deserialize(randGen1.serialize());
 			expect(game.random.generate()).toBe(randGen2.generate());
+			expect(game.onUpdate.length).toBe(0);
 			// reset 前の PointDownEvent の情報が破棄されていることを確認
 			expect(
 				game._pointEventResolver.pointUp({

--- a/src/__tests__/UtilSpec.ts
+++ b/src/__tests__/UtilSpec.ts
@@ -52,4 +52,11 @@ describe("test Util", () => {
 			Math.sqrt(Math.pow(-0.5 - 3, 2) + Math.pow(1 - 3, 2)).toFixed(2)
 		);
 	});
+
+	it("clamp", () => {
+		expect(Util.clamp(0.4, 0, 1)).toBe(0.4);
+		expect(Util.clamp(0, -100, 100)).toBe(0);
+		expect(Util.clamp(-10, -5, 5)).toBe(-5);
+		expect(Util.clamp(200, 10, 100)).toBe(100);
+	});
 });

--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -28,6 +28,7 @@ export * from "./AssetManagerLoadHandler";
 export * from "./AudioPlayContext";
 export * from "./AudioSystem";
 export * from "./AudioSystemManager";
+export * from "./AudioUtil";
 export * from "./BitmapFont";
 export * from "./Camera";
 export * from "./Camera2D";


### PR DESCRIPTION
## このpull requestが解決する内容
* `g.AudioUtil` を追加
  * 音声のフェードイン・フェードアウト・クロスフェードの機能を提供します
* `g.Game#onUpdate` を追加
  * ティックの進行後 (`g.Scene#onUpdate` が発火した後) に発火するトリガ
* `g.Util#clamp()` を追加
* `EasingFunction` `AudioTransitionContext` を追加

## 動作確認
以下のミニマムコンテンツにて動作確認済み

<details>
<summary>展開</summary>

赤い四角をクリックするとフェードイン・クロスフェード・フェードアウトするサンプル
```javascript
module.exports = () => {
  const game = g.game;
  const scene = new g.Scene({
    game,
    assetPaths: [
      "/assets/**/*"
    ],
  });
  scene.onLoad.addOnce(() => {
    const rect = new g.FilledRect({
      scene,
      cssColor: "red",
      width: 32,
      height: 32,
      touchable: true,
    });
    rect.onPointDown.addOnce(() => {
      const akiurara = game.audio.create(scene.asset.getAudio("/assets/audio/akiurara"));
      const yume = game.audio.create(scene.asset.getAudio("/assets/audio/yume"));
      scene.setTimeout(() => {
        console.log("fadeIn");
        g.AudioUtil.fadeIn(game, akiurara, 5000, 0.1);
      }, 0);
      scene.setTimeout(() => {
        console.log("crossFade");
        g.AudioUtil.crossFade(game, yume, akiurara, 5000, 0.1);
      }, 6000);
      scene.setTimeout(() => {
        console.log("transitionVolume");
        g.AudioUtil.transitionVolume(game, yume, 5000, 0.4);
      }, 12000);
      scene.setTimeout(() => {
        console.log("fadeOut");
        g.AudioUtil.fadeOut(game, yume, 5000);
      }, 18000);
      rect.remove();
    });
    scene.append(rect);
  });
  game.pushScene(scene);
};
```
</details>

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

