### PR TITLE
doc: fix errors in API doc comments

### DIFF
--- a/src/AssetAccessor.ts
+++ b/src/AssetAccessor.ts
@@ -16,7 +16,7 @@ export class AssetAccessor {
 	/**
 	 * `AssetAccessor` のインスタンスを生成する。
 	 *
-	 * @param ラップする `AssetManager`
+	 * @param assetManager ラップする `AssetManager`
 	 */
 	constructor(assetManager: AssetManager) {
 		this._assetManager = assetManager;

--- a/src/DynamicFont.ts
+++ b/src/DynamicFont.ts
@@ -312,7 +312,7 @@ export class DynamicFont extends Font {
 	 * 実装上の制限から、このメソッドを呼び出す場合、maxAtlasNum が 1 または undefined/null(1として扱われる) である必要がある。
 	 * そうでない場合、失敗する可能性がある。
 	 *
-	 * @param missingGlyph `BitmapFont#map` に存在しないコードポイントの代わりに表示するべき文字。最初の一文字が用いられる。
+	 * @param missingGlyphChar `BitmapFont#map` に存在しないコードポイントの代わりに表示するべき文字。最初の一文字が用いられる。
 	 */
 	asBitmapFont(missingGlyphChar?: string): BitmapFont | null {
 		if (this._atlasSet.getAtlasNum() !== 1) {

--- a/src/Matrix.ts
+++ b/src/Matrix.ts
@@ -49,7 +49,7 @@ export interface Matrix {
 	/**
 	 * 2D object利用の一般的な値を基に変換行列の値を再計算する。
 	 * @param width 対象の横幅
-	 * @param heigth 対象の縦幅
+	 * @param height 対象の縦幅
 	 * @param scaleX 対象の横方向への拡大率
 	 * @param scaleY 対象の縦方向への拡大率
 	 * @param angle 角度。単位は `degree` であり `radian` ではない
@@ -73,7 +73,7 @@ export interface Matrix {
 	/**
 	 * `update()` によって得られる行列の逆変換になるよう変換行列の値を再計算する。
 	 * @param width 対象の横幅
-	 * @param heigth 対象の縦幅
+	 * @param height 対象の縦幅
 	 * @param scaleX 対象の横方向への拡大率
 	 * @param scaleY 対象の縦方向への拡大率
 	 * @param angle 角度。単位は `degree` であり `radian` ではない

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -18,10 +18,15 @@ import type { Timer } from "./Timer";
 import type { TimerIdentifier } from "./TimerManager";
 import { TimerManager } from "./TimerManager";
 
+/**
+ * `Scene#requestAssets()` 完了時の通知を受け取るハンドラ。
+ *
+ * @param error アセット読み込みエラー (発生した場合) 。エラーがない場合、 `undefined` 。
+ */
 export type SceneRequestAssetHandler = (error?: RequestAssetLoadError) => void;
 
 /**
- * `Scene#requestAsset` の引数に渡すことができるパラメータ。
+ * `Scene#requestAssets()` の引数に渡すことができるパラメータ。
  */
 export interface SceneRequestAssetsParameterObject {
 	assetIds: (string | DynamicAssetConfiguration | AssetGenerationConfiguration)[];
@@ -523,7 +528,7 @@ export class Scene {
 	 *
 	 * このメソッドは、このシーンに紐づいている `E` の `modified()` を呼び出すことで暗黙に呼び出される。
 	 * 通常、ゲーム開発者がこのメソッドを呼び出す必要はない。
-	 * @param isBubbling この関数をこのシーンの子の `modified()` から呼び出す場合、真を渡さなくてはならない。省略された場合、偽。
+	 * @param _isBubbling この関数をこのシーンの子の `modified()` から呼び出す場合、真を渡さなくてはならない。省略された場合、偽。
 	 */
 	modified(_isBubbling?: boolean): void {
 		this.game.modified();

--- a/src/SurfaceUtil.ts
+++ b/src/SurfaceUtil.ts
@@ -55,7 +55,7 @@ export module SurfaceUtil {
 	 * これはエンジンが利用するものであり、ゲーム開発者が呼び出す必要はない。
 	 *
 	 * @param animatingHandler アニメーティングハンドラ
-	 * @param beforeSurface ハンドラ登録を解除するサーフェス
+	 * @param _beforeSurface ハンドラ登録を解除するサーフェス
 	 * @param afterSurface ハンドラを登録するサーフェス
 	 */
 	export function migrateAnimatingHandler(animatingHandler: AnimatingHandler, _beforeSurface: Surface, afterSurface: Surface): void {

--- a/src/entities/E.ts
+++ b/src/entities/E.ts
@@ -427,8 +427,8 @@ export class E extends Object2D implements CommonArea {
 	 * 戻り値は、このエンティティの子孫の描画をスキップすべきであれば偽、でなければ真である。
 	 * (この値は、子孫の描画方法をカスタマイズする一部のサブクラスにおいて、通常の描画パスをスキップするために用いられる)
 	 *
-	 * @param renderer 描画先に対するRenderer
-	 * @param camera 対象のカメラ
+	 * @param _renderer 描画先に対するRenderer
+	 * @param _camera 対象のカメラ
 	 */
 	renderSelf(_renderer: Renderer, _camera?: Camera): boolean {
 		// nothing to do
@@ -567,7 +567,7 @@ export class E extends Object2D implements CommonArea {
 	 * 本メソッドは、このオブジェクトの `Object2D` 由来のプロパティ (`x`, `y`, `angle` など) を変更した場合にも呼びだす必要がある。
 	 * 本メソッドは、描画キャッシュの無効化処理を含まない。描画キャッシュを持つエンティティは、このメソッドとは別に `invalidate()` を提供している。
 	 * 描画キャッシュの無効化も必要な場合は、このメソッドではなくそちらを呼び出す必要がある。
-	 * @param isBubbling 通常ゲーム開発者が指定する必要はない。この変更通知が、(このエンティティ自身のみならず)子孫の変更の通知を含む場合、真を渡さなければならない。省略された場合、偽。
+	 * @param _isBubbling 通常ゲーム開発者が指定する必要はない。この変更通知が、(このエンティティ自身のみならず)子孫の変更の通知を含む場合、真を渡さなければならない。省略された場合、偽。
 	 */
 	modified(_isBubbling?: boolean): void {
 		// _matrixの用途は描画に限らない(e.g. E#findPointSourceByPoint)ので、Modifiedフラグと無関係にクリアする必要がある
@@ -601,7 +601,7 @@ export class E extends Object2D implements CommonArea {
 	 *
 	 * 戻り値は、子孫の探索をスキップすべきであれば偽、でなければ真である。
 	 *
-	 * @param point このエンティティ（`this`）の位置を基準とした相対座標
+	 * @param _point このエンティティ（`this`）の位置を基準とした相対座標
 	 */
 	shouldFindChildrenByPoint(_point: CommonOffset): boolean {
 		// nothing to do

--- a/src/entities/FrameSprite.ts
+++ b/src/entities/FrameSprite.ts
@@ -129,7 +129,7 @@ export class FrameSprite extends Sprite {
 	 * `Sprite` から `FrameSprite` を作成する。
 	 * @param sprite 画像として使う`Sprite`
 	 * @param width 作成されるエンティティの高さ。省略された場合、 `sprite.width`
-	 * @param hegith 作成されるエンティティの高さ。省略された場合、 `sprite.height`
+	 * @param height 作成されるエンティティの高さ。省略された場合、 `sprite.height`
 	 */
 	static createBySprite(sprite: Sprite, width?: number, height?: number): FrameSprite {
 		const frameSprite = new FrameSprite({

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,11 +6,26 @@ import type { ErrorLike } from "@akashic/pdi-types";
 import type { AssetGenerationConfiguration } from "./AssetGenerationConfiguration";
 import type { DynamicAssetConfiguration } from "./DynamicAssetConfiguration";
 
+/**
+ * アセット読み込み失敗の詳細。
+ */
 export interface RequestAssetDetail {
+	/**
+	 * 読み込み失敗したアセット ID (またはアセット定義) の配列。
+	 */
 	failureAssetIds: (string | DynamicAssetConfiguration | AssetGenerationConfiguration)[];
 }
 
+/**
+ * アセット読み込み失敗を表すエラー。
+ *
+ * このエラーは `Scene` 生成時に指定されたアセットの読み込み失敗では発生しないことに注意。
+ * `Scene#requestAssets()` によるシーン中の動的なアセットリクエストの失敗時、そのコールバックにのみ通知される。
+ */
 export interface RequestAssetLoadError extends ErrorLike {
 	name: "RequestAssetLoadError";
+	/**
+	 * 読み込み失敗したリクエストの詳細。
+	 */
 	detail: RequestAssetDetail;
 }

--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -22,6 +22,7 @@ export * from "./entities/FrameSprite";
 export * from "./entities/Label";
 export * from "./entities/Pane";
 export * from "./entities/Sprite";
+export * from "./errors";
 export * from "./AssetAccessor";
 export * from "./AssetGenerationConfiguration";
 export * from "./AssetHolder";


### PR DESCRIPTION
## このpull requestが解決する内容

#499 で更新した typedoc が  `@param` などの typo を警告するようになったので修正します。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

