### PR TITLE
chore: update package.json devEngines and .npmrc min-release-age

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,11 @@ on:
       - v2-main
 
 env:
-  NODE_VERSION: 16
+  NODE_VERSION: 24
+
+permissions:
+  contents: write
+  id-token: write
 
 jobs:
   release:
@@ -14,9 +18,9 @@ jobs:
     name: Publish and Release
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -26,7 +30,6 @@ jobs:
           npm run build
           npm test
       - name: Publish and Release
-        uses: akashic-games/action-release@v2
+        uses: akashic-games/action-release@a81329f4a70100c4729df80dba17ec8d5da52511 # v3.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -9,11 +12,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [14.x, 16.x]
+        node: [24.x]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -56,5 +56,12 @@
   },
   "typings": "lib/main.node.d.ts",
   "author": "DWANGO Co., Ltd.",
-  "license": "MIT"
+  "license": "MIT",
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
+  }
 }


### PR DESCRIPTION
### やったこと
- `.npmrc` (`min-release-age=7` 記載)を追加
- `package.json` に `npm@>=11.11.0` でないとnpmコマンドを実行できない設定を追加
- Github Actions ワークフローを以下のように修正
  - Node v24 を利用するように 
  - 各アクションをPINで指定するように
  - permissions の設定
  - npm publish を OIDC 認証で行うように