### PR TITLE
chore: set padding to 0 in `CacheableE`

### DIFF
--- a/src/entities/CacheableE.ts
+++ b/src/entities/CacheableE.ts
@@ -20,7 +20,7 @@ export abstract class CacheableE extends E {
 	 *
 	 * @private
 	 */
-	static PADDING: number = 1;
+	static PADDING: number = 0;
 
 	/**
 	 * エンジンが子孫を描画すべきであれば`true`、でなければ`false`を本クラスを継承したクラスがセットする。


### PR DESCRIPTION
## このpull requestが解決する内容

rel #96
`CacheableE.PADDING` の値を `0` に修正します。

## 動作確認

### コンテンツ

#96 と同一のものです。

<details>
<summary>クリックして展開</summary>

```js
module.exports = () => {
  var game = g.game;
  var scene = new g.Scene({game: g.game});
  scene.loaded.add(function() {
    var font = new g.DynamicFont({ game, fontFamily: "sans-serif", size: 10 });
    var label = new g.Label({ scene, font, text: "hoge", fontSize: 50, parent: scene, x: 100, y: 0 });
    label.update.add(() => {
      label.x -= 0.3;  // 少数部分を使う
      if (label.x < 0)
        label.x = game.width;
      label.modified();
    });
  });
  g.game.pushScene(scene);
};
```
</details>

### 現状の動作
https://github.com/user-attachments/assets/e9db6d30-2b61-4896-a6e7-c9d8c0625289

### `PADDING` を `0` にした場合
https://github.com/user-attachments/assets/ae8ee1da-5ca8-44ac-815b-98c98b6837f0

### `CacheableE` の描画位置を整数にした場合
https://github.com/user-attachments/assets/31dc55f1-d6fd-461d-9b1e-567c97d3d522

## 破壊的な変更を含んでいるか?

- なし
