### PR TITLE
feat: follow pdi-types@1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 3.14.0
+* @akashic/pdi-types@1.10.0 に追従
+  * `"binary"` アセットに対応
+  * `ScriptAsset#exports` に対応
+
 ## 3.13.0
 * どのボタンでマウスクリックが行われたか認識できるように
 * 内部モジュールの更新

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.13.0",
+      "version": "3.14.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~1.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.13.0",
       "license": "MIT",
       "dependencies": {
-        "@akashic/game-configuration": "~1.11.1",
+        "@akashic/game-configuration": "~1.12.0",
         "@akashic/pdi-types": "~1.11.1",
         "@akashic/playlog": "~3.2.0",
         "@akashic/trigger": "~2.0.0"
@@ -67,11 +67,11 @@
       }
     },
     "node_modules/@akashic/game-configuration": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.11.1.tgz",
-      "integrity": "sha512-mNlEQrpKUXWvyicD1hFlQFsUCVuVPsJ3HDjNFpwSj4RbCQN1DbwYE+qXR4JF0BjCymhta8ELJkP3BooToi4FzA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.12.0.tgz",
+      "integrity": "sha512-mL7yo0o4HD2KwUHH7/Z4AFMTZl7bs4zBFRLxeg9D8kpwUfS8y1BPDTMlWdfDmataLjHDZAsYq4B6aC/XL7+Haw==",
       "dependencies": {
-        "@akashic/pdi-types": "^1.10.0"
+        "@akashic/pdi-types": "^1.11.1"
       },
       "optionalDependencies": {
         "es6-promise": "^4.2.8"
@@ -8292,11 +8292,11 @@
       }
     },
     "@akashic/game-configuration": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.11.1.tgz",
-      "integrity": "sha512-mNlEQrpKUXWvyicD1hFlQFsUCVuVPsJ3HDjNFpwSj4RbCQN1DbwYE+qXR4JF0BjCymhta8ELJkP3BooToi4FzA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.12.0.tgz",
+      "integrity": "sha512-mL7yo0o4HD2KwUHH7/Z4AFMTZl7bs4zBFRLxeg9D8kpwUfS8y1BPDTMlWdfDmataLjHDZAsYq4B6aC/XL7+Haw==",
       "requires": {
-        "@akashic/pdi-types": "^1.10.0",
+        "@akashic/pdi-types": "^1.11.1",
         "es6-promise": "^4.2.8"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "3.13.0",
       "license": "MIT",
       "dependencies": {
-        "@akashic/game-configuration": "~1.10.0",
+        "@akashic/game-configuration": "~1.11.1",
         "@akashic/pdi-types": "~1.11.1",
         "@akashic/playlog": "~3.2.0",
         "@akashic/trigger": "~2.0.0"
       },
       "devDependencies": {
         "@akashic/eslint-config": "1.1.1",
-        "@akashic/pdi-common-impl": "^1.3.0",
+        "@akashic/pdi-common-impl": "^1.4.0",
         "@types/jest": "^29.0.0",
         "@typescript-eslint/eslint-plugin": "^5.29.0",
         "eslint": "^8.18.0",
@@ -67,23 +67,23 @@
       }
     },
     "node_modules/@akashic/game-configuration": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.10.0.tgz",
-      "integrity": "sha512-LCSIuk4noqspJ8Ilhe8QeS4mb3qd3LZHz9GkXIORBuRnFf6wbtLzab0YlbmxlOWOIXF4ApRBO3pD3YpSQonAJg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.11.1.tgz",
+      "integrity": "sha512-mNlEQrpKUXWvyicD1hFlQFsUCVuVPsJ3HDjNFpwSj4RbCQN1DbwYE+qXR4JF0BjCymhta8ELJkP3BooToi4FzA==",
       "dependencies": {
-        "@akashic/pdi-types": "^1.7.0"
+        "@akashic/pdi-types": "^1.10.0"
       },
       "optionalDependencies": {
         "es6-promise": "^4.2.8"
       }
     },
     "node_modules/@akashic/pdi-common-impl": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@akashic/pdi-common-impl/-/pdi-common-impl-1.3.0.tgz",
-      "integrity": "sha512-6Tvr1Hor8GTlc7VbqDtbGmuEdegNt55l65YD2Yrg8GT4mG5p7d+lLOGritauHmVPJ1QJWssc7wAfyWzWRfFmpQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@akashic/pdi-common-impl/-/pdi-common-impl-1.4.0.tgz",
+      "integrity": "sha512-MhiJ2WcqaKBT24+QF7x72dtz6GqG6V7KI82lW5i9nF8lhOD3Tv49L8/ScZezLOi8GY1TW4v9mxX1GhL8yc1YwQ==",
       "dev": true,
       "dependencies": {
-        "@akashic/pdi-types": "^1.8.0",
+        "@akashic/pdi-types": "^1.10.0",
         "@akashic/trigger": "^2.0.0"
       }
     },
@@ -8292,21 +8292,21 @@
       }
     },
     "@akashic/game-configuration": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.10.0.tgz",
-      "integrity": "sha512-LCSIuk4noqspJ8Ilhe8QeS4mb3qd3LZHz9GkXIORBuRnFf6wbtLzab0YlbmxlOWOIXF4ApRBO3pD3YpSQonAJg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.11.1.tgz",
+      "integrity": "sha512-mNlEQrpKUXWvyicD1hFlQFsUCVuVPsJ3HDjNFpwSj4RbCQN1DbwYE+qXR4JF0BjCymhta8ELJkP3BooToi4FzA==",
       "requires": {
-        "@akashic/pdi-types": "^1.7.0",
+        "@akashic/pdi-types": "^1.10.0",
         "es6-promise": "^4.2.8"
       }
     },
     "@akashic/pdi-common-impl": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@akashic/pdi-common-impl/-/pdi-common-impl-1.3.0.tgz",
-      "integrity": "sha512-6Tvr1Hor8GTlc7VbqDtbGmuEdegNt55l65YD2Yrg8GT4mG5p7d+lLOGritauHmVPJ1QJWssc7wAfyWzWRfFmpQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@akashic/pdi-common-impl/-/pdi-common-impl-1.4.0.tgz",
+      "integrity": "sha512-MhiJ2WcqaKBT24+QF7x72dtz6GqG6V7KI82lW5i9nF8lhOD3Tv49L8/ScZezLOi8GY1TW4v9mxX1GhL8yc1YwQ==",
       "dev": true,
       "requires": {
-        "@akashic/pdi-types": "^1.8.0",
+        "@akashic/pdi-types": "^1.10.0",
         "@akashic/trigger": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {
-    "@akashic/game-configuration": "~1.10.0",
+    "@akashic/game-configuration": "~1.11.1",
     "@akashic/pdi-types": "~1.11.1",
     "@akashic/playlog": "~3.2.0",
     "@akashic/trigger": "~2.0.0"
   },
   "devDependencies": {
     "@akashic/eslint-config": "1.1.1",
-    "@akashic/pdi-common-impl": "^1.3.0",
+    "@akashic/pdi-common-impl": "^1.4.0",
     "@types/jest": "^29.0.0",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "eslint": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {
-    "@akashic/game-configuration": "~1.11.1",
+    "@akashic/game-configuration": "~1.12.0",
     "@akashic/pdi-types": "~1.11.1",
     "@akashic/playlog": "~3.2.0",
     "@akashic/trigger": "~2.0.0"

--- a/src/AssetAccessor.ts
+++ b/src/AssetAccessor.ts
@@ -1,4 +1,4 @@
-import type { AudioAsset, ImageAsset, ScriptAsset, TextAsset, VectorImageAsset } from "@akashic/pdi-types";
+import type { AudioAsset, BinaryAsset, ImageAsset, ScriptAsset, TextAsset, VectorImageAsset } from "@akashic/pdi-types";
 import type { AssetManager } from "./AssetManager";
 
 /**
@@ -109,6 +109,30 @@ export class AssetAccessor {
 	}
 
 	/**
+	 * パスから読み込み済みのバイナリアセット（現在のシーンで読み込んだ、またはグローバルなアセット）を取得する。
+	 *
+	 * パスはgame.jsonのあるディレクトリをルート (`/`) とする、 `/` 区切りの絶対パスでなければならない。
+	 * 当該のバイナリアセットが読み込まれていない場合、エラー。
+	 *
+	 * @param path 取得するバイナリアセットのパス
+	 */
+	getBinary(path: string): BinaryAsset {
+		return this._assetManager.peekLiveAssetByAccessorPath(path, "binary");
+	}
+
+	/**
+	 * パスから読み込み済みのバイナリアセット（現在のシーンで読み込んだ、またはグローバルなアセット）を取得し、その内容のバイト配列を返す。
+	 *
+	 * パスはgame.jsonのあるディレクトリをルート (`/`) とする、 `/` 区切りの絶対パスでなければならない。
+	 * 当該のバイナリアセットが読み込まれていない場合、エラー。
+	 *
+	 * @param path 内容のバイト配列を取得するバイナリアセットのパス
+	 */
+	getBinaryData(path: string): ArrayBuffer {
+		return this.getBinary(path).data;
+	}
+
+	/**
 	 * 与えられたパターンまたはフィルタにマッチするパスを持つ、読み込み済みの全画像アセット（現在のシーンで読み込んだ、またはグローバルなアセット）を取得する。
 	 *
 	 * ここでパスはgame.jsonのあるディレクトリをルート (`/`) とする、 `/` 区切りの絶対パスである。
@@ -165,6 +189,16 @@ export class AssetAccessor {
 	 */
 	getAllVectorImages(patternOrFilter?: string | ((path: string) => boolean)): VectorImageAsset[] {
 		return this._assetManager.peekAllLiveAssetsByPattern(patternOrFilter ?? "**/*", "vector-image");
+	}
+
+	/**
+	 * 与えられたパターンまたはフィルタにマッチするパスを持つ、読み込み済みのバイナリアセット（現在のシーンで読み込んだ、またはグローバルなアセット）を取得する。
+	 * 引数の仕様については `AssetAccessor#getAllImages()` の仕様を参照のこと。
+	 *
+	 * @param patternOrFilter 取得するベクタ画像アセットのパスパターンまたはフィルタ。省略した場合、読み込み済みの全て
+	 */
+	getAllBinaries(patternOrFilter?: string | ((path: string) => boolean)): BinaryAsset[] {
+		return this._assetManager.peekAllLiveAssetsByPattern(patternOrFilter ?? "**/*", "binary");
 	}
 
 	/**
@@ -235,5 +269,25 @@ export class AssetAccessor {
 	 */
 	getVectorImageById(assetId: string): VectorImageAsset {
 		return this._assetManager.peekLiveAssetById(assetId, "vector-image");
+	}
+
+	/**
+	 * アセットIDから読み込み済みのバイナリアセット（現在のシーンで読み込んだ、またはグローバルなアセット）を取得する。
+	 * 当該のバイナリアセットが読み込まれていない場合、エラー。
+	 *
+	 * @param assetId 取得するバイナリアセットのID
+	 */
+	getBinaryById(assetId: string): BinaryAsset {
+		return this._assetManager.peekLiveAssetById(assetId, "binary");
+	}
+
+	/**
+	 * アセットIDから読み込み済みのバイナリアセット（現在のシーンで読み込んだ、またはグローバルなアセット）を取得し、その内容のバイト配列を返す。
+	 * 当該のバイナリアセットが読み込まれていない場合、エラー。
+	 *
+	 * @param assetId 取得するバイナリアセットのID
+	 */
+	getBinaryDataById(assetId: string): ArrayBuffer {
+		return this.getBinaryById(assetId).data;
 	}
 }

--- a/src/DynamicAssetConfiguration.ts
+++ b/src/DynamicAssetConfiguration.ts
@@ -1,6 +1,7 @@
 import type {
 	AssetConfigurationCommonBase,
 	AudioAssetConfigurationBase,
+	BinaryAssetConfigurationBase,
 	ImageAssetConfigurationBase,
 	ScriptAssetConfigurationBase,
 	TextAssetConfigurationBase,
@@ -14,7 +15,8 @@ export type DynamicAssetConfiguration =
 	| DynamicVectorImageAssetConfigurationBase
 	| DynamicTextAssetConfigurationBase
 	| DynamicScriptAssetConfigurationBase
-	| DynamicVideoAssetConfigurationBase;
+	| DynamicVideoAssetConfigurationBase
+	| DynamicBinaryAssetConfigurationBase;
 
 /**
  * (実行時に定義される)Assetの設定を表すインターフェース。
@@ -74,6 +76,13 @@ export interface DynamicTextAssetConfigurationBase
 export interface DynamicScriptAssetConfigurationBase
 	extends Omit<DynamicAssetConfigurationBase, "type">,
 		Omit<ScriptAssetConfigurationBase, UnneededKeysForDynamicAsset> {}
+
+/**
+ * BinaryAssetの設定。
+ */
+export interface DynamicBinaryAssetConfigurationBase
+	extends Omit<DynamicAssetConfigurationBase, "type">,
+		Omit<BinaryAssetConfigurationBase, UnneededKeysForDynamicAsset> {}
 
 // interface メンバは多重継承できないため、 DynamicAssetConfigurationBase の type メンバ を Omit する
 type UnneededKeysForDynamicAsset = "path" | "virtualPath" | "global";

--- a/src/__tests__/AssetAccessorSpec.ts
+++ b/src/__tests__/AssetAccessorSpec.ts
@@ -341,7 +341,7 @@ describe("test AssetAccessor", () => {
 
 				expect(accessor.getTextContentById("id-assets/stage01/map.json")).toBe(sampleJSONFileContent);
 				expect(accessor.getJSONContentById("id-assets/stage01/map.json")).toEqual(JSON.parse(sampleJSONFileContent));
-				expect(accessor.getBinaryDataById("id-assets/bin/lib01.wasm")).toEqual(sampleArrayBufferContent);
+				expect(accessor.getBinaryDataById("id-assets/bin/lib01.wasm")).toBe(sampleArrayBufferContent);
 				done();
 			}
 		);

--- a/src/__tests__/AssetAccessorSpec.ts
+++ b/src/__tests__/AssetAccessorSpec.ts
@@ -57,6 +57,11 @@ describe("test AssetAccessor", () => {
 				width: 64,
 				height: 64
 			},
+			"id-assets/bin/lib01.wasm": {
+				type: "binary",
+				path: "assets/bin/lib01.wasm",
+				virtualPath: "assets/bin/lib01.wasm"
+			},
 			"node_modules/@akashic-extension/some-library/lib/index.js": {
 				type: "script",
 				path: "node_modules/@akashic-extension/some-library/lib/index.js",
@@ -94,6 +99,8 @@ describe("test AssetAccessor", () => {
 		testValue: true
 	});
 
+	const sampleArrayBufferContent = new ArrayBuffer(8);
+
 	const assetIds = [
 		"id-script/main.js",
 		"id-assets/stage01/bgm01",
@@ -102,6 +109,7 @@ describe("test AssetAccessor", () => {
 		"id-assets/stage01/map.json",
 		"id-assets/chara01/image.png",
 		"id-assets/icon/icon01.svg",
+		"id-assets/bin/lib01.wasm",
 		"node_modules/@akashic-extension/some-library/lib/index.js",
 		"node_modules/@akashic-extension/some-library/assets/image.png",
 		"node_modules/@akashic-extension/some-library/assets/boss.png",
@@ -111,6 +119,7 @@ describe("test AssetAccessor", () => {
 	function setupAssetAccessor(assetIds: string[], fail: (arg: any) => void, callback: (accessor: AssetAccessor) => void): void {
 		const game = new Game(gameConfiguration);
 		game.resourceFactory.scriptContents["assets/stage01/map.json"] = sampleJSONFileContent;
+		game.resourceFactory.binaryContents["assets/bin/lib01.wasm"] = sampleArrayBufferContent;
 
 		const manager = game._assetManager;
 		const accessor = new AssetAccessor(manager);
@@ -165,8 +174,16 @@ describe("test AssetAccessor", () => {
 					path: "assets/icon/icon01.svg"
 				});
 
+				expect(extractAssetProps(accessor.getBinary("/assets/bin/lib01.wasm"))).toEqual({
+					id: "id-assets/bin/lib01.wasm",
+					type: "binary",
+					path: "assets/bin/lib01.wasm"
+				});
+
 				expect(accessor.getTextContent("/assets/stage01/map.json")).toBe(sampleJSONFileContent);
 				expect(accessor.getJSONContent("/assets/stage01/map.json")).toEqual(JSON.parse(sampleJSONFileContent));
+				expect(accessor.getBinaryData("/assets/bin/lib01.wasm")).toBe(sampleArrayBufferContent);
+
 				done();
 			}
 		);
@@ -268,6 +285,14 @@ describe("test AssetAccessor", () => {
 					}
 				]);
 
+				expect(accessor.getAllBinaries().map(extractAssetProps)).toEqual([
+					{
+						id: "id-assets/bin/lib01.wasm",
+						type: "binary",
+						path: "assets/bin/lib01.wasm"
+					}
+				]);
+
 				done();
 			}
 		);
@@ -308,8 +333,15 @@ describe("test AssetAccessor", () => {
 					path: "assets/icon/icon01.svg"
 				});
 
+				expect(extractAssetProps(accessor.getBinaryById("id-assets/bin/lib01.wasm"))).toEqual({
+					id: "id-assets/bin/lib01.wasm",
+					type: "binary",
+					path: "assets/bin/lib01.wasm"
+				});
+
 				expect(accessor.getTextContentById("id-assets/stage01/map.json")).toBe(sampleJSONFileContent);
 				expect(accessor.getJSONContentById("id-assets/stage01/map.json")).toEqual(JSON.parse(sampleJSONFileContent));
+				expect(accessor.getBinaryDataById("id-assets/bin/lib01.wasm")).toEqual(sampleArrayBufferContent);
 				done();
 			}
 		);

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -461,6 +461,26 @@ export class GeneratedVectorImageAsset extends pci.VectorImageAsset {
 	}
 }
 
+export class BinaryAsset extends pci.BinaryAsset {
+	game: g.Game;
+
+	constructor(game: g.Game, id: string, assetPath: string) {
+		super(id, assetPath);
+		this.game = game;
+	}
+
+	_load(loader: AssetLoadHandler): void {
+		setTimeout(() => {
+			if ((this.game.resourceFactory as ResourceFactory).binaryContents.hasOwnProperty(this.path)) {
+				this.data = (this.game.resourceFactory as ResourceFactory).binaryContents[this.path];
+			} else {
+				this.data = new ArrayBuffer(0);
+			}
+			if (!this.destroyed()) loader._onAssetLoad(this);
+		}, 0);
+	}
+}
+
 export class AudioPlayer extends pci.AudioPlayer {
 	canHandleStoppedValue: boolean;
 
@@ -495,6 +515,7 @@ export class GlyphFactory extends pci.GlyphFactory {
 export class ResourceFactory extends pci.ResourceFactory {
 	_game: g.Game;
 	scriptContents: { [path: string]: string };
+	binaryContents: { [path: string]: ArrayBuffer };
 
 	// 真である限り createXXAsset() が DelayedAsset を生成する(現在は createImageAsset() のみ)。
 	// DelayedAsset は、flushDelayedAssets() 呼び出しまで読み込み完了(またはエラー)通知を遅延するアセットである。
@@ -507,6 +528,7 @@ export class ResourceFactory extends pci.ResourceFactory {
 	constructor() {
 		super();
 		this.scriptContents = {};
+		this.binaryContents = {};
 		this._game = undefined!;
 		this.createsDelayedAsset = false;
 		this._necessaryRetryCount = 0;
@@ -571,6 +593,10 @@ export class ResourceFactory extends pci.ResourceFactory {
 
 	createScriptAsset(id: string, assetPath: string): ScriptAsset {
 		return new ScriptAsset(this._game, this._necessaryRetryCount, id, assetPath);
+	}
+
+	createBinaryAsset(id: string, assetPath: string): BinaryAsset {
+		return new BinaryAsset(this._game, id, assetPath);
 	}
 
 	createSurface(width: number, height: number): pci.Surface {

--- a/src/__tests__/helpers/mock.ts
+++ b/src/__tests__/helpers/mock.ts
@@ -383,8 +383,8 @@ export class ScriptAsset extends pci.ScriptAsset {
 	game: g.Game;
 	_failureController: LoadFailureController;
 
-	constructor(game: g.Game, necessaryRetryCount: number, id: string, assetPath: string) {
-		super(id, assetPath);
+	constructor(game: g.Game, necessaryRetryCount: number, id: string, assetPath: string, exports?: string[]) {
+		super(id, assetPath, exports);
 		this.game = game;
 		this._failureController = new LoadFailureController(necessaryRetryCount);
 	}
@@ -591,8 +591,8 @@ export class ResourceFactory extends pci.ResourceFactory {
 		return new TextAsset(this._game, this._necessaryRetryCount, id, assetPath);
 	}
 
-	createScriptAsset(id: string, assetPath: string): ScriptAsset {
-		return new ScriptAsset(this._game, this._necessaryRetryCount, id, assetPath);
+	createScriptAsset(id: string, assetPath: string, exports?: string[]): ScriptAsset {
+		return new ScriptAsset(this._game, this._necessaryRetryCount, id, assetPath, exports);
 	}
 
 	createBinaryAsset(id: string, assetPath: string): BinaryAsset {

--- a/src/auxiliary/EmptyBinaryAsset.ts
+++ b/src/auxiliary/EmptyBinaryAsset.ts
@@ -1,0 +1,43 @@
+import type { Asset, AssetLoadHandler, BinaryAsset } from "@akashic/pdi-types";
+import { Trigger } from "@akashic/trigger";
+
+export class EmptyBinaryAsset implements BinaryAsset {
+	id: string;
+	path: string;
+	originalPath: string;
+	type: "binary" = "binary";
+	data: ArrayBuffer;
+
+	onDestroyed: Trigger<Asset> = new Trigger();
+
+	constructor(id: string, path: string) {
+		this.id = id;
+		this.path = path;
+		this.originalPath = path;
+		this.data = new ArrayBuffer(0);
+	}
+
+	inUse(): boolean {
+		return false;
+	}
+
+	destroy(): void {
+		if (this.destroyed()) {
+			return;
+		}
+		this.onDestroyed.destroy();
+		this.onDestroyed = undefined!;
+	}
+
+	destroyed(): boolean {
+		return !this.onDestroyed;
+	}
+
+	_load(loader: AssetLoadHandler): void {
+		loader._onAssetLoad(this);
+	}
+
+	_assetPathFilter(path: string): string {
+		return path;
+	}
+}


### PR DESCRIPTION
## このpull requestが解決する内容
[pdi-types@1.10.0](https://github.com/akashic-games/pdi-types/pull/56) に追従します。

* `ScriptAsset#constructor` の第3引数に `exports` を追加
* `BinaryAsset` の追加
  * 非対応環境では `EmptyBinaryAsset` を生成

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

