### PR TITLE
Fix reftest yml

### DIFF
--- a/.github/workflows/reftest.yml
+++ b/.github/workflows/reftest.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           npm ci
           npm pack
-          fileName=$(ls -1 *.tgz)
+          fileName=$(ls -1 akashic-akashic-engine-*.tgz)
           echo "pack_name=$fileName" >> $GITHUB_OUTPUT
       - name: Run engine-files reftest
         working-directory: engine-files

--- a/.github/workflows/reftest.yml
+++ b/.github/workflows/reftest.yml
@@ -28,7 +28,9 @@ jobs:
         id: akashic_engine
         run: |
           npm ci
-          echo "pack_name=$(npm pack)" >> $GITHUB_OUTPUT
+          npm pack
+          fileName=$(ls -1 *.tgz)
+          echo "pack_name=$fileName" >> $GITHUB_OUTPUT
       - name: Run engine-files reftest
         working-directory: engine-files
         run: |


### PR DESCRIPTION
## このpull requestが解決する内容

actions の reftest.yml で `npm pack` を実行し戻り値のファイル名を取得していたが、不要な出力が入るようになった。
`npm pack` 後に ls コマンドで tgz ファイルを取得するように修正。

## 破壊的な変更を含んでいるか?

- なし