### PR TITLE
feat: support 'prepare' phase before the scene load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # unreleased changes
 * `g.Scene#vars` を追加
+* `g.Scene` のアセット読み込み後に任意の非同期処理を行うための `prepare` をサポート
+   * `g.Game#pushScene()` に第2引数 `PushSceneOption` を追加
+   * `g.Game#replaceScene()` の第2引数を `boolean | ReplaceSceneOption` に変更
 
 ## 3.14.0
 * @akashic/pdi-types@1.10.0 に追従

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+# unreleased changes
+* `g.Scene#vars` を追加
+
 ## 3.14.0
 * @akashic/pdi-types@1.10.0 に追従
   * `"binary"` アセットに対応

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-# unreleased changes
+# 3.14.1
 * `g.Scene#vars` を追加
 * `g.Scene` のアセット読み込み後に任意の非同期処理を行うための `prepare` をサポート
    * `g.Game#pushScene()` に第2引数 `PushSceneOption` を追加

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.14.0",
+      "version": "3.14.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -2048,7 +2048,10 @@ export class Game {
 		});
 		// ローディングシーンを保持するためクロージャを許容
 		loadingScene.onTargetReady.addOnce(() => {
-			const done = loadingScene.end.bind(loadingScene);
+			const done = (): void => {
+				if (this._isTerminated) return;
+				loadingScene.end();
+			};
 			prepare(done);
 		});
 		return loadingScene;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -2053,7 +2053,7 @@ export class Game {
 			explicitEnd: true,
 			name
 		});
-		// ローディングシーンを保持するためクロージャを許容
+		// prepare 対象シーンを保持するためクロージャを許容
 		loadingScene.onTargetReady.addOnce(() => {
 			const done = (): void => {
 				if (this._isTerminated) return;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -96,7 +96,7 @@ interface PostTickPushSceneTask {
 	scene: Scene;
 
 	/**
-	 * 現在のシーンのアセット読み込み後、任意の非同期処理を行うためのコールバック。
+	 * 現在のシーンのアセット読み込み後、任意の非同期処理を行うためのハンドラ。
 	 */
 	prepare?: (done: () => void) => void;
 }
@@ -121,7 +121,7 @@ interface PostTickReplaceSceneTask {
 	preserveCurrent: boolean;
 
 	/**
-	 * 現在のシーンのアセット読み込み後、任意の非同期処理を行うためのコールバック。
+	 * 現在のシーンのアセット読み込み後、任意の非同期処理を行うためのハンドラ。
 	 */
 	prepare?: (done: () => void) => void;
 }
@@ -221,7 +221,7 @@ export interface EventTriggerMap {
  */
 export interface PushSceneOption {
 	/**
-	 * 現在のシーンのアセット読み込み後、任意の非同期処理を行うためのコールバック。
+	 * 現在のシーンのアセット読み込み後、任意の非同期処理を行うためのハンドラ。
 	 */
 	prepare?: (done: () => void) => void;
 }
@@ -235,7 +235,7 @@ export interface ReplaceSceneOption {
 	 */
 	preserveCurrent?: boolean;
 	/**
-	 * 現在のシーンのアセット読み込み後、任意の非同期処理を行うためのコールバック。
+	 * 現在のシーンのアセット読み込み後、任意の非同期処理を行うためのハンドラ。
 	 */
 	prepare?: (done: () => void) => void;
 }

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1954,8 +1954,8 @@ export class Game {
 			// 取り除いた結果スタックトップがロード中のシーンになった場合はローディングシーンを積み直す
 			const nextScene = this.scene();
 			if (nextScene && nextScene._needsLoading() && nextScene._loadingState !== "loaded-fired") {
-				const loadingScene = nextScene._currentPrepare
-					? this._createPreparingLoadingScene(nextScene, nextScene._currentPrepare, `akashic:preparing-${nextScene.name}`)
+				const loadingScene = nextScene._waitingPrepare
+					? this._createPreparingLoadingScene(nextScene, nextScene._waitingPrepare, `akashic:preparing-${nextScene.name}`)
 					: this.loadingScene ?? this._defaultLoadingScene;
 				this._doPushScene(loadingScene, true, this._defaultLoadingScene);
 				loadingScene.reset(nextScene);
@@ -2047,7 +2047,7 @@ export class Game {
 	 * 引数に指定したハンドラが完了するまで待機する空のローディングシーンを作成する。
 	 */
 	private _createPreparingLoadingScene(scene: Scene, prepare: (done: () => void) => void, name?: string): LoadingScene {
-		scene._currentPrepare = prepare;
+		scene._waitingPrepare = prepare;
 		const loadingScene = new LoadingScene({
 			game: this,
 			explicitEnd: true,
@@ -2059,8 +2059,8 @@ export class Game {
 				if (this._isTerminated) return;
 				loadingScene.end();
 			};
-			const prepare = scene._currentPrepare;
-			scene._currentPrepare = undefined;
+			const prepare = scene._waitingPrepare;
+			scene._waitingPrepare = undefined;
 			if (prepare) {
 				prepare(done);
 			} else {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -220,6 +220,9 @@ export interface EventTriggerMap {
  * Game#pushScene() のオプション
  */
 export interface PushSceneOption {
+	/**
+	 * 現在のシーンのアセット読み込み後、任意の非同期処理を行うためのコールバック。
+	 */
 	prepare?: (done: () => void) => void;
 }
 
@@ -227,7 +230,13 @@ export interface PushSceneOption {
  * Game#replaceScene() のオプション
  */
 export interface ReplaceSceneOption {
+	/**
+	 * 現在のシーンを破棄するか否か。
+	 */
 	preserveCurrent?: boolean;
+	/**
+	 * 現在のシーンのアセット読み込み後、任意の非同期処理を行うためのコールバック。
+	 */
 	prepare?: (done: () => void) => void;
 }
 

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -2065,11 +2065,7 @@ export class Game {
 				prepare(done);
 			} else {
 				// NOTE: 異常系ではあるが prepare が存在しない場合は loadingScene.end() を直接呼ぶ
-				this._postTickTasks.unshift({
-					type: PostTickTaskType.Call,
-					fun: loadingScene.end,
-					owner: loadingScene
-				});
+				this._pushPostTickTask(loadingScene.end, loadingScene);
 			}
 		});
 		return loadingScene;

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -867,7 +867,11 @@ export class Scene implements StorageLoaderHandler {
 	 * @private
 	 */
 	_needsLoading(): boolean {
-		return this._sceneAssetHolder.waitingAssetsCount > 0 || (!!this._storageLoader && !this._storageLoader._loaded);
+		return (
+			this._sceneAssetHolder.waitingAssetsCount > 0 ||
+			(!!this._storageLoader && !this._storageLoader._loaded) ||
+			!!this._currentPrepare
+		);
 	}
 
 	/**

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -580,6 +580,7 @@ export class Scene implements StorageLoaderHandler {
 		this._storageLoader = undefined;
 
 		this.game = undefined!;
+		this._currentPrepare = undefined;
 
 		this.state = "destroyed";
 		this.onStateChange.fire(this.state);

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -980,6 +980,5 @@ export class Scene implements StorageLoaderHandler {
 		if (this._loadingState === "loaded-fired") return;
 		this.onLoad.fire(this);
 		this._loadingState = "loaded-fired";
-		this._currentPrepare = undefined; // TODO: 本来は _currentPrepare に値を代入する側 (e.g. g.Game) でクリアすべき
 	}
 }

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -437,6 +437,11 @@ export class Scene implements StorageLoaderHandler {
 	_assetHolders: AssetHolder<SceneRequestAssetHandler>[];
 
 	/**
+	 * @private
+	 */
+	_currentPrepare: ((done: () => void) => void) | undefined;
+
+	/**
 	 * 各種パラメータを指定して `Scene` のインスタンスを生成する。
 	 * @param param 初期化に用いるパラメータのオブジェクト
 	 */
@@ -974,5 +979,6 @@ export class Scene implements StorageLoaderHandler {
 		if (this._loadingState === "loaded-fired") return;
 		this.onLoad.fire(this);
 		this._loadingState = "loaded-fired";
+		this._currentPrepare = undefined; // TODO: 本来は _currentPrepare に値を代入する側 (e.g. g.Game) でクリアすべき
 	}
 }

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -439,7 +439,7 @@ export class Scene implements StorageLoaderHandler {
 	/**
 	 * @private
 	 */
-	_currentPrepare: ((done: () => void) => void) | undefined;
+	_waitingPrepare: ((done: () => void) => void) | undefined;
 
 	/**
 	 * 各種パラメータを指定して `Scene` のインスタンスを生成する。
@@ -580,7 +580,7 @@ export class Scene implements StorageLoaderHandler {
 		this._storageLoader = undefined;
 
 		this.game = undefined!;
-		this._currentPrepare = undefined;
+		this._waitingPrepare = undefined;
 
 		this.state = "destroyed";
 		this.onStateChange.fire(this.state);
@@ -876,7 +876,7 @@ export class Scene implements StorageLoaderHandler {
 		return (
 			this._sceneAssetHolder.waitingAssetsCount > 0 ||
 			(!!this._storageLoader && !this._storageLoader._loaded) ||
-			!!this._currentPrepare
+			!!this._waitingPrepare
 		);
 	}
 

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -361,6 +361,13 @@ export class Scene implements StorageLoaderHandler {
 	operation: Trigger<OperationEvent>;
 
 	/**
+	 * ゲーム開発者向けのコンテナ。
+	 *
+	 * この値はゲームエンジンのロジックからは使用されず、ゲーム開発者は任意の目的に使用してよい。
+	 */
+	vars: any;
+
+	/**
 	 * @private
 	 */
 	_storageLoader: StorageLoader | undefined;
@@ -464,6 +471,7 @@ export class Scene implements StorageLoaderHandler {
 		this._ready = this._onReady;
 		this.assets = {};
 		this.asset = new AssetAccessor(game._assetManager);
+		this.vars = {};
 
 		this._loaded = false;
 		this._prefetchRequested = false;
@@ -558,6 +566,7 @@ export class Scene implements StorageLoaderHandler {
 		this.onAssetLoadFailure.destroy();
 		this.onAssetLoadComplete.destroy();
 		this.assets = {};
+		this.vars = {};
 
 		// アセットを参照しているEより先に解放しないよう最後に解放する
 		for (let i = 0; i < this._assetHolders.length; ++i) this._assetHolders[i].destroy();

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -532,7 +532,7 @@ describe("test Game", () => {
 		// game.scenes テストのため _loaded を待つ必要がある
 		game._onLoad.add(() => {
 			const sequence: string[] = [];
-			const scene1 = new Scene({ game, assetIds: ["foo"], name: "scene1" });
+			const scene1 = new Scene({ game, name: "scene1" });
 			const scene2 = new Scene({ game, assetIds: ["foo"], name: "scene2" });
 			scene1.onLoad.addOnce(() => {
 				sequence.push("scene1 loaded");

--- a/src/__tests__/GameSpec.ts
+++ b/src/__tests__/GameSpec.ts
@@ -548,7 +548,7 @@ describe("test Game", () => {
 							sequence.push("scene1 prepared");
 							done();
 						},
-						100 // この値にとくに根據は無い
+						100 // この値にとくに根拠は無い
 					);
 				}
 			});
@@ -561,7 +561,7 @@ describe("test Game", () => {
 								sequence.push("scene2 prepared");
 								done();
 							},
-							100 // この値にとくに根據は無い
+							100 // この値にとくに根拠は無い
 						);
 					}
 				});
@@ -615,7 +615,7 @@ describe("test Game", () => {
 								sequence.push("scene1 prepared");
 								done();
 							},
-							100 // この値にとくに根據は無い
+							100 // この値にとくに根拠は無い
 						);
 					}
 				});
@@ -628,7 +628,7 @@ describe("test Game", () => {
 									sequence.push("scene2 prepared");
 									done();
 								},
-								100 // この値にとくに根據は無い
+								100 // この値にとくに根拠は無い
 							);
 						}
 					});

--- a/src/__tests__/SceneSpec.ts
+++ b/src/__tests__/SceneSpec.ts
@@ -49,6 +49,7 @@ describe("test Scene", () => {
 		expect(scene.local).toBe("interpolate-local");
 		expect(scene.tickGenerationMode).toBe("manual");
 		expect(scene.name).toEqual("myScene");
+		expect(scene.vars).toEqual({});
 
 		expect(scene.onUpdate instanceof Trigger).toBe(true);
 		expect(scene.onLoad instanceof Trigger).toBe(true);


### PR DESCRIPTION
## このpull requestが解決する内容
* `g.Scene` のアセット読み込み後、任意の非同期処理を行うための `prepare` をサポートします。
* `g.Scene#vars`  を追加します。この値はゲームエンジンのロジックからは使用されず、ゲーム開発者が任意の値を代入することができます。

コードイメージは以下のようになります。
```javascript
const scene = new g.Scene({ ... });
scene.onLoad.addOnce(() => {
  console.log(scene.vars.data);
});

g.game.pushScene(scene, {
  prepare: done => {
    someAsyncFunc()
      .then((data)=> {
        scene.vars.data = data;
        done();
       })
      .catch(_error => done());
  }
});
```

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

