### PR TITLE
Fix set-output command in Actions

### DIFF
--- a/.github/workflows/reftest.yml
+++ b/.github/workflows/reftest.yml
@@ -28,7 +28,7 @@ jobs:
         id: akashic_engine
         run: |
           npm ci
-          echo "::set-output name=pack_name::$(npm pack)"
+          echo "pack_name=$(npm pack)" >> $GITHUB_OUTPUT
       - name: Run engine-files reftest
         working-directory: engine-files
         run: |


### PR DESCRIPTION
## このpull requestが解決する内容

Actions の set-output コマンドが廃止となるため、$GITHUB_OUTPUT を利用するように修正。
[参考ページ](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)


## 破壊的な変更を含んでいるか?

- なし
