### PR TITLE
Fix destroyed check for e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## 3.18.3
+* `g.E#destroy()` で破棄済みチェックを行うように修正
+
 ## 3.18.2
 * `OperationHandler#onOperaiton()` で `instanceof` での判定をやめ `Array.isArray()` を利用するように修正
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.18.2",
+  "version": "3.18.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.18.2",
+      "version": "3.18.3",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.18.2",
+  "version": "3.18.3",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/__tests__/ESpec.ts
+++ b/src/__tests__/ESpec.ts
@@ -360,6 +360,18 @@ describe("test E", () => {
 		expect((e as any)._onPointUp).toBeUndefined();
 	});
 
+	it("destroy - check for multiple executions", () => {
+		const e2 = new E({ scene: runtime.scene });
+		const spy = jest.spyOn(e2.scene, "unregister");
+		e2.destroy();
+		expect(e2.destroyed()).toBeTruthy();
+		expect(spy.mock.calls.length).toBe(1);
+
+		e2.destroy();
+		expect(spy.mock.calls.length).toBe(1); // 破棄済みの場合、 destory() を実行しても呼ばれないのでカウントは増えない。
+		spy.mockClear();
+	});
+
 	it("modified", () => {
 		resetUpdated(runtime);
 		expect(runtime.game._modified).toBe(false);

--- a/src/__tests__/ESpec.ts
+++ b/src/__tests__/ESpec.ts
@@ -363,6 +363,7 @@ describe("test E", () => {
 	it("destroy - check for multiple executions", () => {
 		const e2 = new E({ scene: runtime.scene });
 		const spy = jest.spyOn(e2.scene, "unregister");
+
 		e2.destroy();
 		expect(e2.destroyed()).toBeTruthy();
 		expect(spy.mock.calls.length).toBe(1);

--- a/src/entities/E.ts
+++ b/src/entities/E.ts
@@ -513,6 +513,8 @@ export class E extends Object2D implements CommonArea {
 	 * 子孫を持っている場合、子孫も破棄される。
 	 */
 	destroy(): void {
+		if (this.destroyed()) return;
+
 		if (this.parent) this.remove();
 
 		if (this.children) {


### PR DESCRIPTION
## このpull requestが解決する内容

`g.E#destroy()` で破棄済みチェックを行うように修正。

## 破壊的な変更を含んでいるか?

- なし
