### PR TITLE
fix: assetBundle が存在する状況において、 assetBundle に含まれないアセットIDが指定されていたときに通常のアセットの生成へとフォールバックするように修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## 3.19.1
+* assetBundle が存在する状況においてスクリプトアセット以外を利用するとエラーとなる問題を修正
+
 ## 3.19.0
 * @akashic/game-configuration@2.4.0 に追従
   * `assetBundle` に対応

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.19.0",
+  "version": "3.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.19.0",
+  "version": "3.19.1",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/AssetManager.ts
+++ b/src/AssetManager.ts
@@ -686,7 +686,7 @@ export class AssetManager implements AssetLoadHandler {
 		if (this._assetBundle && typeof idOrConf === "string") {
 			const id = idOrConf;
 			const conf = this._assetBundle.assets[id] as BundledAssetConfiguration;
-			const type = conf.type;
+			const type = conf?.type;
 			switch (type) {
 				case "script":
 					const asset = new BundledScriptAsset({
@@ -694,12 +694,9 @@ export class AssetManager implements AssetLoadHandler {
 						...conf
 					});
 					return asset;
-				default:
-					throw ExceptionFactory.createAssertionError(
-						`AssertionError#_createAssetFor: unknown asset type ${type} for asset ID: ${id}`
-					);
 			}
-		} else if (typeof idOrConf === "string") {
+		}
+		if (typeof idOrConf === "string") {
 			id = idOrConf;
 			conf = this.configuration[id];
 			uri = this.configuration[id].path;


### PR DESCRIPTION
## このpull requestが解決する内容
assetBundle が存在する状況において、 assetBundle に含まれないアセットIDが指定されていたときに通常のアセットの生成へとフォールバックするように修正します。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

