### PR TITLE
Support exports default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## 3.16.6
+* exports.default をサポートする `g.ModuleManager#_internalRequire` を追加
+
 ## 3.16.5
 * `g.Scene#requestAssets()` で対象のアセットのロード失敗時に `callback` 経由でエラーを通知するインタフェースを追加
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.16.5",
+  "version": "3.16.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.16.5",
+      "version": "3.16.6",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.16.5",
+  "version": "3.16.6",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1985,7 +1985,7 @@ export class Game {
 		// `game.json` の `operationPlugins` フィールドの登録は `game._onLoad` のfire後でなければならない。
 		for (const pluginInfo of operationPluginsField) {
 			if (!pluginInfo.script) continue;
-			const pluginClass = this._moduleManager._require(pluginInfo.script);
+			const pluginClass = this._moduleManager._internalRequire(pluginInfo.script);
 			const plugin = this.operationPluginManager.register(pluginClass, pluginInfo.code, pluginInfo.option);
 			if (!pluginInfo.manualStart && plugin) {
 				plugin.start();
@@ -1995,7 +1995,7 @@ export class Game {
 
 		const preloadAssetIds = this._assetManager.preloadScriptAssetIds();
 		for (const preloadAssetId of preloadAssetIds) {
-			const fun = this._moduleManager._require(preloadAssetId);
+			const fun = this._moduleManager._internalRequire(preloadAssetId);
 			if (!fun || typeof fun !== "function")
 				throw ExceptionFactory.createAssertionError(`Game#_handleLoad: ${preloadAssetId} has no-exported function.`);
 			fun();
@@ -2004,7 +2004,7 @@ export class Game {
 		if (this._mainFunc) {
 			this._mainFunc(this._runtimeValueBase, this._mainParameter || {});
 		} else if (this._main) {
-			const mainFun = this._moduleManager._require(this._main);
+			const mainFun = this._moduleManager._internalRequire(this._main);
 			if (!mainFun || typeof mainFun !== "function")
 				throw ExceptionFactory.createAssertionError(`Game#_handleLoad: Entry point ${this._main} not found.`);
 			mainFun(this._mainParameter);

--- a/src/ModuleManager.ts
+++ b/src/ModuleManager.ts
@@ -38,6 +38,22 @@ export class ModuleManager {
 	}
 
 	/**
+	 * エンジン内部で利用する _require() を wrap した関数
+	 *
+	 * 引数の仕様については `_require()` の仕様を参照のこと。
+	 * _require() の戻り値で __esModule が真の場合に戻り値の .default を返す。
+	 * 現状 Akashic Engine では ESM を扱えていない。そのため、対象の __esModule を参照し .default を返すことで、
+	 * TypeScript/Babel 向けの簡易対応とし exports.default を扱えるようにしている。
+	 * 通常、ゲーム開発者がこのメソッドを利用する必要はない。
+	 *
+	 * @ignore
+	 */
+	_internalRequire(path: string, currentModule?: Module): any {
+		const module = this._require(path, currentModule);
+		return module.__esModule ? module.default : module;
+	}
+
+	/**
 	 * node.js の require() ライクな読み込み処理を行い、その結果を返す。
 	 *
 	 * node.jsのrequireに限りなく近いモデルでrequireする。

--- a/src/WeakRefKVS.ts
+++ b/src/WeakRefKVS.ts
@@ -22,7 +22,6 @@ class PseudoWeakRef<T extends object> {
  * 通常、ゲーム開発者はこのクラスを利用する必要はない。
  */
 export class WeakRefKVS<T extends object> {
-
 	/**
 	 * @ignore
 	 */

--- a/src/__tests__/ModuleSpec.ts
+++ b/src/__tests__/ModuleSpec.ts
@@ -44,6 +44,12 @@ describe("test Module", () => {
 				path: "/script/bar.js",
 				virtualPath: "script/bar.js"
 			},
+			aGlobalAssetExportDefault: {
+				type: "script",
+				global: true,
+				path: "/script/exportDefault.js",
+				virtualPath: "script/exportDefault.js"
+			},
 			// dummy modules
 			dummymod: {
 				type: "script",
@@ -224,6 +230,8 @@ describe("test Module", () => {
 		"/script/foo.js": "module.exports = { me: 'script-foo', thisModule: module }",
 		"/script/bar.js": "module.exports = { me: 'script-bar', thisModule: module }",
 		"/script/dummypath.js": "module.exports = { me: 'script-dummymod', thisModule: module }",
+		"/script/exportDefault.js":
+			"Object.defineProperty(exports, '__esModule', { value: true });function exportDefault() { return 'exportDefault'; } exports.default = exportDefault;",
 		"/cascaded/script.js": "module.exports = { me: 'script-cascaded', thisModule: module }",
 		"/node_modules/noPackageJson/index.js": "module.exports = { me: 'noPackageJson-index', thisModule: module };",
 		"/node_modules/noDefaultIndex/root.js": "exports.me = 'noDefaultIndex-root'; exports.thisModule = module; ",
@@ -353,6 +361,18 @@ describe("test Module", () => {
 			expect(mod.me).toBe("noPackageJson-index");
 			expect(mod.thisModule instanceof Module).toBe(true);
 			expect(mod.thisModule.filename).toBe("/node_modules/noPackageJson/index.js");
+			done();
+		});
+		game._startLoadingGlobalAssets();
+	});
+
+	it("internalRequire - export default", done => {
+		const game = new Game(gameConfiguration, "./");
+		const manager = game._moduleManager;
+		game.resourceFactory.scriptContents = scriptContents;
+		game._onLoad.add(() => {
+			const mod = manager._internalRequire("./script/exportDefault.js");
+			expect(mod()).toBe("exportDefault");
 			done();
 		});
 		game._startLoadingGlobalAssets();


### PR DESCRIPTION
## このpull requestが解決する内容

exports.default をサポートするため `ModuleManager#_internalRequire` を追加します。
require 対象の __esModule が真の場合に module.default を返すようにします。

## 破壊的な変更を含んでいるか?

- なし
