### PR TITLE
Implements of audiosystem onvolumechange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## 3.20.3
+* `g.game.music|sound.volume` の変更が再生中の `AudioPlayContext` に反映されない問題を修正
+
 ## 3.20.2
 * すでに削除済みのタイマーに対して clear しても例外としないように修正
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # ChangeLog
 
 ## 3.20.3
-* `g.game.music|sound.volume` の変更が再生中の `AudioPlayContext` に反映されない問題を修正
+* `g.game.audio.music|sound.volume` の変更が再生中の `AudioPlayContext` に反映されない問題を修正
 
 ## 3.20.2
 * すでに削除済みのタイマーに対して clear しても例外としないように修正

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.20.2",
+  "version": "3.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-engine",
-      "version": "3.20.2",
+      "version": "3.20.3",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-engine",
-  "version": "3.20.2",
+  "version": "3.20.3",
   "description": "The core library of Akashic Engine",
   "main": "index.js",
   "dependencies": {

--- a/src/AudioSystem.ts
+++ b/src/AudioSystem.ts
@@ -245,7 +245,12 @@ export abstract class AudioSystem implements PdiAudioSystem {
 	/**
 	 * @private
 	 */
-	abstract _onVolumeChanged(): void;
+	_onVolumeChanged(): void {
+		for (const key of this._contextMap.keys()) {
+			const ctx = this._contextMap.get(key);
+			ctx?.changeVolume(this.volume);
+		}
+	}
 
 	/**
 	 * @private
@@ -317,7 +322,8 @@ export class MusicAudioSystem extends AudioSystem {
 	/**
 	 * @private
 	 */
-	_onVolumeChanged(): void {
+	override _onVolumeChanged(): void {
+		super._onVolumeChanged();
 		this.player._notifyVolumeChanged();
 	}
 
@@ -454,7 +460,8 @@ export class SoundAudioSystem extends AudioSystem {
 	/**
 	 * @private
 	 */
-	_onVolumeChanged(): void {
+	override _onVolumeChanged(): void {
+		super._onVolumeChanged();
 		for (let i = 0; i < this.players.length; ++i) {
 			this.players[i]._notifyVolumeChanged();
 		}

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -214,7 +214,6 @@ describe("test AudioSystem", () => {
 
 		const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
 		const ctx1 = system.create(asset);
-		ctx1.changeVolume(0.3);
 		// systemのvolumeが変更されても、playerの音量は変わらない
 		player.changeVolume(0.2);
 		system.volume = 0.7;
@@ -229,7 +228,6 @@ describe("test AudioSystem", () => {
 		const player = system.createPlayer() as AudioPlayer;
 		const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
 		const ctx1 = system.create(asset);
-		ctx1.changeVolume(0.3);
 		// systemのvolumeが変更されても、playerの音量は変わらない
 		player.changeVolume(0.3);
 		system.volume = 0.7;

--- a/src/__tests__/AudioSystemSpec.ts
+++ b/src/__tests__/AudioSystemSpec.ts
@@ -211,22 +211,31 @@ describe("test AudioSystem", () => {
 		const game = new Game({ width: 320, height: 320, main: "", assets: {} });
 		const system = game.audio.music;
 		const player = system.createPlayer() as AudioPlayer;
+
+		const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+		const ctx1 = system.create(asset);
+		ctx1.changeVolume(0.3);
 		// systemのvolumeが変更されても、playerの音量は変わらない
 		player.changeVolume(0.2);
 		system.volume = 0.7;
 		expect(player.volume).toBe(0.2);
 		expect(system.volume).toBe(0.7);
+		expect(ctx1.volume).toBe(0.7);
 	});
 
 	it("SoundAudioSystem#_onVolumeChanged", () => {
 		const game = new Game({ width: 320, height: 320, main: "", assets: {} });
 		const system = game.audio.sound;
 		const player = system.createPlayer() as AudioPlayer;
+		const asset = game.resourceFactory.createAudioAsset("a1", "./", 2000, system, false, {});
+		const ctx1 = system.create(asset);
+		ctx1.changeVolume(0.3);
 		// systemのvolumeが変更されても、playerの音量は変わらない
 		player.changeVolume(0.3);
 		system.volume = 0.7;
 		expect(player.volume).toBe(0.3);
 		expect(system.volume).toBe(0.7);
+		expect(ctx1.volume).toBe(0.7);
 	});
 
 	describe("AudioPlayContext operations", () => {


### PR DESCRIPTION
## このpull requestが解決する内容

`g.game.audio.music|sound.volume` の変更が再生中の `AudioPlayContext` に反映されない問題を修正

**動作確認**
修正した箇所を serve で使う engineFiles.js に反映し、BGM が再生中にvolume を変更できるコンテンツで音量が変わる事を確認。

## 破壊的な変更を含んでいるか?

- なし
